### PR TITLE
fix: devcontainer から SSH_AUTH_SOCK のマウントと環境変数を削除

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,11 +34,7 @@
   },
   "remoteUser": "node",
   "workspaceFolder": "/workspace",
-  "mounts": [
-    "source=${localEnv:SSH_AUTH_SOCK},target=/run/host-services/ssh-auth.sock,type=bind"
-  ],
   "remoteEnv": {
-    "SSH_AUTH_SOCK": "/run/host-services/ssh-auth.sock",
     "GH_TOKEN": "${localEnv:GH_TOKEN}"
   },
   "initializeCommand": "security find-generic-password -s 'Claude Code-credentials' -w 2>/dev/null > ~/.claude/.credentials.json && chmod 600 ~/.claude/.credentials.json || true",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       NODE_OPTIONS: "--max-old-space-size=4096 --dns-result-order=ipv4first"
       CLAUDE_CONFIG_DIR: "/home/node/.claude"
       POWERLEVEL9K_DISABLE_GITSTATUS: "true"
-      SSH_AUTH_SOCK: "/run/host-services/ssh-auth.sock"
       GH_TOKEN: "${GH_TOKEN:-}"
     env_file:
       - ./backend/.env


### PR DESCRIPTION
## Summary

- `.devcontainer/devcontainer.json`: `SSH_AUTH_SOCK` のバインドマウントと `remoteEnv` エントリを削除
- `.devcontainer/docker-compose.yml`: `SSH_AUTH_SOCK` 環境変数を削除

## Issue

Copilot レビューコメント対応（PR #17）：`SSH_AUTH_SOCK` が未設定の環境（Windows・クリーンなシェル等）ではマウントソースが空になりコンテナ起動に失敗する問題を修正。

## Test plan

- [x] Vitest テストパス
- [x] Pest テストパス
- [x] ESLint リントパス
- [x] Pint リントパス