### PR TITLE
docs: Git Flowのマージ方針を明確化

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -1,0 +1,88 @@
+name: Backmerge
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: backmerge-main-to-develop
+  cancel-in-progress: false
+
+jobs:
+  create-pr:
+    name: Create main to develop PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create backmerge PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BACKMERGE_BRANCH: backmerge/main-to-develop
+        run: |
+          set -euo pipefail
+
+          git fetch --prune origin \
+            +refs/heads/main:refs/remotes/origin/main \
+            +refs/heads/develop:refs/remotes/origin/develop
+
+          if git merge-base --is-ancestor origin/main origin/develop; then
+            echo "origin/develop already contains origin/main."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git switch --force-create "$BACKMERGE_BRANCH" origin/develop
+
+          if ! git merge --no-ff --no-edit origin/main; then
+            echo "main -> develop backmerge has conflicts. Resolve it manually." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          git push --force-with-lease origin "HEAD:refs/heads/$BACKMERGE_BRANCH"
+
+          cat > /tmp/backmerge-body.md <<'MARKDOWN'
+          ## 概要
+
+          - `main` に入った release / hotfix / release-please の変更を `develop` に戻します
+          - このPRは `main` への push 後に自動作成されます
+
+          ## マージ方針
+
+          - merge commit でマージする
+          - squash merge は使わない
+          MARKDOWN
+
+          pr_number="$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --head "$BACKMERGE_BRANCH" \
+            --base develop \
+            --state open \
+            --json number \
+            --jq '.[0].number')"
+
+          if [ -n "$pr_number" ]; then
+            gh pr edit "$pr_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "chore: main の変更を develop に backmerge" \
+              --body "$(cat /tmp/backmerge-body.md)"
+            echo "Updated backmerge PR #$pr_number." >> "$GITHUB_STEP_SUMMARY"
+          else
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base develop \
+              --head "$BACKMERGE_BRANCH" \
+              --title "chore: main の変更を develop に backmerge" \
+              --body-file /tmp/backmerge-body.md
+            echo "Created backmerge PR." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,5 +17,6 @@ jobs:
       - uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/docs/rules/git-flow.md
+++ b/docs/rules/git-flow.md
@@ -101,6 +101,15 @@ Issue / Project / Epic の運用は [`project.md`](project.md) を正本とす�
 | `hotfix/*` → `main` | rebase merge | 緊急修正を `main` に直列に反映する |
 | `main` → `develop` | merge commit | release / hotfix / release-please の変更を backmerge として明示する |
 
+### Backmerge 自動化
+
+`main` への push 後、`.github/workflows/backmerge.yml` が `main` と `develop` の履歴差分を確認する。
+`main` が `develop` に含まれていない場合は、`backmerge/main-to-develop` ブランチを作成し、`main` から `develop` への backmerge PR を自動作成する。
+
+- workflow は PR 作成までを担当し、自動 merge はしない
+- backmerge PR は **merge commit** でマージし、squash merge は使わない
+- conflict が発生した場合、workflow は失敗させ、手動で解消する
+
 ### PR タイトル
 
 - 70文字以内、日本語で書く

--- a/docs/rules/git-flow.md
+++ b/docs/rules/git-flow.md
@@ -83,10 +83,23 @@ Issue / Project / Epic の運用は [`project.md`](project.md) を正本とす�
 ### 基本ルール
 
 - **1 Issue = 1 PR** を厳守
-- **squash merge** で develop/main にマージ
+- `feature/*` / `fix/*` から `develop` へは **squash merge** する
+- `develop` から `release/<version>` へは merge せず、`develop` の最新から **branch cut** する
+- `release/<version>` から `main` へは **rebase merge** する（squash merge 禁止）
+- `main` へ取り込んだ後、必要に応じて `main` から `develop` へ **backmerge** する
 - `Closes #<issue番号>` で Issue と紐付け
 - Epic Issue は複数 sub-issue の親として扱い、原則として実装 PR では閉じない
 - 実装 PR は Epic の sub-issue を `Closes #<issue番号>` で閉じる
+
+### マージ方式
+
+| 方向 | 方式 | 理由 |
+| ---- | ---- | ---- |
+| `feature/*` / `fix/*` → `develop` | squash merge | 1 Issue の作業履歴を 1 commit にまとめ、`develop` の履歴を読みやすく保つ |
+| `develop` → `release/<version>` | branch cut | リリース候補を固定するだけなので merge commit を作らない |
+| `release/<version>` → `main` | rebase merge | release branch の commit を `main` に直列に反映し、squash による履歴分岐を避ける |
+| `hotfix/*` → `main` | rebase merge | 緊急修正を `main` に直列に反映する |
+| `main` → `develop` | merge commit | release / hotfix / release-please の変更を backmerge として明示する |
 
 ### PR タイトル
 
@@ -139,16 +152,23 @@ Conventional Commits のタイプから自動的にバージョンを算出す�
 ### リリースフロー
 
 ```
-develop で開発 → release/vX.Y.Z ブランチ → main へ squash merge
-                                                       ↓
-                                          release-please が Release PR を自動作成
-                                                       ↓
-                                          Release PR をマージ → GitHub Release + git タグ自動作成
+develop で開発 → release/vX.Y.Z を branch cut → main へ rebase merge
+                                                              ↓
+                                                 release-please が Release PR を自動作成
+                                                              ↓
+                                                 Release PR をマージ → GitHub Release + git タグ自動作成
+                                                              ↓
+                                                 main から develop へ backmerge
 ```
 
-1. `main` へのプッシュ（squash merge）で `release.yml` が起動
-2. release-please が `CHANGELOG.md` を更新し、バージョンバンプを含む **Release PR** を作成
-3. Release PR をマージすると GitHub Release とタグ（例: `v1.2.3`）が自動作成される
+1. `develop` のリリース候補 commit から `release/vX.Y.Z` ブランチを作成する
+2. `release/vX.Y.Z` から `main` へ PR を作成し、**rebase merge** で取り込む
+3. `main` へのプッシュで `release.yml` が起動
+4. release-please が `CHANGELOG.md` を更新し、バージョンバンプを含む **Release PR** を作成
+5. Release PR をマージすると GitHub Release とタグ（例: `v1.2.3`）が自動作成される
+6. release-please の `CHANGELOG.md` / `.release-please-manifest.json` 変更を `main` から `develop` へ backmerge する
+
+`release/vX.Y.Z` 上でリリース調整の commit を追加した場合も、`main` へ取り込んだ後に `main` から `develop` へ backmerge する。
 
 ### 初期バージョン
 


### PR DESCRIPTION
## 概要

- Git Flow のマージ方式をブランチ種別ごとに明文化
- `feature/*` / `fix/* -> develop` は squash merge として維持
- `develop -> release/<version>` は merge ではなく branch cut と明記
- `release/<version> -> main` は rebase merge とし、squash merge 禁止を明記
- `main -> develop` は release / hotfix / release-please の backmerge として merge commit を使う方針に整理
- release-please action に `target-branch: main` を追加し、default branch が `develop` でも Release PR の対象を `main` に固定
- `main` への push 後に `main -> develop` の backmerge PR を自動作成する workflow を追加

## 背景

`release/v0.1.0 -> main` を squash merge したことで、内容差分はないものの `main` と `develop` の履歴が分岐しました。今後同じ状態を避けるため、release / hotfix / backmerge の扱いを明確化します。

また、release-please が `release-please--branches--develop` を作成していたため、`release.yml` 側で対象ブランチを明示します。

`main -> develop` の backmerge は漏れやすいため、CI は PR 作成までを自動化します。自動 merge はせず、PR は merge commit で取り込む前提です。

## 関連 Issue

なし

## テスト計画

- [x] ドキュメント: `git diff --check --cached`
- [x] CI設定: `git diff --check -- .github/workflows/release.yml`
- [x] Backmerge workflow: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/backmerge.yml")'`
- [x] Backmerge workflow: `git diff --check -- .github/workflows/backmerge.yml docs/rules/git-flow.md`
- [ ] CI: GitHub Actions の成功を確認