### PR TITLE
docs: add domain design specs (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .worktree
-specs/
+/specs/

--- a/docs/specs/bounded-contexts.md
+++ b/docs/specs/bounded-contexts.md
@@ -1,0 +1,185 @@
+# Bounded Context 定義
+
+RealWorld（Conduit）仕様に基づくドメインの Bounded Context を定義する。
+
+## コンテキスト一覧
+
+| Context | 責務 | 主要エンティティ |
+|---------|------|----------------|
+| Identity | ユーザー登録・ログイン・認証 | User |
+| Publishing | 記事 CRUD・コメント・タグ管理 | Article, Comment, Tag |
+| Social | プロフィール・フォロー・お気に入り・フィード | Profile, Follow, Favorite |
+
+---
+
+## 1. Identity Context
+
+### 責務
+
+ユーザーのアイデンティティに関する一切を管理する。
+
+- ユーザー登録（Registration）
+- ログイン・認証トークン発行（Authentication）
+- ユーザー情報の更新（email, username, password, bio, image）
+- 現在のユーザー情報の取得
+
+### 主要エンティティ
+
+| エンティティ | 説明 |
+|-------------|------|
+| **User** | システム内の認証済みユーザー。email・username で一意に識別される |
+
+### ValueObject 候補
+
+| ValueObject | 理由 |
+|------------|------|
+| Email | フォーマットバリデーション・一意性制約を持つ。プリミティブ string では表現力不足 |
+| Username | 文字種・長さ制約・一意性制約を持つ |
+| Password | ハッシュ化ロジック・強度バリデーションを内包する |
+| Bio | 長さ制約を持つ任意テキスト（nullable） |
+| ImageUrl | URL フォーマットバリデーション（nullable） |
+
+### API エンドポイント対応
+
+| エンドポイント | 操作 |
+|--------------|------|
+| `POST /api/users` | ユーザー登録 |
+| `POST /api/users/login` | ログイン |
+| `GET /api/user` | 現在のユーザー取得 |
+| `PUT /api/user` | ユーザー情報更新 |
+
+---
+
+## 2. Publishing Context
+
+### 責務
+
+記事のライフサイクルとそれに付随するコンテンツ（コメント・タグ）を管理する。
+
+- 記事の作成・取得・更新・削除（CRUD）
+- 記事一覧の取得（フィルタリング: tag, author, favorited）
+- コメントの追加・取得・削除
+- タグの管理・一覧取得
+
+### 主要エンティティ
+
+| エンティティ | 説明 |
+|-------------|------|
+| **Article** | 集約ルート。タイトル・本文・タグリストを持ち、slug で一意に識別される |
+| **Comment** | Article に従属する。記事へのコメント |
+| **Tag** | 記事を分類するためのラベル |
+
+### ValueObject 候補
+
+| ValueObject | 理由 |
+|------------|------|
+| Slug | タイトルから自動生成。URL セーフな文字列に変換するロジックを内包する |
+| ArticleTitle | 空文字禁止・長さ制約のバリデーションを持つ |
+| ArticleBody | 空文字禁止のバリデーションを持つ |
+| ArticleDescription | 記事の要約。空文字禁止 |
+| TagName | タグの名前。正規化（小文字変換等）のロジックを持つ |
+| CommentBody | 空文字禁止のバリデーションを持つ |
+
+### 集約境界
+
+- **Article 集約**: Article（集約ルート）+ Comment（子エンティティ）+ Tag（関連）
+  - Comment は Article を通じてのみアクセスする
+  - Tag は Article との多対多関係で、独立した集約ではない
+
+### API エンドポイント対応
+
+| エンドポイント | 操作 |
+|--------------|------|
+| `POST /api/articles` | 記事作成 |
+| `GET /api/articles` | 記事一覧取得（フィルタ・ページネーション） |
+| `GET /api/articles/:slug` | 記事取得 |
+| `PUT /api/articles/:slug` | 記事更新 |
+| `DELETE /api/articles/:slug` | 記事削除 |
+| `POST /api/articles/:slug/comments` | コメント追加 |
+| `GET /api/articles/:slug/comments` | コメント一覧取得 |
+| `DELETE /api/articles/:slug/comments/:id` | コメント削除 |
+| `GET /api/tags` | タグ一覧取得 |
+
+---
+
+## 3. Social Context
+
+### 責務
+
+ユーザー間のソーシャルインタラクションとパーソナライズされたフィードを管理する。
+
+- プロフィールの取得
+- ユーザーのフォロー・アンフォロー
+- 記事のお気に入り登録・解除
+- フォロー中ユーザーの記事フィード取得
+
+### 主要エンティティ
+
+| エンティティ | 説明 |
+|-------------|------|
+| **Profile** | ユーザーの公開プロフィール。Identity Context の User を参照する |
+| **Follow** | ユーザー間のフォロー関係 |
+| **Favorite** | ユーザーと記事間のお気に入り関係 |
+
+### API エンドポイント対応
+
+| エンドポイント | 操作 |
+|--------------|------|
+| `GET /api/profiles/:username` | プロフィール取得 |
+| `POST /api/profiles/:username/follow` | フォロー |
+| `DELETE /api/profiles/:username/follow` | アンフォロー |
+| `POST /api/articles/:slug/favorite` | お気に入り登録 |
+| `DELETE /api/articles/:slug/favorite` | お気に入り解除 |
+| `GET /api/articles/feed` | フィード取得（フォロー中ユーザーの記事） |
+
+---
+
+## コンテキストマップ
+
+### コンテキスト間の関係
+
+```
+┌──────────────┐         ┌──────────────────┐         ┌──────────────┐
+│   Identity   │◄────────│      Social      │────────►│  Publishing  │
+│   Context    │         │     Context      │         │   Context    │
+│              │         │                  │         │              │
+│  ・User      │         │  ・Profile       │         │  ・Article   │
+│  ・Auth      │         │  ・Follow        │         │  ・Comment   │
+│              │         │  ・Favorite      │         │  ・Tag       │
+│              │         │  ・Feed          │         │              │
+└──────────────┘         └──────────────────┘         └──────────────┘
+       ▲                                                      ▲
+       │              Identity Context は                       │
+       │              User ID を提供する                         │
+       │              (上流: Supplier)                          │
+       └─────────────────────────────────────────────────────────┘
+                    Publishing Context は
+                    Article の Author として
+                    User ID を参照する
+```
+
+### 関係の種類
+
+| 上流 (Supplier) | 下流 (Consumer) | 関係の種類 | 説明 |
+|----------------|----------------|-----------|------|
+| Identity | Publishing | Customer-Supplier | Article の Author として User ID を参照する。Publishing は Identity の User ID を受け取るが、User の内部構造には依存しない |
+| Identity | Social | Customer-Supplier | Profile は User の公開情報を表現する。Follow/Favorite の主体として User ID を参照する |
+| Publishing | Social | Customer-Supplier | Favorite の対象として Article ID を参照する。Feed は Article の一覧を返す |
+
+### データ受け渡し方針
+
+1. **コンテキスト間は ID（識別子）のみで連携する**
+   - User ID, Article ID など、プリミティブな識別子を受け渡す
+   - エンティティオブジェクトを直接渡さない
+
+2. **下流コンテキストは上流の内部構造に依存しない**
+   - Publishing Context は User の email やパスワードを知らない
+   - Social Context は Article の本文を直接扱わない
+
+3. **API レスポンスの組み立ては Presentation 層で行う**
+   - 複数コンテキストのデータを結合する必要がある場合（例: 記事一覧に著者プロフィールを含める）、Presentation 層または Application 層の Query で横断的に取得する
+   - Domain 層ではコンテキスト境界を厳密に守る
+
+4. **共有カーネル（Shared Kernel）は設けない**
+   - 現時点ではコンテキスト間で共有するドメインロジックはない
+   - 将来的に必要になった場合は ADR で判断する

--- a/docs/specs/ubiquitous-language.md
+++ b/docs/specs/ubiquitous-language.md
@@ -1,0 +1,136 @@
+# Ubiquitous Language（ユビキタス言語）定義
+
+RealWorld（Conduit）仕様に基づく、プロジェクト全体で統一して使用する用語を定義する。
+
+コード（クラス名・メソッド名・変数名）、ドキュメント、会話のすべてにおいて、ここで定義された用語を一貫して使用すること。
+
+---
+
+## 用語一覧
+
+### Identity Context
+
+| 用語 | 定義 | 使用ルール |
+|------|------|-----------|
+| **User** | システムに登録された認証済みユーザー。email と username で一意に識別される | `Account`, `Member` は使わない。常に `User` を使う |
+| **Email** | ユーザーのメールアドレス。ログイン識別子として使用する | `mail`, `emailAddress` は使わない |
+| **Username** | ユーザーの表示名。プロフィール URL の識別子としても使用する | `name`, `displayName`, `handle` は使わない |
+| **Password** | ユーザーの認証パスワード。システム内では常にハッシュ化して保持する | `pass`, `pwd` は使わない |
+| **Bio** | ユーザーの自己紹介テキスト | `biography`, `description`, `about` は使わない |
+| **Image** | ユーザーのアバター画像 URL | `avatar`, `photo`, `picture` は使わない |
+| **Token** | 認証トークン（JWT）。ログイン・登録時に発行される | `session`, `authKey` は使わない |
+
+### Publishing Context
+
+| 用語 | 定義 | 使用ルール |
+|------|------|-----------|
+| **Article** | ユーザーが投稿するコンテンツ。タイトル・本文・説明・タグを持つ | `Post`, `Entry`, `Blog` は使わない。常に `Article` を使う |
+| **Slug** | Article のタイトルから生成される URL セーフな一意識別子 | `permalink`, `urlId` は使わない |
+| **Title** | Article の表題 | Article のコンテキストでは `ArticleTitle` (ValueObject) として扱う |
+| **Description** | Article の要約・概要文 | `summary`, `excerpt` は使わない |
+| **Body** | Article の本文コンテンツ | `content`, `text` は使わない |
+| **Tag** | Article を分類するためのラベル。Article に複数付与できる | `category`, `label`, `topic` は使わない |
+| **TagList** | Article に付与された Tag の集合 | `tags`, `categories` 等の曖昧な名前は API 互換以外で使わない |
+| **Comment** | Article に対するユーザーのコメント | `reply`, `response`, `note` は使わない |
+| **Author** | Article または Comment を作成した User | 記事・コメントの作成者を指す場合に限り使用する。`writer`, `creator`, `poster` は使わない |
+
+### Social Context
+
+| 用語 | 定義 | 使用ルール |
+|------|------|-----------|
+| **Profile** | User の公開情報（username, bio, image, following 状態） | `UserProfile`, `PublicUser` は使わない |
+| **Follow** | あるユーザーが別のユーザーをフォローする関係 | `Subscribe`, `Watch` は使わない。動詞としても `follow` / `unfollow` を使う |
+| **Favorite** | ユーザーが Article をお気に入りに登録する行為・関係 | `Like`, `Bookmark`, `Star` は使わない。動詞としても `favorite` / `unfavorite` を使う |
+| **Feed** | 現在のユーザーがフォローしているユーザーの Article の時系列一覧 | `Timeline`, `Stream` は使わない |
+| **FavoritesCount** | Article がお気に入りに登録された回数 | `likeCount`, `stars` は使わない |
+| **Following** | 現在のユーザーが対象ユーザーをフォローしているかどうかの状態（boolean） | Profile のフィールドとして使用する |
+
+---
+
+## 禁止事項
+
+### 1. 同義語の乱立禁止
+
+上記の用語表で「使わない」と指定された同義語をコード・ドキュメントで使用してはならない。
+
+```
+# Bad
+$account = Account::find($id);      // Account ではなく User
+$post->likes()->count();             // likes ではなく favorites
+$user->subscribers;                  // subscribers ではなく followers
+
+# Good
+$user = User::find($id);
+$article->favorites()->count();
+$user->followers;
+```
+
+### 2. API 都合の語彙を Domain に持ち込まない
+
+API のリクエスト/レスポンス形式で使われるフィールド名（例: `tagList`）と Domain の用語は区別する。
+
+- API 層のフィールド名は RealWorld 仕様に従う（互換性のため）
+- Domain 層では本ドキュメントの用語定義に従う
+- 変換は Presentation 層（JsonResource / FormRequest）で行う
+
+```php
+// Domain 層 — Domain の用語を使う
+final readonly class Article
+{
+    /** @param list<Tag> $tags */
+    public function __construct(
+        public ArticleTitle $title,
+        public Slug $slug,
+        public ArticleBody $body,
+        public ArticleDescription $description,
+        public array $tags,  // Domain では "tags"
+    ) {}
+}
+
+// Presentation 層 — API 仕様に合わせて変換する
+class ArticleResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'slug' => $this->slug->value,
+            'title' => $this->title->value,
+            'body' => $this->body->value,
+            'description' => $this->description->value,
+            'tagList' => $this->tags,  // API 仕様では "tagList"
+        ];
+    }
+}
+```
+
+### 3. 技術用語と Domain 用語の混同禁止
+
+技術的な概念をドメイン用語として使わない。
+
+| 技術用語（使わない） | Domain 用語（使う） |
+|-------------------|-------------------|
+| `UserEntity` | `User` |
+| `ArticleModel` | `Article` |
+| `CommentRecord` | `Comment` |
+| `TagDTO` | `Tag`（DTO の場合は `CreateArticleDto` のように操作名を含める） |
+
+### 4. 略語の禁止
+
+Domain 層のクラス名・メソッド名で略語を使わない。
+
+| 略語（使わない） | 正式名（使う） |
+|----------------|--------------|
+| `desc` | `description` |
+| `img` | `image` |
+| `usr` | `user` |
+| `auth` | `authentication` / `authorization`（文脈に応じて使い分ける） |
+| `fav` | `favorite` |
+| `pwd` | `password` |
+
+---
+
+## 用語の追加・変更ルール
+
+1. 新しいドメイン用語が必要になった場合、本ドキュメントに追加してからコードに反映する
+2. 既存の用語を変更する場合、本ドキュメントを更新し、コード全体を一括でリネームする
+3. 判断に迷う場合は ADR として記録する

--- a/rules/backend.md
+++ b/rules/backend.md
@@ -13,6 +13,10 @@
 
 DDD（ドメイン駆動設計）ベースの4層アーキテクチャを採用する。
 
+> **ドメイン設計仕様の参照**
+> - Bounded Context 定義: [`docs/specs/bounded-contexts.md`](../docs/specs/bounded-contexts.md)
+> - ユビキタス言語定義: [`docs/specs/ubiquitous-language.md`](../docs/specs/ubiquitous-language.md)
+
 ```
 Presentation → Application → Domain ← Infrastructure
 ```


### PR DESCRIPTION
## Summary
- Bounded Context 定義（Identity / Publishing / Social）とコンテキストマップを `docs/specs/bounded-contexts.md` に作成
- Ubiquitous Language 定義（用語一覧・禁止事項・運用ルール）を `docs/specs/ubiquitous-language.md` に作成
- `rules/backend.md` からドメイン設計仕様への参照リンクを追加
- `.gitignore` の `specs/` を `/specs/` に修正し、`docs/specs/` が追跡可能に

## Issue
Closes #5

## Test plan
- [ ] `docs/specs/bounded-contexts.md` が RealWorld 仕様に基づいた内容になっている
- [ ] `docs/specs/ubiquitous-language.md` の用語定義が網羅されている
- [ ] `rules/backend.md` から設計仕様への参照が機能する