### PR TITLE
chore: integrate app services into devcontainer via Docker Compose

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,18 +1,7 @@
 {
   "name": "Claude Code Sandbox",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "args": {
-      "TZ": "${localEnv:TZ:Asia/Tokyo}",
-      "CLAUDE_CODE_VERSION": "latest",
-      "GIT_DELTA_VERSION": "0.18.2",
-      "ZSH_IN_DOCKER_VERSION": "1.2.0"
-    }
-  },
-  "runArgs": [
-    "--cap-add=NET_ADMIN",
-    "--cap-add=NET_RAW"
-  ],
+  "dockerComposeFile": ["../compose.yml", "docker-compose.yml"],
+  "service": "devcontainer",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -41,19 +30,6 @@
     }
   },
   "remoteUser": "node",
-  "mounts": [
-    "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
-    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume",
-    "source=${localEnv:HOME}/.config/gh,target=/home/node/.config/gh,type=bind"
-  ],
-  "containerEnv": {
-    "NODE_OPTIONS": "--max-old-space-size=4096",
-    "CLAUDE_CONFIG_DIR": "/home/node/.claude",
-    "POWERLEVEL9K_DISABLE_GITSTATUS": "true",
-    "SSH_AUTH_SOCK": "/run/host-services/ssh-auth.sock",
-    "GH_TOKEN": "${localEnv:GH_TOKEN}"
-  },
-  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
   "postStartCommand": "sudo /usr/local/bin/init-firewall.sh",
   "waitFor": "postStartCommand"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   devcontainer:
     build:
-      context: .
+      context: .devcontainer
       dockerfile: Dockerfile
       args:
         TZ: "${TZ:-Asia/Tokyo}"
@@ -9,7 +9,7 @@ services:
         GIT_DELTA_VERSION: "0.18.2"
         ZSH_IN_DOCKER_VERSION: "1.2.0"
     volumes:
-      - ..:/workspace:cached
+      - .:/workspace:cached
       - claude-code-bashhistory:/commandhistory
       - claude-code-config:/home/node/.claude
       - "${HOME}/.config/gh:/home/node/.config/gh"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  devcontainer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        TZ: "${TZ:-Asia/Tokyo}"
+        CLAUDE_CODE_VERSION: "latest"
+        GIT_DELTA_VERSION: "0.18.2"
+        ZSH_IN_DOCKER_VERSION: "1.2.0"
+    volumes:
+      - ..:/workspace:cached
+      - claude-code-bashhistory:/commandhistory
+      - claude-code-config:/home/node/.claude
+      - "${HOME}/.config/gh:/home/node/.config/gh"
+    environment:
+      NODE_OPTIONS: "--max-old-space-size=4096"
+      CLAUDE_CONFIG_DIR: "/home/node/.claude"
+      POWERLEVEL9K_DISABLE_GITSTATUS: "true"
+      SSH_AUTH_SOCK: "/run/host-services/ssh-auth.sock"
+      GH_TOKEN: "${GH_TOKEN:-}"
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    networks:
+      - app-network
+    depends_on:
+      - db
+      - api-php
+      - api-nginx
+      - web
+
+volumes:
+  claude-code-bashhistory:
+  claude-code-config:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       POWERLEVEL9K_DISABLE_GITSTATUS: "true"
       SSH_AUTH_SOCK: "/run/host-services/ssh-auth.sock"
       GH_TOKEN: "${GH_TOKEN:-}"
+    command: sleep infinity
     cap_add:
       - NET_ADMIN
       - NET_RAW


### PR DESCRIPTION
## Summary

- `.devcontainer/docker-compose.yml` を新規作成し、devcontainerサービスを定義
- `devcontainer.json` を `dockerComposeFile` モードに変更（`compose.yml` + `docker-compose.yml` の2ファイル構成）
- devcontainerが `app-network` に参加し、db / api-php / api-nginx / web / mailpit と同一ネットワークで通信可能に

## 変更詳細

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| 起動方式 | 単一Dockerfileビルド | Docker Compose統合 |
| アプリサービス | 手動で `docker compose up` が必要 | devcontainer起動時に自動起動 |
| ネットワーク | 独立 | `app-network` で全サービスと共有 |
| SSH / GH認証 | 前PRで設定済み | docker-compose.yml側に移行 |

## Test plan

- [ ] Rebuild Container でdevcontainerが正常に起動することを確認
- [ ] db / api-php / api-nginx / web / mailpit が自動起動することを確認
- [ ] コンテナ内から `curl http://api-nginx` 等でサービス間通信ができることを確認
- [ ] `gh auth status` で認証済みであることを確認