### PR TITLE
docs: Label運用ガイドとREADMEを整理

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,15 @@
 
 Closes #<issue番号>
 
+## Labels
+
+このPRに関連するLabelは [Label運用ガイド](docs/labels.md) を確認してください。
+
+- type:
+- area:
+- priority:
+- status:
+
 ## テスト計画
 
 - [ ] Vitest テストパス

--- a/README.md
+++ b/README.md
@@ -1,62 +1,32 @@
 # real-world
 
-React 19 + Laravel 13 のモノレポ構成。AI駆動開発（ハーネスエンジニアリング）の学習・実践プロジェクト。
+React 19 + Laravel 13 で API / CRUD / DDD を学ぶためのモノレポです。
+フロントエンド、バックエンド、Docker 環境をまとめて管理しています。
 
 ## 技術スタック
 
-| レイヤー | 技術 | テスト | リント |
-|---------|------|--------|-------|
-| フロントエンド | React 19 + TypeScript 5.9 + Vite 8 | Vitest + Testing Library | ESLint |
-| バックエンド | Laravel 13 + PHP 8.4 | Pest 4.4 | Pint + PHPStan |
-| DB | MySQL 8.0 | — | — |
-
-## ディレクトリ構成
-
-```
-.
-├── frontend/          # React 19 + TypeScript
-├── backend/           # Laravel 13
-├── docker/
-│   ├── backend/       # PHP-FPM / Nginx
-│   ├── frontend/      # Node
-│   └── db/            # MySQL
-├── specs/             # Issue単位の設計メモ・実行プラン（gitignored）
-├── .agents/
-│   └── skills/        # Codex スキル
-├── .claude/
-│   ├── rules/         # 互換用ポインタ（正本は docs/rules/）
-│   └── skills/        # Claude Code スキル
-├── .devcontainer/     # Dev Container 設定
-├── docs/
-│   ├── ai/            # AI ハーネス設計
-│   ├── adr/           # アーキテクチャ決定記録
-│   ├── arch/          # ドメイン設計・Bounded Context
-│   ├── design/        # 機能設計テンプレート
-│   └── rules/         # AI向けコーディング規約の正本
-└── compose.yml
-```
+| レイヤー | 技術 |
+| --- | --- |
+| フロントエンド | React 19 + TypeScript 5.9 + Vite 8 |
+| バックエンド | Laravel 13 + PHP 8.4 |
+| DB | MySQL 8.0 |
+| テスト | Vitest + Testing Library / Pest |
+| 品質チェック | ESLint / Pint / PHPStan |
 
 ## セットアップ
 
-### 必要なもの
+必要なもの:
 
 - Docker Desktop
-- VS Code + Dev Containers 拡張（devcontainer 利用時）
+- VS Code + Dev Containers 拡張（任意）
 
-### 起動
+起動:
 
 ```bash
-# 全サービス起動
 docker compose up -d
-
-# PHPコンテナ接続
-docker compose exec backend-php bash
-
-# 停止
-docker compose down
 ```
 
-### バックエンド初期設定
+バックエンド初期設定:
 
 ```bash
 docker compose exec backend-php bash
@@ -66,59 +36,59 @@ php artisan key:generate
 php artisan migrate
 ```
 
-### フロントエンド初期設定
+フロントエンド初期設定:
 
 ```bash
 docker compose exec frontend sh
 pnpm install
 ```
 
+停止:
+
+```bash
+docker compose down
+```
+
 ## アクセス先
 
 | サービス | URL |
-|---------|-----|
-| フロントエンド | http://localhost:5173 |
+| --- | --- |
+| フロントエンド | http://localhost:3005 |
 | バックエンド API | http://localhost:8080 |
 | Mailpit | http://localhost:8025 |
 
 ## テスト・リント
 
-### フロントエンド
+フロントエンド:
 
 ```bash
-cd frontend && pnpm vitest run      # テスト
-cd frontend && pnpm eslint .        # リント
-cd frontend && pnpm tsc -b --noEmit # 型チェック
+cd frontend && pnpm vitest run
+cd frontend && pnpm eslint .
+cd frontend && pnpm tsc -b --noEmit
 ```
 
-### バックエンド
+バックエンド:
 
 ```bash
-cd backend && php artisan test              # テスト
-cd backend && ./vendor/bin/pint --test      # リント確認
-cd backend && ./vendor/bin/phpstan analyse  # 静的解析
+cd backend && php artisan test
+cd backend && ./vendor/bin/pint --test
+cd backend && ./vendor/bin/phpstan analyse
 ```
 
-## Dev Container
+## 主なディレクトリ
 
-VS Code / Cursor の Dev Containers で開発環境を起動できます。
+| パス | 内容 |
+| --- | --- |
+| `frontend/` | React アプリケーション |
+| `backend/` | Laravel API |
+| `docker/` | Docker 関連設定 |
+| `docs/` | 設計、ADR、運用ルール |
+| `specs/` | Issue 単位の設計メモ・実行プラン（gitignored） |
 
-- Claude Code が事前インストール済み
-- GitHub CLI (`gh`) と `pnpm` がそのまま使える
-- ホストの `~/.claude`（認証情報）・`~/.config/gh`（GitHub CLI）を自動マウント
-- `backend/.env` の環境変数をコンテナ内に自動注入
-- `php` / `composer` は devcontainer から `backend-php` サービスへ委譲されるため、`cd backend && php artisan test` などの既存コマンドをそのまま使える
-- Dev Container は開発用であり、ネットワーク隔離 sandbox としては扱わない
+## 関連ドキュメント
 
-### Dev Container の PHP 実行について
-
-devcontainer 自体は Node ベースの作業コンテナで、PHP は同居させていません。
-PHP の実行環境は `compose.yml` の `backend-php` サービスに一元化しています。
-
-- `php`: `backend-php` コンテナで `php` を実行するラッパー
-- `composer`: `backend-php` コンテナで `composer` を実行するラッパー
-- `delegate-backend-php`: 上記ラッパーの共通実装
-- `docker`: devcontainer 内の `node` ユーザーから Docker Desktop のソケットへアクセスするためのラッパー
-
-このため、devcontainer では `artisan` 専用コマンドは持たず、`php artisan ...` を標準の使い方とします。
-設定変更後は Dev Container を `Rebuild Container` して反映してください。
+- [AI Harness Design](docs/ai/harness.md)
+- [コーディングルール](docs/rules/)
+- [アーキテクチャ決定記録](docs/adr/)
+- [ドメイン設計](docs/arch/)
+- [Label運用ガイド](docs/labels.md)

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,0 +1,172 @@
+# Label運用ガイド
+
+GitHub Issues / Pull Requests で使う Label の分類、意図、付け方をまとめる。
+Issue 作成時や PR 作成時に、作業の種類、対象領域、優先度、状態を明示して、後から探しやすくすることを目的とする。
+
+## 目的
+
+- Issue / PR の種類を明確にする
+- Backend / Frontend / DDD / API など、作業対象の領域を明確にする
+- 優先度を判断しやすくする
+- 着手可能か、議論中か、ブロック中かを判断しやすくする
+- GitHub Issues / Pull Requests / Projects でフィルタリングしやすくする
+
+## Label分類
+
+```text
+type: 作業の種類
+area: 作業対象の領域
+priority: 優先度
+status: 作業状態
+```
+
+## type Labels
+
+| Label | 意図 |
+| --- | --- |
+| `type: docs` | ドキュメント作成・更新に関するIssue / PR |
+| `type: planning` | 要件整理、設計方針、Issue分解など計画系のIssue / PR |
+| `type: feature` | 新機能の実装に関するIssue / PR |
+| `type: refactor` | 振る舞いを変えずに内部設計やコード構造を改善するIssue / PR |
+| `type: chore` | 設定、環境構築、依存関係更新など機能以外の作業Issue / PR |
+| `type: test` | テスト追加・修正・テスト方針に関するIssue / PR |
+
+## area Labels
+
+| Label | 意図 |
+| --- | --- |
+| `area: requirements` | 要件定義、スコープ整理、受け入れ条件に関するIssue / PR |
+| `area: ddd` | DDD、Bounded Context、ユビキタス言語、ドメイン設計に関するIssue / PR |
+| `area: backend` | Laravel API、UseCase、Domain、DBなどBackend領域のIssue / PR |
+| `area: frontend` | React、画面、ルーティング、UI、状態管理に関するIssue / PR |
+| `area: api` | エンドポイント、リクエスト、レスポンス、API仕様に関するIssue / PR |
+| `area: auth` | 登録、ログイン、JWT、現在ユーザー取得に関するIssue / PR |
+| `area: article` | 記事一覧、記事詳細、記事作成、記事更新、記事削除に関するIssue / PR |
+| `area: comment` | コメント一覧、コメント投稿、コメント削除に関するIssue / PR |
+| `area: profile` | プロフィール表示、プロフィール更新、公開ユーザー情報に関するIssue / PR |
+| `area: social` | フォロー、お気に入り、フィードに関するIssue / PR |
+| `area: infra` | Docker、CI/CD、GitHub Actions、環境構築に関するIssue / PR |
+| `area: non-functional` | 品質、パフォーマンス、保守性、Lint、Format、開発体験に関するIssue / PR |
+
+## priority Labels
+
+| Label | 意図 |
+| --- | --- |
+| `priority: high` | 優先度が高く、早めに対応したいIssue / PR |
+| `priority: medium` | 通常優先度のIssue / PR |
+| `priority: low` | 後回しでも問題ないIssue / PR |
+
+## status Labels
+
+| Label | 意図 |
+| --- | --- |
+| `status: needs discussion` | 方針や仕様について議論が必要なIssue / PR |
+| `status: ready` | 着手可能な状態のIssue / PR |
+| `status: blocked` | 他のIssueや決定待ちにより進められないIssue / PR |
+
+## Labelの付け方ルール
+
+### Issue作成時
+
+Issueには、原則として以下を付ける。
+
+```text
+type: 1つ以上
+area: 1つ以上
+priority: 原則1つ
+status: 必要に応じて1つ
+```
+
+例:
+
+```text
+type: docs
+area: requirements
+priority: high
+status: ready
+```
+
+### PR作成時
+
+PRには、対応したIssueと同じLabelを基本的に付ける。
+ただし、PRの実際の変更内容に応じて `type:` や `area:` を追加・調整してよい。
+
+例:
+
+```text
+type: docs
+area: ddd
+priority: medium
+```
+
+## 使用例
+
+### 要件定義書を作成するIssue
+
+```text
+type: docs
+area: requirements
+priority: high
+status: ready
+```
+
+### DDDのContext Mapを整理するIssue
+
+```text
+type: docs
+type: planning
+area: ddd
+priority: medium
+status: needs discussion
+```
+
+### Laravel APIの認証機能を実装するIssue
+
+```text
+type: feature
+area: backend
+area: api
+area: auth
+priority: high
+status: ready
+```
+
+### Reactの画面実装Issue
+
+```text
+type: feature
+area: frontend
+priority: medium
+status: ready
+```
+
+### DockerやCIの設定Issue
+
+```text
+type: chore
+area: infra
+area: non-functional
+priority: medium
+```
+
+## 注意点
+
+- `type:` は「何をするか」
+- `area:` は「どの領域か」
+- `priority:` は「どれくらい優先するか」
+- `status:` は「今どういう状態か」
+- `area:` は複数付けてもよい
+- `priority:` は基本的に1つだけ付ける
+- `status:` は状況に応じて更新する
+- Labelは完璧に付けることより、後から探しやすくすることを重視する
+
+## 受け入れ条件
+
+- [ ] Label一覧がdocsに追加されている
+- [ ] `type:` / `area:` / `priority:` / `status:` の意味が説明されている
+- [ ] 各Labelの意図が表形式で整理されている
+- [ ] Issue作成時のLabel付与ルールが記載されている
+- [ ] PR作成時のLabel付与ルールが記載されている
+- [ ] 使用例が記載されている
+- [ ] 既存docsやREADMEから参照できる場合はリンクが追加されている
+- [ ] アプリケーションコードは変更されていない


### PR DESCRIPTION
## 概要

- GitHub Label の分類、意図、付け方、使用例を `docs/labels.md` に追加
- README を人間向けの概要、セットアップ、アクセス先、検証コマンド、関連ドキュメント中心に整理
- PR テンプレートに Label 確認欄を追加
- README のフロントエンド URL を `http://localhost:3005` に更新

## 関連 Issue

なし

## Labels

- type: docs
- area: non-functional
- priority: medium
- status: ready

## テスト計画

- [x] `git diff --check`
- [x] ドキュメント変更のみのため、アプリケーションテストは未実行

## レビューチェックリスト

- [x] アプリケーションコードを変更していない
- [x] README から Label 運用ガイドへ参照できる
- [x] PR 作成時に Label を確認できる