### PR TITLE
docs: ProjectのEpic運用を追加

### DIFF
--- a/.agents/skills/issue-planning/SKILL.md
+++ b/.agents/skills/issue-planning/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: issue-planning
+description: >
+  GitHub Issue / Epic / sub-issue を作成・分解・整理するスキル。
+  「Issueを作って」「後続Issueを切って」「Epicに分けて」「sub issueに分解して」
+  「GitHub Projectへ追加して」など、Issue作成やバックログ整理を求められたときに使う。
+---
+
+# Issue Planning ワークフロー
+
+GitHub Issue 作成時に、Epic 化、sub-issue 分解、Project field、label、親子関係を整理する。
+
+## 前提
+
+- Issue / Project / Epic 運用の正本は `docs/rules/project.md`
+- Label 運用の正本は `docs/labels.md`
+- 後続 Epic 候補の正本は `docs/issue-breakdown.md`
+- Git Flow / PR 紐付けは `docs/rules/git-flow.md`
+- セキュリティ観点は `docs/rules/security.md`
+
+## ワークフロー
+
+### Step 1: 入力と既存Issue確認
+
+- ユーザーの依頼範囲を確認する。
+- 既存 Issue と重複しないか `gh issue list` / `gh issue view` で確認する。
+- `docs/requirements.md` と関連する `docs/*` を参照し、Issue化する根拠を確認する。
+
+### Step 2: Epic化の判定
+
+次のいずれかなら Epic Issue を作る。
+
+- 複数レイヤー、複数PR、複数レビュー観点に分かれる
+- Backend / Frontend / QA など sub-issue に分解できる
+- `docs/issue-breakdown.md` の Epic Candidates に該当する
+
+Epic にしない場合でも、既存 Epic の sub-issue にできるか確認する。
+
+### Step 3: Sub-Issue 分解
+
+分解できる場合は、作成前に短い分解案を提示する。
+
+分解軸:
+
+- Backend / Frontend / Infra / QA
+- API endpoint / 画面 / feature / Context
+- 認証、認可、バリデーション、エラー処理、テスト
+- 1 Issue = 1 PR でレビュー可能な単位
+
+### Step 4: Issue本文作成
+
+各 Issue には次を含める。
+
+- 概要
+- 背景
+- 対応内容
+- 受け入れ条件
+- テスト観点
+- Project / Epic
+- 関連: `Parent: #<epic番号>` または `Sub-issues of #<epic番号>`
+- 参照 docs
+
+Epic Issue には sub-issue 候補一覧と完了条件を含める。
+
+### Step 5: 作成
+
+Issue 作成は `gh issue create` を使う。
+
+```bash
+gh issue create --title "<title>" --body-file <file> --label "<labels>"
+```
+
+Project に追加する場合:
+
+```bash
+gh issue create --title "<title>" --body-file <file> --label "<labels>" --project "<project-title>"
+```
+
+`--project` には `project` scope が必要な場合がある。権限エラー時は `gh auth refresh -s project` を案内する。
+
+### Step 6: Sub-Issue 紐付け
+
+GitHub CLI の `gh issue create` は parent issue 指定を直接サポートしない場合がある。
+その場合は REST API で紐付ける。
+
+```bash
+sub_issue_id=$(gh api repos/:owner/:repo/issues/<child-number> --jq .id)
+gh api -X POST repos/:owner/:repo/issues/<parent-number>/sub_issues -f sub_issue_id="$sub_issue_id"
+```
+
+紐付け後、子 Issue の本文にも `Parent: #<parent-number>` を残す。
+
+### Step 7: Project field 設定
+
+Project の custom field は Project 内メタデータなので、Issue 本文にも Epic / Parent を残す。
+
+最低限設定する field:
+
+- `Epic`
+- `Priority`
+- `Status`
+- `Sprint`（決まっている場合）
+- `Size` / `Story Point`（見積もる場合）
+
+Project ID / field ID / option ID が不明な場合は、Issue 作成後に「未設定field」としてユーザーに明示する。
+
+### Step 8: 一覧確認
+
+Issue 作成後は、一覧性のため次を確認する。
+
+- Epic Issue に `type: epic` が付いている
+- 子 Issue に `Parent: #...` がある
+- sub-issue として紐付いている
+- Project view では `Parent issue`, `Sub-issue progress`, `Epic` を表示できる
+
+## 注意事項
+
+- 1 Issue = 1 PR を維持する
+- Epic Issue は原則として実装PRで閉じない
+- Project custom field だけを親子関係の正にしない
+- Issue を大量作成する前に、分解案をユーザーへ提示する

--- a/.claude/skills/issue-planning/SKILL.md
+++ b/.claude/skills/issue-planning/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: issue-planning
+description: >
+  GitHub Issue / Epic / sub-issue を作成・分解・整理するスキル。
+  「Issueを作って」「後続Issueを切って」「Epicに分けて」「sub issueに分解して」
+  「GitHub Projectへ追加して」など、Issue作成やバックログ整理を求められたときに使う。
+---
+
+# Issue Planning ワークフロー
+
+GitHub Issue 作成時に、Epic 化、sub-issue 分解、Project field、label、親子関係を整理する。
+
+## 前提
+
+- Issue / Project / Epic 運用の正本は `docs/rules/project.md`
+- Label 運用の正本は `docs/labels.md`
+- 後続 Epic 候補の正本は `docs/issue-breakdown.md`
+- Git Flow / PR 紐付けは `docs/rules/git-flow.md`
+- セキュリティ観点は `docs/rules/security.md`
+
+## ワークフロー
+
+### Step 1: 入力と既存Issue確認
+
+- ユーザーの依頼範囲を確認する。
+- 既存 Issue と重複しないか `gh issue list` / `gh issue view` で確認する。
+- `docs/requirements.md` と関連する `docs/*` を参照し、Issue化する根拠を確認する。
+
+### Step 2: Epic化の判定
+
+次のいずれかなら Epic Issue を作る。
+
+- 複数レイヤー、複数PR、複数レビュー観点に分かれる
+- Backend / Frontend / QA など sub-issue に分解できる
+- `docs/issue-breakdown.md` の Epic Candidates に該当する
+
+Epic にしない場合でも、既存 Epic の sub-issue にできるか確認する。
+
+### Step 3: Sub-Issue 分解
+
+分解できる場合は、作成前に短い分解案を提示する。
+
+分解軸:
+
+- Backend / Frontend / Infra / QA
+- API endpoint / 画面 / feature / Context
+- 認証、認可、バリデーション、エラー処理、テスト
+- 1 Issue = 1 PR でレビュー可能な単位
+
+### Step 4: Issue本文作成
+
+各 Issue には次を含める。
+
+- 概要
+- 背景
+- 対応内容
+- 受け入れ条件
+- テスト観点
+- Project / Epic
+- 関連: `Parent: #<epic番号>` または `Sub-issues of #<epic番号>`
+- 参照 docs
+
+Epic Issue には sub-issue 候補一覧と完了条件を含める。
+
+### Step 5: 作成
+
+Issue 作成は `gh issue create` を使う。
+
+```bash
+gh issue create --title "<title>" --body-file <file> --label "<labels>"
+```
+
+Project に追加する場合:
+
+```bash
+gh issue create --title "<title>" --body-file <file> --label "<labels>" --project "<project-title>"
+```
+
+`--project` には `project` scope が必要な場合がある。権限エラー時は `gh auth refresh -s project` を案内する。
+
+### Step 6: Sub-Issue 紐付け
+
+GitHub CLI の `gh issue create` は parent issue 指定を直接サポートしない場合がある。
+その場合は REST API で紐付ける。
+
+```bash
+sub_issue_id=$(gh api repos/:owner/:repo/issues/<child-number> --jq .id)
+gh api -X POST repos/:owner/:repo/issues/<parent-number>/sub_issues -f sub_issue_id="$sub_issue_id"
+```
+
+紐付け後、子 Issue の本文にも `Parent: #<parent-number>` を残す。
+
+### Step 7: Project field 設定
+
+Project の custom field は Project 内メタデータなので、Issue 本文にも Epic / Parent を残す。
+
+最低限設定する field:
+
+- `Epic`
+- `Priority`
+- `Status`
+- `Sprint`（決まっている場合）
+- `Size` / `Story Point`（見積もる場合）
+
+Project ID / field ID / option ID が不明な場合は、Issue 作成後に「未設定field」としてユーザーに明示する。
+
+### Step 8: 一覧確認
+
+Issue 作成後は、一覧性のため次を確認する。
+
+- Epic Issue に `type: epic` が付いている
+- 子 Issue に `Parent: #...` がある
+- sub-issue として紐付いている
+- Project view では `Parent issue`, `Sub-issue progress`, `Epic` を表示できる
+
+## 注意事項
+
+- 1 Issue = 1 PR を維持する
+- Epic Issue は原則として実装PRで閉じない
+- Project custom field だけを親子関係の正にしない
+- Issue を大量作成する前に、分解案をユーザーへ提示する

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -48,6 +48,20 @@ body:
       required: true
 
   - type: textarea
+    id: project
+    attributes:
+      label: Project / Epic
+      description: GitHub Projects の Epic field、親Issue、sub-issue候補を記述してください。
+      value: |
+        Epic: <該当する場合>
+        Parent: #
+        Sub-issue分解:
+        - [ ] 不要
+        - [ ] 必要（候補を下に記述）
+    validations:
+      required: false
+
+  - type: textarea
     id: acceptance
     attributes:
       label: 受け入れ条件

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,87 @@
+name: Epic
+description: 複数のsub-issueを束ねる機能単位の親Issue
+title: "epic: "
+labels:
+  - "type: epic"
+  - "type: planning"
+  - "status: needs discussion"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Epic / sub-issue / GitHub Project の運用は `docs/rules/project.md` を確認してください。
+        Label の分類と付け方は `docs/labels.md` を確認してください。
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: このEpicで実現するユーザー価値や機能単位を記述してください。
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: スコープ
+      description: このEpicに含める範囲を箇条書きで記述してください。
+      value: |
+        - <含める範囲>
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: 対象外
+      description: このEpicでは扱わない範囲を記述してください。
+      value: |
+        - <対象外>
+    validations:
+      required: true
+
+  - type: textarea
+    id: sub_issues
+    attributes:
+      label: Sub-issue候補
+      description: 切り分ける予定の子Issueを記述してください。
+      value: |
+        - [ ] <sub-issue候補>
+    validations:
+      required: true
+
+  - type: textarea
+    id: completion
+    attributes:
+      label: 完了条件
+      description: Epicを閉じられる条件をチェックリストで記述してください。
+      value: |
+        - [ ] すべてのsub-issueが完了している
+        - [ ] 代表的なユーザーフローが確認されている
+        - [ ] 必要なドキュメントが更新されている
+    validations:
+      required: true
+
+  - type: dropdown
+    id: epic_field
+    attributes:
+      label: Project Epic field
+      description: GitHub Projects の `Epic` field に設定する値を選択してください。
+      options:
+        - Backend Foundation
+        - Frontend Foundation
+        - Identity Context
+        - Publishing Context
+        - Social Context
+        - API Integration
+        - E2E / Quality
+        - 未定
+    validations:
+      required: true
+
+  - type: textarea
+    id: related
+    attributes:
+      label: 関連
+      description: 関連Issue、PR、参照docsがあれば記述してください。
+      placeholder: "Related: #"

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -43,6 +43,20 @@ body:
       required: true
 
   - type: textarea
+    id: project
+    attributes:
+      label: Project / Epic
+      description: GitHub Projects の Epic field、親Issue、sub-issue候補を記述してください。
+      value: |
+        Epic: <Backend Foundation / Frontend Foundation / Identity Context / Publishing Context / Social Context / API Integration / E2E / Quality>
+        Parent: #
+        Sub-issue分解:
+        - [ ] 不要
+        - [ ] 必要（候補を下に記述）
+    validations:
+      required: true
+
+  - type: textarea
     id: requirements
     attributes:
       label: 要件

--- a/.github/ISSUE_TEMPLATE/fix.yml
+++ b/.github/ISSUE_TEMPLATE/fix.yml
@@ -62,6 +62,20 @@ body:
       required: true
 
   - type: textarea
+    id: project
+    attributes:
+      label: Project / Epic
+      description: GitHub Projects の Epic field、親Issue、sub-issue候補を記述してください。
+      value: |
+        Epic: <該当する場合>
+        Parent: #
+        Sub-issue分解:
+        - [ ] 不要
+        - [ ] 必要（候補を下に記述）
+    validations:
+      required: false
+
+  - type: textarea
     id: acceptance
     attributes:
       label: 受け入れ条件

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ React 19 + TypeScript / Laravel 13 のモノレポ。API、CRUD、新しい技�
 
 - `.agents/skills/code-review/` - コードレビュー、テスト妥当性、アーキテクチャ確認。
 - `.agents/skills/verify-qa/` - 型チェック、テスト、リント、静的解析、audit の実行。
+- `.agents/skills/issue-planning/` - GitHub Issue / Epic / sub-issue の作成、分解、Project field 整理。
 - `.agents/skills/tdd-issue/` - GitHub Issue 起点の TDD 実装。
 - `.agents/skills/worktree-issue/` - TDD 不要の Issue 対応やドキュメント・設定変更。
 
@@ -31,6 +32,7 @@ React 19 + TypeScript / Laravel 13 のモノレポ。API、CRUD、新しい技�
 - `docs/rules/backend.md` - `backend/` 変更時。
 - `docs/rules/db.md` - DB・マイグレーション変更時。
 - `docs/rules/git-flow.md` - ブランチ、コミット、PR 作成時。
+- `docs/rules/project.md` - Issue、Epic、sub-issue、GitHub Projects 運用時。
 - `docs/rules/log.md` - ログ追加時。
 
 ## レビュー観点

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ React 19 + TypeScript / Laravel 13 のモノレポ。API、CRUD、新しい技�
 
 - `.claude/skills/code-review/` - コードレビュー、テスト妥当性、アーキテクチャ確認。
 - `.claude/skills/verify-qa/` - 型チェック、テスト、リント、静的解析、audit の実行。
+- `.claude/skills/issue-planning/` - GitHub Issue / Epic / sub-issue の作成、分解、Project field 整理。
 - `.claude/skills/tdd-issue/` - GitHub Issue 起点の TDD 実装。
 - `.claude/skills/worktree-issue/` - TDD 不要の Issue 対応やドキュメント・設定変更。
 
@@ -31,6 +32,7 @@ React 19 + TypeScript / Laravel 13 のモノレポ。API、CRUD、新しい技�
 - `docs/rules/backend.md` - `backend/` 変更時。
 - `docs/rules/db.md` - DB・マイグレーション変更時。
 - `docs/rules/git-flow.md` - ブランチ、コミット、PR 作成時。
+- `docs/rules/project.md` - Issue、Epic、sub-issue、GitHub Projects 運用時。
 - `docs/rules/log.md` - ログ追加時。
 
 ## レビュー観点

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,8 @@
 | `db/` | DBML 形式のスキーマ記録 |
 | `labels.md` | GitHub ラベルの分類と付与ルール |
 
+GitHub Projects、Epic、sub-issue の運用は [`rules/project.md`](rules/project.md) を参照します。
+
 ## Issue 単位の設計メモ
 
 Issue に着手するときは [`../specs/_template-feature-spec.md`](../specs/_template-feature-spec.md) を使い、作業用メモをリポジトリルートの `specs/` に作成します。

--- a/docs/ai/harness.md
+++ b/docs/ai/harness.md
@@ -60,5 +60,6 @@ ADR は廃止方向とし、判断は要件・ルール・ドメイン設計・�
 
 - `code-review`: レビュー、テスト妥当性、アーキテクチャ確認。
 - `verify-qa`: 型チェック、テスト、リント、静的解析、audit の実行。
+- `issue-planning`: GitHub Issue / Epic / sub-issue の作成、分解、Project field 整理。
 - `tdd-issue`: GitHub Issue 起点の設計、TDD 実装、PR 準備。
 - `worktree-issue`: TDD 不要の Issue 対応、ドキュメント、設定変更。

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -26,6 +26,7 @@ status: 作業状態
 | --- | --- |
 | `type: docs` | ドキュメント作成・更新に関するIssue / PR |
 | `type: planning` | 要件整理、設計方針、Issue分解など計画系のIssue / PR |
+| `type: epic` | 複数のsub-issueを束ねる機能単位の親Issue |
 | `type: feature` | 新機能の実装に関するIssue / PR |
 | `type: fix` | 不具合修正、仕様とのズレ、回帰修正に関するIssue / PR |
 | `type: refactor` | 振る舞いを変えずに内部設計やコード構造を改善するIssue / PR |
@@ -78,6 +79,9 @@ priority: 原則1つ
 status: 必要に応じて1つ
 ```
 
+GitHub Projects の Epic / sub-issue 運用は `docs/rules/project.md` を正本とする。
+Epic Issue には `type: epic` を付け、実装 Issue は該当 Epic の sub-issue として紐付ける。
+
 例:
 
 ```text
@@ -119,6 +123,17 @@ type: planning
 area: ddd
 priority: medium
 status: needs discussion
+```
+
+### Epic Issue
+
+```text
+type: epic
+type: planning
+area: backend
+area: frontend
+priority: high
+status: ready
 ```
 
 ### Laravel APIの認証機能を実装するIssue

--- a/docs/rules/git-flow.md
+++ b/docs/rules/git-flow.md
@@ -78,11 +78,15 @@ chore(ci): GitHub Actions のキャッシュ設定を更新
 
 ## PR 方針
 
+Issue / Project / Epic の運用は [`project.md`](project.md) を正本とする。
+
 ### 基本ルール
 
 - **1 Issue = 1 PR** を厳守
 - **squash merge** で develop/main にマージ
 - `Closes #<issue番号>` で Issue と紐付け
+- Epic Issue は複数 sub-issue の親として扱い、原則として実装 PR では閉じない
+- 実装 PR は Epic の sub-issue を `Closes #<issue番号>` で閉じる
 
 ### PR タイトル
 

--- a/docs/rules/project.md
+++ b/docs/rules/project.md
@@ -1,0 +1,172 @@
+# GitHub Project / Issue 運用ルール
+
+GitHub Issue と GitHub Projects で、Epic、sub-issue、Project custom field を使って機能単位の計画と進捗を管理する。
+
+## 基本方針
+
+- 機能単位の大きなまとまりは Epic Issue として作成する。
+- Epic に含まれる実装・テスト・ドキュメント作業は sub-issue として切り分ける。
+- 実際の親子関係は GitHub Issues の sub-issues を正とする。
+- GitHub Projects の custom field は一覧性、grouping、filtering、sprint 管理のために使う。
+- Epic 候補と実装順の正本は `docs/issue-breakdown.md` とする。
+
+## Epic Issue
+
+Epic Issue は、複数 Issue に分割される機能単位の親 Issue として扱う。
+
+### Epic の作成基準
+
+次のいずれかに当てはまる場合は Epic Issue を作る。
+
+- Backend / Frontend / QA など複数レイヤーにまたがる
+- 1 PR で完了させるには大きすぎる
+- 認証、記事、プロフィールなど、ユーザー価値としてまとまりがある
+- 実装順や依存関係を管理したい
+
+### Epic に含める内容
+
+- 目的
+- スコープ
+- 対象外
+- sub-issue 候補
+- 完了条件
+- 依存 Epic / 依存 Issue
+- 参照する `docs/` 文書
+
+### Epic タイトル
+
+```text
+epic: <機能名>
+```
+
+例:
+
+```text
+epic: Identity Context を実装する
+epic: Publishing Context を実装する
+```
+
+## Sub-Issue 分解
+
+Issue 作成時に、sub-issue へ分解できるかを必ず確認する。
+
+### 分解する基準
+
+次の境界で分ける。
+
+- Backend と Frontend
+- API endpoint / 画面 / QA
+- Context や feature
+- Red / Green / Refactor の実装単位
+- 認証・認可・バリデーションなどレビュー観点が異なる単位
+
+### 分解しない基準
+
+次の場合は単一 Issue のままでよい。
+
+- docs の小さな修正
+- 1 PR で完了し、レビュー観点も単純
+- 分割すると依存関係だけが増えて進捗管理が悪くなる
+
+### Sub-Issue タイトル
+
+```text
+<type>: <対象>を<作業内容>
+```
+
+例:
+
+```text
+feat: 登録・ログインAPIを実装する
+feat: Auth Providerと認証フォームを実装する
+test: Identity ContextのAPI契約テストを補強する
+```
+
+## GitHub Projects Fields
+
+Project には次の field を用意する。
+
+| Field | Type | 用途 |
+| --- | --- | --- |
+| `Epic` | Single select | 機能単位の分類。Board や Table で group by する |
+| `Parent issue` | Built-in | GitHub sub-issue の親 Issue を表示する |
+| `Sub-issue progress` | Built-in | Epic / 親 Issue の進捗を表示する |
+| `Sprint` | Iteration | 期間単位の計画に使う |
+| `Priority` | Single select | `P0`, `P1`, `P2`, `No Priority` など |
+| `Size` | Single select | `XS`, `S`, `M`, `L`, `XL` など |
+| `Story Point` | Number | 見積もりが必要な場合のみ使う |
+| `Start date` | Date | 着手予定日 |
+| `End date` | Date | 完了予定日 |
+
+### Epic field の候補
+
+`Epic` field の候補は `docs/issue-breakdown.md` の Epic Candidates に合わせる。
+
+- Backend Foundation
+- Frontend Foundation
+- Identity Context
+- Publishing Context
+- Social Context
+- API Integration
+- E2E / Quality
+
+必要になった場合のみ追加し、追加時は `docs/issue-breakdown.md` も更新する。
+
+## Recommended Project Views
+
+### Epic Board
+
+- Layout: Board
+- Columns: `Status`
+- Group by: `Epic`
+- Purpose: 機能単位ごとの進捗把握
+
+### Hierarchy Table
+
+- Layout: Table
+- Visible fields: `Parent issue`, `Sub-issue progress`, `Epic`, `Priority`, `Sprint`, `Status`
+- Group by: `Parent issue`
+- Purpose: 親子関係の確認
+
+### Current Sprint
+
+- Layout: Board or Table
+- Filter: current `Sprint`
+- Group by: `Priority` or `Epic`
+- Purpose: 現在のスプリント内の優先度と進捗確認
+
+### Backlog by Epic
+
+- Layout: Table
+- Filter: `Status` is not `Done`
+- Group by: `Epic`
+- Purpose: Epic ごとの未完了作業確認
+
+## Issue 一覧で親子関係が見えにくい場合
+
+GitHub の通常 Issue 一覧では、Project field や sub-issue 階層が十分に見えないことがある。
+そのため、次の運用で補う。
+
+- Epic Issue には `type: epic` label を付ける。
+- Epic Issue の本文に sub-issue 一覧を残す。
+- 子 Issue の本文に `Parent: #<epic番号>` を書く。
+- 子 Issue は GitHub の sub-issue として Epic Issue に紐付ける。
+- Project の `Hierarchy Table` view を親子確認の正本にする。
+- Issue 検索では `label:"type: epic"` や `parent-issue:<owner>/<repo>#<issue番号>` を使う。
+
+## Issue 作成時のチェックリスト
+
+- [ ] Epic Issue にすべきか確認した
+- [ ] sub-issue に分割できるか確認した
+- [ ] `Epic` field を設定した
+- [ ] 必要なら `Parent issue` を設定した
+- [ ] `Priority` と `Status` を設定した
+- [ ] labels は `docs/labels.md` に従った
+- [ ] 参照すべき `docs/` 文書を本文に書いた
+- [ ] セキュリティ、認可、バリデーション、テスト観点を受け入れ条件に含めた
+
+## 注意点
+
+- Project custom field は Project 内のメタデータであり、Issue 本体の親子関係の代替にはしない。
+- Epic field と label は一覧性の補助として使い、親子関係は sub-issues で管理する。
+- 1 Issue = 1 PR の原則は維持する。Epic Issue 自体は原則として実装 PR では閉じず、sub-issue 完了で閉じる。


### PR DESCRIPTION
## 概要

- GitHub Projects / Epic / sub-issue 運用ルールを `docs/rules/project.md` として追加
- Issue作成時にEpic化・sub-issue分解を検討する `issue-planning` skill を追加
- Epic用Issue templateと、既存Issue templateのProject / Epic欄を追加
- `type: epic` label運用と、PR時のEpic/sub-issue方針を追記

## 関連 Issue

なし（運用ルール整備）

## テスト計画

- [x] Issue template YAML parse
- [x] `rg 'issue-planning|project.md|type: epic|Epic field|Parent issue|Sub-issue progress|Sub-Issue|sub-issue' ...`
- [x] `git diff --check`
- [ ] フロントエンド: 対象外（docs / template / skillのみ）
- [ ] バックエンド: 対象外（docs / template / skillのみ）