### PR TITLE
docs: レビュー指摘と日本語運用ルールを修正

### DIFF
--- a/.agents/skills/skill-creator/scripts/package_skill.py
+++ b/.agents/skills/skill-creator/scripts/package_skill.py
@@ -16,6 +16,19 @@ from pathlib import Path
 from quick_validate import validate_skill
 
 
+EXCLUDED_DIR_NAMES = {'__pycache__', '.pytest_cache', '.mypy_cache', '.ruff_cache', '.git'}
+EXCLUDED_FILE_NAMES = {'.DS_Store'}
+EXCLUDED_FILE_SUFFIXES = {'.pyc', '.pyo'}
+
+
+def should_package_file(file_path):
+    """Return whether a file should be included in a packaged skill."""
+    if any(part in EXCLUDED_DIR_NAMES for part in file_path.parts):
+        return False
+
+    return file_path.name not in EXCLUDED_FILE_NAMES and file_path.suffix not in EXCLUDED_FILE_SUFFIXES
+
+
 def package_skill(skill_path, output_dir=None):
     """
     Package a skill folder into a .skill file.
@@ -68,7 +81,7 @@ def package_skill(skill_path, output_dir=None):
         with zipfile.ZipFile(skill_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
             # Walk through the skill directory
             for file_path in skill_path.rglob('*'):
-                if file_path.is_file():
+                if file_path.is_file() and should_package_file(file_path):
                     # Calculate the relative path within the zip
                     arcname = file_path.relative_to(skill_path.parent)
                     zipf.write(file_path, arcname)

--- a/.agents/skills/tdd-issue/SKILL.md
+++ b/.agents/skills/tdd-issue/SKILL.md
@@ -18,7 +18,7 @@ GitHub Issueを起点に、要件整理・設計・タスク分解を経てTDD�
 
 - **フロントエンド**: React 19 + TypeScript 5.9 + Vite 8 / テスト: Vitest + Testing Library / リント: ESLint
 - **バックエンド**: Laravel 13 + PHP 8.4 / テスト: Pest 4.4 / リント: Laravel Pint
-- **ルール**: `.Codex/rules/` 配下の各ファイルを作業開始前に必ず確認（特に `.Codex/rules/security.md`）
+- **ルール**: `.claude/rules/` 配下の各ファイルを作業開始前に必ず確認（特に `.claude/rules/security.md`）
 - **ディレクトリ**: フロントエンド=`frontend/` / バックエンド=`backend/`
 
 ## 作業場所の選択
@@ -72,9 +72,9 @@ Issueのタイトル・本文・ラベルを読み取り、実装スコープを
 
 #### Step 2: rulesの確認
 
-`.Codex/rules/` ディレクトリ内の関連ルールファイルを確認する。
+`.claude/rules/` ディレクトリ内の関連ルールファイルを確認する。
 対象技術スタック（frontend / backend）に応じて該当ファイルを読む。
-**`.Codex/rules/security.md` は必ず確認する。**
+**`.claude/rules/security.md` は必ず確認する。**
 
 #### Step 3: 要件整理・設計ドキュメント作成
 
@@ -88,7 +88,7 @@ Issueのタイトル・本文・ラベルを読み取り、実装スコープを
    - **ドメインモデル設計**: Entity / ValueObject / Repository（DDD 適用時）
    - **フロントエンド設計**: Feature 構成、コンポーネント分割、状態管理（フロントエンド関与時）
    - **DB 設計**: テーブル、マイグレーション（DB 変更時）
-   - **セキュリティ確認**: `.Codex/rules/security.md` の禁止事項に抵触しないか
+   - **セキュリティ確認**: `.claude/rules/security.md` の禁止事項に抵触しないか
 3. **タスク分解**: TDD サイクルのコミット単位でタスクを列挙
 4. 設計内容をユーザーに提示し、確認を得てから実装に進む
 
@@ -100,7 +100,7 @@ git checkout -b feature/#<issue番号>-<issue-slug>
 
 - `<issue-slug>`: Issueタイトルから英語kebab-caseで短く生成
 - 例: `feature/#42-add-user-auth`
-- mainブランチの最新から切ること
+- developブランチの最新から切ること
 
 ### Phase 2: TDD 実装
 
@@ -201,7 +201,7 @@ worktreeモードで作業した場合は、ExitWorktreeでクリーンアップ
 - 1 Issue = 1 PR を厳守
 - **Phase 1（分析・設計）を飛ばして Phase 2（実装）に入らない**
 - テストが通らない状態でPRを作成しない
-- `.Codex/rules/` のルールに従うこと
+- `.claude/rules/` のルールに従うこと
 - `docs/` に関連する設計書・仕様書があれば参照すること
 
 ## Issue ラベル運用

--- a/.agents/skills/tdd-issue/SKILL.md
+++ b/.agents/skills/tdd-issue/SKILL.md
@@ -161,25 +161,25 @@ git commit -m "<type>: <説明>"
 git push -u origin <ブランチ名>
 ```
 
-- コミットメッセージは英語、Conventional Commits形式
+- コミットメッセージは Conventional Commits 形式。`type` / `scope` は英字、説明は日本語で書く
 - `Co-Authored-By:` 行は含めない
 - TDD サイクルの粒度でコミットを分ける:
-  1. `test: add tests for <feature>` (Red)
-  2. `feat: implement <feature>` (Green)
-  3. `refactor: clean up <feature>` (Refactor、必要な場合のみ)
+  1. `test: <機能>のテストを追加` (Red)
+  2. `feat: <機能>を実装` (Green)
+  3. `refactor: <機能>を整理` (Refactor、必要な場合のみ)
 - `specs/` 配下の作業メモは gitignored のためコミット対象に含めない
 
 #### Step 10: PR作成
 
 ```bash
 gh pr create --title "<タイトル>" --body "$(cat <<'EOF'
-## Summary
+## 概要
 - <変更内容を箇条書き>
 
-## Issue
+## 関連 Issue
 Closes #<issue番号>
 
-## Test plan
+## テスト計画
 - [ ] Vitest テストパス
 - [ ] Pest テストパス
 - [ ] ESLint リントパス
@@ -188,7 +188,7 @@ EOF
 )"
 ```
 
-- PRタイトルは70文字以内
+- PRタイトルは70文字以内、日本語で書く
 - `Closes #<issue番号>` でIssueと紐付け
 - マージ方針: squash merge
 

--- a/.agents/skills/verify-qa/SKILL.md
+++ b/.agents/skills/verify-qa/SKILL.md
@@ -14,13 +14,13 @@ description: >
 
 - **フロントエンド**: `frontend/` - React 19 + TypeScript 5.9 + Vite 8
 - **バックエンド**: `backend/` - Laravel 13 + PHP 8.4
-- **ルール**: `.Codex/rules/security.md` を必ず確認
+- **ルール**: `.claude/rules/security.md` を必ず確認
 
 ## ワークフロー
 
 ### Step 1: セキュリティチェック
 
-`.Codex/rules/security.md` を読み、変更内容に以下がないか確認:
+`.claude/rules/security.md` を読み、変更内容に以下がないか確認:
 
 - `.env` の変更・コミット
 - ハードコーディングされたシークレット

--- a/.agents/skills/worktree-issue/SKILL.md
+++ b/.agents/skills/worktree-issue/SKILL.md
@@ -18,7 +18,7 @@ TDDサイクルが不要なタスク（ドキュメント変更、設定変更�
 
 - **フロントエンド**: React 19 + TypeScript 5.9 + Vite 8 / リント: ESLint
 - **バックエンド**: Laravel 13 + PHP 8.4 / リント: Laravel Pint
-- **ルール**: `.Codex/rules/` 配下の各ファイルを作業開始前に必ず確認（特に `.Codex/rules/security.md`）
+- **ルール**: `.claude/rules/` 配下の各ファイルを作業開始前に必ず確認（特に `.claude/rules/security.md`）
 - **ディレクトリ**: フロントエンド=`frontend/` / バックエンド=`backend/`
 
 ## ワークフロー
@@ -33,9 +33,9 @@ Issueのタイトル・本文・ラベル・コメントを読み取り、実装
 
 ### Step 2: rulesの確認
 
-`.Codex/rules/` ディレクトリ内の関連ルールファイルを確認する。
+`.claude/rules/` ディレクトリ内の関連ルールファイルを確認する。
 対象技術スタック（frontend / backend）に応じて該当ファイルを読む。
-**`.Codex/rules/security.md` は必ず確認する。**
+**`.claude/rules/security.md` は必ず確認する。**
 
 ### Step 3: worktree作成・ブランチ切り替え
 
@@ -53,7 +53,7 @@ git checkout -b feature/#<issue番号>-<issue-slug>
 
 - `<issue-slug>`: Issueタイトルから英語kebab-caseで短く生成
 - 例: `feature/#42-update-docs`
-- mainブランチの最新から切ること
+- developブランチの最新から切ること
 
 ### Step 4: 依存関係インストール
 
@@ -74,7 +74,7 @@ cd backend && composer install
 
 Issueの要件に基づき実装を行う。
 
-- `.Codex/rules/` の規約に従うこと
+- `.claude/rules/` の規約に従うこと
 - `docs/` に関連する設計書・仕様書があれば参照すること
 
 ### Step 6: リント・検証
@@ -150,6 +150,6 @@ ExitWorktree でworktreeを退出・クリーンアップ
 
 - 1 Issue = 1 PR を厳守
 - リントが通らない状態でPRを作成しない
-- `.Codex/rules/` のルールに従うこと
+- `.claude/rules/` のルールに従うこと
 - `docs/` に関連する設計書・仕様書があれば参照すること
 - worktreeは作業完了後に必ずクリーンアップすること

--- a/.agents/skills/worktree-issue/SKILL.md
+++ b/.agents/skills/worktree-issue/SKILL.md
@@ -111,30 +111,30 @@ git commit -m "<type>: <説明>"
 git push -u origin <ブランチ名>
 ```
 
-- コミットメッセージは英語、Conventional Commits形式
+- コミットメッセージは Conventional Commits 形式。`type` / `scope` は英字、説明は日本語で書く
 - 複数コミットOK（内容に応じて分けてよい）
 
 ### Step 8: PR作成
 
 ```bash
 gh pr create --title "<タイトル>" --body "$(cat <<'EOF'
-## Summary
+## 概要
 - <変更内容を箇条書き>
 
-## Issue
+## 関連 Issue
 Closes #<issue番号>
 
-## Test plan
+## テスト計画
 - [ ] リントパス
 - [ ] 型チェックパス（該当する場合）
 - [ ] 既存テストへの影響なし
 
-🤖 Generated with [Codex](https://Codex.com/Codex)
+Codexで生成
 EOF
 )"
 ```
 
-- PRタイトルは70文字以内
+- PRタイトルは70文字以内、日本語で書く
 - `Closes #<issue番号>` でIssueと紐付け
 - マージ方針: squash merge
 

--- a/.claude/rules/git-flow.md
+++ b/.claude/rules/git-flow.md
@@ -31,7 +31,7 @@ Conventional Commits 形式を使用する。
 <type>: <説明>
 ```
 
-- 説明は**日本語・英語どちらでも可**
+- `type` / `scope` は Conventional Commits に従い英字、説明は**日本語**で書く
 - `Co-Authored-By:` 行は**含めない**
 - コミットメッセージは commitlint で自動検証される（Husky）
 
@@ -86,21 +86,21 @@ chore(ci): GitHub Actions のキャッシュ設定を更新
 
 ### PR タイトル
 
-- 70文字以内
+- 70文字以内、日本語で書く
 - コミットタイプを含める（例: `feat: ユーザー認証を追加 (#42)`）
 
 ### PR テンプレート
 
 ```markdown
-## Summary
+## 概要
 
 - <変更内容を箇条書き>
 
-## Issue
+## 関連 Issue
 
 Closes #<issue番号>
 
-## Test plan
+## テスト計画
 
 - [ ] Vitest テストパス
 - [ ] Pest テストパス

--- a/.claude/skills/tdd-issue/SKILL.md
+++ b/.claude/skills/tdd-issue/SKILL.md
@@ -100,7 +100,7 @@ git checkout -b feature/#<issue番号>-<issue-slug>
 
 - `<issue-slug>`: Issueタイトルから英語kebab-caseで短く生成
 - 例: `feature/#42-add-user-auth`
-- mainブランチの最新から切ること
+- developブランチの最新から切ること
 
 ### Phase 2: TDD 実装
 
@@ -161,25 +161,25 @@ git commit -m "<type>: <説明>"
 git push -u origin <ブランチ名>
 ```
 
-- コミットメッセージは英語、Conventional Commits形式
+- コミットメッセージは Conventional Commits 形式。`type` / `scope` は英字、説明は日本語で書く
 - `Co-Authored-By:` 行は含めない
 - TDD サイクルの粒度でコミットを分ける:
-  1. `test: add tests for <feature>` (Red)
-  2. `feat: implement <feature>` (Green)
-  3. `refactor: clean up <feature>` (Refactor、必要な場合のみ)
+  1. `test: <機能>のテストを追加` (Red)
+  2. `feat: <機能>を実装` (Green)
+  3. `refactor: <機能>を整理` (Refactor、必要な場合のみ)
 - `specs/` 配下の作業メモは gitignored のためコミット対象に含めない
 
 #### Step 10: PR作成
 
 ```bash
 gh pr create --title "<タイトル>" --body "$(cat <<'EOF'
-## Summary
+## 概要
 - <変更内容を箇条書き>
 
-## Issue
+## 関連 Issue
 Closes #<issue番号>
 
-## Test plan
+## テスト計画
 - [ ] Vitest テストパス
 - [ ] Pest テストパス
 - [ ] ESLint リントパス
@@ -188,7 +188,7 @@ EOF
 )"
 ```
 
-- PRタイトルは70文字以内
+- PRタイトルは70文字以内、日本語で書く
 - `Closes #<issue番号>` でIssueと紐付け
 - マージ方針: squash merge
 

--- a/.claude/skills/worktree-issue/SKILL.md
+++ b/.claude/skills/worktree-issue/SKILL.md
@@ -53,7 +53,7 @@ git checkout -b feature/#<issue番号>-<issue-slug>
 
 - `<issue-slug>`: Issueタイトルから英語kebab-caseで短く生成
 - 例: `feature/#42-update-docs`
-- mainブランチの最新から切ること
+- developブランチの最新から切ること
 
 ### Step 4: 依存関係インストール
 
@@ -111,30 +111,30 @@ git commit -m "<type>: <説明>"
 git push -u origin <ブランチ名>
 ```
 
-- コミットメッセージは英語、Conventional Commits形式
+- コミットメッセージは Conventional Commits 形式。`type` / `scope` は英字、説明は日本語で書く
 - 複数コミットOK（内容に応じて分けてよい）
 
 ### Step 8: PR作成
 
 ```bash
 gh pr create --title "<タイトル>" --body "$(cat <<'EOF'
-## Summary
+## 概要
 - <変更内容を箇条書き>
 
-## Issue
+## 関連 Issue
 Closes #<issue番号>
 
-## Test plan
+## テスト計画
 - [ ] リントパス
 - [ ] 型チェックパス（該当する場合）
 - [ ] 既存テストへの影響なし
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+Claude Codeで生成
 EOF
 )"
 ```
 
-- PRタイトルは70文字以内
+- PRタイトルは70文字以内、日本語で書く
 - `Closes #<issue番号>` でIssueと紐付け
 - マージ方針: squash merge
 

--- a/.github/commit_message_template
+++ b/.github/commit_message_template
@@ -1,4 +1,4 @@
-# <type>(<scope>): <説明（日本語・英語可）>
+# <type>(<scope>): <説明（日本語）>
 #
 # type: feat | fix | refactor | test | docs | chore | ci | release | revert
 # scope（任意）: frontend | backend | db | ci | docs | infra
@@ -10,5 +10,6 @@
 #
 # ルール:
 #   - 先頭行は100文字以内
+#   - type/scope は Conventional Commits に従い英字、説明は日本語で書く
 #   - Co-Authored-By: 行は含めない
 #   - commitlint で自動検証される

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,19 @@
-## Summary
+## 概要
 
 - <変更内容を箇条書き>
 
-## Issue
+## 関連 Issue
 
 Closes #<issue番号>
 
-## Test plan
+## テスト計画
 
 - [ ] Vitest テストパス
 - [ ] Pest テストパス
 - [ ] ESLint リントパス
 - [ ] Pint リントパス
 
-## Review checklist
+## レビューチェックリスト
 
 - [ ] コードが `rules/` の規約に準拠している
 - [ ] テストが追加・更新されている

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Frontend は Vitest、Testing Library、`@testing-library/user-event` を使い�
 
 ## コミットと Pull Request
 
-コミットは commitlint で検証される Conventional Commits 形式です。type は `feat`、`fix`、`refactor`、`test`、`docs`、`chore`、`ci`、`release`、`revert` を使います。scope は `frontend`、`backend`、`db`、`infra`、`docs` などが推奨です。ブランチは `develop` から `feature/#<issue>-<slug>` または `fix/#<issue>-<slug>` で切ります。PR は `develop` 向けにし、`.github/pull_request_template.md` に沿って Summary、`Closes #<issue>`、Test plan を記載し、squash merge します。
+コミットは commitlint で検証される Conventional Commits 形式です。type は `feat`、`fix`、`refactor`、`test`、`docs`、`chore`、`ci`、`release`、`revert` を使います。scope は `frontend`、`backend`、`db`、`infra`、`docs` などが推奨です。type/scope は英字、コミット説明は日本語で書いてください。ブランチは `develop` から `feature/#<issue>-<slug>` または `fix/#<issue>-<slug>` で切ります。PR は `develop` 向けにし、タイトル・本文・テンプレート記入内容を日本語で記載します。`.github/pull_request_template.md` に沿って概要、`Closes #<issue>`、テスト計画を記載し、squash merge します。
 
 ## セキュリティとエージェント向け注意
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+coverage
 *.local
 
 # Editor directories and files

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.0",
+    "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^10.3.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.0
         version: 6.0.1(vite@8.0.10(@types/node@25.6.0))
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
       eslint:
         specifier: ^10.3.0
         version: 10.3.0
@@ -68,7 +71,7 @@ importers:
         version: 8.0.10(@types/node@25.6.0)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0))
 
 packages:
 
@@ -160,6 +163,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -387,36 +394,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -583,6 +596,15 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/coverage-v8@4.1.5':
+    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
+    peerDependencies:
+      '@vitest/browser': 4.1.5
+      vitest: 4.1.5
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
@@ -643,6 +665,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -898,6 +923,10 @@ packages:
     resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
@@ -907,6 +936,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -937,6 +969,21 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1011,24 +1058,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1063,6 +1114,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
@@ -1208,6 +1266,10 @@ packages:
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
   symbol-tree@3.2.4:
@@ -1552,6 +1614,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -1981,6 +2045,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.10(@types/node@25.6.0)
 
+  '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.5
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0))
+
   '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2046,6 +2124,12 @@ snapshots:
   aria-query@5.3.2: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   balanced-match@4.0.4: {}
 
@@ -2341,6 +2425,8 @@ snapshots:
 
   globals@17.6.0: {}
 
+  has-flag@4.0.0: {}
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
@@ -2352,6 +2438,8 @@ snapshots:
       '@exodus/bytes': 1.15.0
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
 
   ignore@5.3.2: {}
 
@@ -2370,6 +2458,21 @@ snapshots:
   is-potential-custom-element-name@1.0.1: {}
 
   isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -2482,6 +2585,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   mdn-data@2.27.1: {}
 
@@ -2615,6 +2728,10 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   symbol-tree@3.2.4: {}
 
   tinybench@2.9.0: {}
@@ -2693,7 +2810,7 @@ snapshots:
       '@types/node': 25.6.0
       fsevents: 2.3.3
 
-  vitest@4.1.5(@types/node@25.6.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)):
+  vitest@4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0))
@@ -2717,6 +2834,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## 概要

- Vitest の v8 coverage provider 依存関係と lockfile を追加し、fresh install 後でも `pnpm test:coverage` が動くように修正
- local agent skill のルール参照先を `.Codex/rules/` から `.claude/rules/` へ修正
- Issue ワークフローのブランチ起点を Git Flow に合わせて `develop` に統一
- packaged skill から `__pycache__` や `*.pyc` などの生成物を除外
- frontend coverage 出力を lint 対象から除外
- コミットメッセージと PR タイトル・本文を日本語で書く運用ルールを追加
- `origin/develop` との競合を解消

## 関連 Issue

レビュー指摘対応のため該当なし

## テスト計画

- [x] `pnpm -C frontend exec tsc -b --noEmit`
- [x] `pnpm -C frontend lint`
- [x] `pnpm -C frontend test`
- [x] `pnpm -C frontend test:coverage`
- [x] `python3 .agents/skills/skill-creator/scripts/quick_validate.py .agents/skills/skill-creator`
- [x] `python3 .agents/skills/skill-creator/scripts/package_skill.py .agents/skills/skill-creator /private/tmp/skill-package-test`
- [x] `git diff --check`