### PR TITLE
feat: add worktree-issue skill and tdd-issue worktree option (#8)

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -2,3 +2,4 @@ settings.json
 settings.local.json
 **/__pycache__/
 *.pyc
+worktrees

--- a/.claude/skills/tdd-issue/SKILL.md
+++ b/.claude/skills/tdd-issue/SKILL.md
@@ -4,6 +4,7 @@ description: >
   GitHub Issueを起点にTDD（テスト駆動開発）でタスクを遂行するスキル。
   Git Flowベースでブランチを作成し、Red→Green→Refactorサイクルで実装し、
   テスト・リントを通してからPRを作成する。
+  worktree（隔離環境）またはlocal（ローカルリポジトリ直接）を選択可能。
   フロントエンド: React 19 + TypeScript 5.9 + Vite 8 / バックエンド: Laravel 12 + PHP 8.3。
   トリガー: 「Issue #XXX をTDDで」「このIssueをやって」「GHビューでIssue#XXX」
   など、GitHub IssueベースのTDD開発を求められたとき。
@@ -19,6 +20,43 @@ GitHub Issueを起点に、TDDサイクルで実装しPRを作成する。
 - **バックエンド**: Laravel 12 + PHP 8.3 / テスト: Pest 4.4 / リント: Laravel Pint
 - **ルール**: `rules/` 配下の各ファイルを作業開始前に必ず確認（特に `rules/security.md`）
 - **ディレクトリ**: フロントエンド=`web/` / バックエンド=`api/`
+
+## 作業場所の選択
+
+ユーザーの指示またはタスクの性質に応じて作業場所を選択する。
+
+| モード | 説明 | 使い分け |
+|--------|------|----------|
+| **worktree** | 隔離されたworktree上で作業 | 他の作業に影響を与えたくないとき、並行作業時 |
+| **local** | ローカルリポジトリ上で直接作業 | シンプルな変更、既にローカルで作業中のとき |
+
+- ユーザーが明示的に指定した場合はそれに従う
+- 指定がない場合はユーザーに確認する
+
+### worktreeモードの場合
+
+Step 3の前にworktreeを作成する:
+
+```
+EnterWorktree でworktreeに入る
+```
+
+worktreeには `node_modules/` や `vendor/` が含まれないため、
+変更対象に応じて依存関係をインストールする:
+
+```bash
+# フロントエンド
+cd web && pnpm install
+
+# バックエンド
+cd api && composer install
+```
+
+Step 9のPR作成後にworktreeをクリーンアップする:
+
+```
+ExitWorktree でworktreeを退出・クリーンアップ
+```
 
 ## ワークフロー
 
@@ -126,6 +164,10 @@ EOF
 - PRタイトルは70文字以内
 - `Closes #<issue番号>` でIssueと紐付け
 - マージ方針: squash merge
+
+### Step 10: クリーンアップ（worktreeモードの場合）
+
+worktreeモードで作業した場合は、ExitWorktreeでクリーンアップする。
 
 ## 注意事項
 

--- a/.claude/skills/worktree-issue/SKILL.md
+++ b/.claude/skills/worktree-issue/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: worktree-issue
+description: >
+  GitHub Issueを起点にworktree上でタスクを遂行するスキル。
+  TDD不要なタスク（ドキュメント変更、設定変更など）をworktreeで隔離実行し、
+  commit → push → PR作成まで一貫して行う。
+  Git Flow規約（ブランチ命名、Conventional Commits、PR形式）に準拠。
+  トリガー: 「Issue #XXX をworktreeで」「worktreeでIssue対応」
+  「ドキュメント変更をIssue #XXX で」など、TDD不要のIssue対応を求められたとき。
+---
+
+# Worktree Issue ワークフロー
+
+GitHub Issueを起点に、worktree上で実装しPRを作成する。
+TDDサイクルが不要なタスク（ドキュメント変更、設定変更など）に適している。
+
+## 前提
+
+- **フロントエンド**: React 19 + TypeScript 5.9 + Vite 8 / リント: ESLint
+- **バックエンド**: Laravel 12 + PHP 8.3 / リント: Laravel Pint
+- **ルール**: `rules/` 配下の各ファイルを作業開始前に必ず確認（特に `rules/security.md`）
+- **ディレクトリ**: フロントエンド=`web/` / バックエンド=`api/`
+
+## ワークフロー
+
+### Step 1: Issue確認
+
+```
+gh issue view <issue番号>
+```
+
+Issueのタイトル・本文・ラベル・コメントを読み取り、実装スコープを把握する。
+
+### Step 2: rulesの確認
+
+`rules/` ディレクトリ内の関連ルールファイルを確認する。
+対象技術スタック（frontend / backend）に応じて該当ファイルを読む。
+**`rules/security.md` は必ず確認する。**
+
+### Step 3: worktree作成・ブランチ切り替え
+
+EnterWorktreeツールを使用してworktreeを作成する。
+
+```
+EnterWorktree でworktreeに入る
+```
+
+worktree内でブランチを作成:
+
+```bash
+git checkout -b feature/#<issue番号>-<issue-slug>
+```
+
+- `<issue-slug>`: Issueタイトルから英語kebab-caseで短く生成
+- 例: `feature/#42-update-docs`
+- mainブランチの最新から切ること
+
+### Step 4: 依存関係インストール
+
+worktreeには `node_modules/` や `vendor/` が含まれないため、
+変更対象に応じて依存関係をインストールする。
+
+**フロントエンド (`web/`) を変更する場合**:
+```bash
+cd web && pnpm install
+```
+
+**バックエンド (`api/`) を変更する場合**:
+```bash
+cd api && composer install
+```
+
+### Step 5: 実装
+
+Issueの要件に基づき実装を行う。
+
+- `rules/` の規約に従うこと
+- `docs/` に関連する設計書・仕様書があれば参照すること
+
+### Step 6: リント・検証
+
+変更対象に応じてリント・型チェックを実行する。
+
+**フロントエンド**:
+```bash
+cd web && pnpm tsc -b --noEmit   # 型チェック
+cd web && pnpm eslint .            # リント
+```
+
+**バックエンド**:
+```bash
+cd api && ./vendor/bin/pint --test  # リント
+```
+
+**テストが存在する場合は実行する**:
+```bash
+# フロントエンド
+cd web && pnpm vitest run
+
+# バックエンド
+cd api && php artisan test
+```
+
+失敗があれば修正し、全てパスするまで繰り返す。
+
+### Step 7: コミット・プッシュ
+
+```bash
+git add <変更ファイル>
+git commit -m "<type>: <説明>"
+git push -u origin <ブランチ名>
+```
+
+- コミットメッセージは英語、Conventional Commits形式
+- 複数コミットOK（内容に応じて分けてよい）
+
+### Step 8: PR作成
+
+```bash
+gh pr create --title "<タイトル>" --body "$(cat <<'EOF'
+## Summary
+- <変更内容を箇条書き>
+
+## Issue
+Closes #<issue番号>
+
+## Test plan
+- [ ] リントパス
+- [ ] 型チェックパス（該当する場合）
+- [ ] 既存テストへの影響なし
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- PRタイトルは70文字以内
+- `Closes #<issue番号>` でIssueと紐付け
+- マージ方針: squash merge
+
+### Step 9: worktreeクリーンアップ
+
+ExitWorktreeツールを使用してworktreeから退出する。
+
+```
+ExitWorktree でworktreeを退出・クリーンアップ
+```
+
+## 注意事項
+
+- 1 Issue = 1 PR を厳守
+- リントが通らない状態でPRを作成しない
+- `rules/` のルールに従うこと
+- `docs/` に関連する設計書・仕様書があれば参照すること
+- worktreeは作業完了後に必ずクリーンアップすること


### PR DESCRIPTION
## Summary
- `/worktree-issue` スキルを新規追加（TDD不要タスクをworktree上で実行→PR作成）
- `/tdd-issue` スキルにworktree/local選択オプションを追加
- worktreeモード時の依存関係インストール手順（pnpm install / composer install）を明記
- worktreeのクリーンアップ手順を両スキルに組み込み

## Issue
Closes #8

## Test plan
- [ ] `/worktree-issue <issue番号>` でworktree上での実装→PR作成が実行できること
- [ ] `/tdd-issue` でworktree/localの選択ができること
- [ ] 既存の `tdd-issue` のTDDサイクル（Red→Green→Refactor）が維持されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)