### PR TITLE
docs: RealWorld MVP のDBスキーマ初版をDBMLで作成する

### DIFF
--- a/docs/db/dbschema.dbml
+++ b/docs/db/dbschema.dbml
@@ -1,0 +1,163 @@
+Project real_world {
+  database_type: 'MySQL'
+  Note: '''
+  RealWorld MVP の ER 図 / DB スキーマ初版。
+
+  - 対象: Identity / Publishing / Social Context の MVP テーブル
+  - 認証トークン: Laravel Sanctum の framework managed table で管理するため、この DBML では domain table に限定する
+  - 削除方針: 原則 Soft Deletes。関連の解除は deleted_at を使い、再登録時は既存 row の復元を優先する
+  - 命名: docs/rules/db.md の snake_case / 複数形 table / role 付き foreign key 方針に従う
+  '''
+}
+
+Table users {
+  id bigint [pk, increment]
+  username varchar(50) [not null]
+  email varchar(255) [not null]
+  password_hash varchar(255) [not null, note: '平文 password は保存しない']
+  bio text [note: 'Profile に表示する公開自己紹介。nullable']
+  image varchar(2048) [note: 'Profile に表示する画像 URL。nullable']
+  created_at timestamp [not null]
+  updated_at timestamp [not null]
+  deleted_at timestamp
+
+  indexes {
+    username [unique, name: 'users_username_unique']
+    email [unique, name: 'users_email_unique']
+  }
+
+  Note: '''
+  Identity Context の User。
+  Profile response では email / password_hash / internal id を公開しない。
+  '''
+}
+
+Table articles {
+  id bigint [pk, increment]
+  author_user_id bigint [not null, note: 'Article Author の User ID']
+  slug varchar(255) [not null]
+  title varchar(255) [not null]
+  description varchar(255) [not null]
+  body text [not null]
+  created_at timestamp [not null]
+  updated_at timestamp [not null]
+  deleted_at timestamp
+
+  indexes {
+    slug [unique, name: 'articles_slug_unique']
+    (author_user_id, created_at) [name: 'articles_author_user_id_created_at_index']
+    created_at [name: 'articles_created_at_index']
+  }
+
+  Note: '''
+  Publishing Context の Article。
+  title 変更時は slug を再生成し、一意性を維持する。
+  Article 一覧は created_at 降順、author filter、tag filter、favorited filter を想定する。
+  '''
+}
+
+Table comments {
+  id bigint [pk, increment]
+  article_id bigint [not null]
+  author_user_id bigint [not null, note: 'Comment Author の User ID']
+  body text [not null]
+  created_at timestamp [not null]
+  updated_at timestamp [not null]
+  deleted_at timestamp
+
+  indexes {
+    (article_id, created_at) [name: 'comments_article_id_created_at_index']
+    author_user_id [name: 'comments_author_user_id_index']
+  }
+
+  Note: '''
+  Publishing Context の Comment。
+  Comment author のみ削除できる。
+  '''
+}
+
+Table tags {
+  id bigint [pk, increment]
+  name varchar(50) [not null]
+  created_at timestamp [not null]
+  updated_at timestamp [not null]
+  deleted_at timestamp
+
+  indexes {
+    name [unique, name: 'tags_name_unique']
+  }
+
+  Note: '''
+  Publishing Context の Tag。
+  Category 的な階層、色、説明文は MVP 対象外。
+  '''
+}
+
+Table article_tag {
+  id bigint [pk, increment]
+  article_id bigint [not null]
+  tag_id bigint [not null]
+  created_at timestamp [not null]
+  updated_at timestamp [not null]
+  deleted_at timestamp
+
+  indexes {
+    (article_id, tag_id) [unique, name: 'article_tag_article_id_tag_id_unique']
+    tag_id [name: 'article_tag_tag_id_index']
+  }
+
+  Note: '''
+  Article と Tag の中間テーブル。
+  中間テーブル名は単数形をアルファベット順で結合する。
+  '''
+}
+
+Table follows {
+  id bigint [pk, increment]
+  follower_user_id bigint [not null, note: 'Follow する User ID']
+  followee_user_id bigint [not null, note: 'Follow される User ID']
+  created_at timestamp [not null]
+  updated_at timestamp [not null]
+  deleted_at timestamp
+
+  indexes {
+    (follower_user_id, followee_user_id) [unique, name: 'follows_follower_followee_unique']
+    followee_user_id [name: 'follows_followee_user_id_index']
+  }
+
+  Note: '''
+  Social Context の Follow 関係。
+  self-follow は DB 制約ではなく Domain rule / FormRequest / Policy 側で拒否する。
+  Feed 取得では follower_user_id から followee_user_id を取得し、Article author_user_id と突き合わせる。
+  '''
+}
+
+Table favorites {
+  id bigint [pk, increment]
+  user_id bigint [not null]
+  article_id bigint [not null]
+  created_at timestamp [not null]
+  updated_at timestamp [not null]
+  deleted_at timestamp
+
+  indexes {
+    (user_id, article_id) [unique, name: 'favorites_user_id_article_id_unique']
+    article_id [name: 'favorites_article_id_index']
+  }
+
+  Note: '''
+  Social Context の Favorite 関係。
+  duplicate favorite / missing favorite removal は冪等に扱う。
+  favoritesCount は article_id 単位の count、favorited は current user 視点で算出する。
+  '''
+}
+
+Ref: articles.author_user_id > users.id [delete: restrict, update: cascade]
+Ref: comments.article_id > articles.id [delete: restrict, update: cascade]
+Ref: comments.author_user_id > users.id [delete: restrict, update: cascade]
+Ref: article_tag.article_id > articles.id [delete: restrict, update: cascade]
+Ref: article_tag.tag_id > tags.id [delete: restrict, update: cascade]
+Ref: follows.follower_user_id > users.id [delete: restrict, update: cascade]
+Ref: follows.followee_user_id > users.id [delete: restrict, update: cascade]
+Ref: favorites.user_id > users.id [delete: restrict, update: cascade]
+Ref: favorites.article_id > articles.id [delete: restrict, update: cascade]

--- a/docs/db/dbschema.dbml
+++ b/docs/db/dbschema.dbml
@@ -5,7 +5,7 @@ Project real_world {
 
   - 対象: Identity / Publishing / Social Context の MVP テーブル
   - 認証トークン: Laravel Sanctum の framework managed table で管理するため、この DBML では domain table に限定する
-  - 削除方針: 原則 Soft Deletes。関連の解除は deleted_at を使い、再登録時は既存 row の復元を優先する
+  - 削除方針: users は Soft Deletes。MVP の Article / Comment / Tag / relation tables は履歴要件がないため現在状態を物理削除で扱う
   - 命名: docs/rules/db.md の snake_case / 複数形 table / role 付き foreign key 方針に従う
   '''
 }
@@ -24,10 +24,12 @@ Table users {
   indexes {
     username [unique, name: 'users_username_unique']
     email [unique, name: 'users_email_unique']
+    deleted_at [name: 'users_deleted_at_index']
   }
 
   Note: '''
   Identity Context の User。
+  password_hash を認証カラムとして使うため、Laravel User Model は authPasswordName / casts / hidden を password_hash に合わせる。
   Profile response では email / password_hash / internal id を公開しない。
   '''
 }
@@ -41,7 +43,6 @@ Table articles {
   body text [not null]
   created_at timestamp [not null]
   updated_at timestamp [not null]
-  deleted_at timestamp
 
   indexes {
     slug [unique, name: 'articles_slug_unique']
@@ -53,6 +54,7 @@ Table articles {
   Publishing Context の Article。
   title 変更時は slug を再生成し、一意性を維持する。
   Article 一覧は created_at 降順、author filter、tag filter、favorited filter を想定する。
+  MVP では削除後の履歴保持を要件化しないため物理削除する。
   '''
 }
 
@@ -63,7 +65,6 @@ Table comments {
   body text [not null]
   created_at timestamp [not null]
   updated_at timestamp [not null]
-  deleted_at timestamp
 
   indexes {
     (article_id, created_at) [name: 'comments_article_id_created_at_index']
@@ -73,6 +74,7 @@ Table comments {
   Note: '''
   Publishing Context の Comment。
   Comment author のみ削除できる。
+  MVP では削除後の履歴保持を要件化しないため物理削除する。
   '''
 }
 
@@ -81,7 +83,6 @@ Table tags {
   name varchar(50) [not null]
   created_at timestamp [not null]
   updated_at timestamp [not null]
-  deleted_at timestamp
 
   indexes {
     name [unique, name: 'tags_name_unique']
@@ -90,6 +91,7 @@ Table tags {
   Note: '''
   Publishing Context の Tag。
   Category 的な階層、色、説明文は MVP 対象外。
+  未使用 Tag の整理が必要になった場合は物理削除する。
   '''
 }
 
@@ -99,7 +101,6 @@ Table article_tag {
   tag_id bigint [not null]
   created_at timestamp [not null]
   updated_at timestamp [not null]
-  deleted_at timestamp
 
   indexes {
     (article_id, tag_id) [unique, name: 'article_tag_article_id_tag_id_unique']
@@ -109,6 +110,7 @@ Table article_tag {
   Note: '''
   Article と Tag の中間テーブル。
   中間テーブル名は単数形をアルファベット順で結合する。
+  現在の紐付けだけを表す relation table のため、解除時は物理削除し復元しない。
   '''
 }
 
@@ -118,7 +120,6 @@ Table follows {
   followee_user_id bigint [not null, note: 'Follow される User ID']
   created_at timestamp [not null]
   updated_at timestamp [not null]
-  deleted_at timestamp
 
   indexes {
     (follower_user_id, followee_user_id) [unique, name: 'follows_follower_followee_unique']
@@ -129,6 +130,7 @@ Table follows {
   Social Context の Follow 関係。
   self-follow は DB 制約ではなく Domain rule / FormRequest / Policy 側で拒否する。
   Feed 取得では follower_user_id から followee_user_id を取得し、Article author_user_id と突き合わせる。
+  現在の Follow 状態だけを表す relation table のため、Unfollow 時は物理削除し復元しない。
   '''
 }
 
@@ -138,7 +140,6 @@ Table favorites {
   article_id bigint [not null]
   created_at timestamp [not null]
   updated_at timestamp [not null]
-  deleted_at timestamp
 
   indexes {
     (user_id, article_id) [unique, name: 'favorites_user_id_article_id_unique']
@@ -149,15 +150,16 @@ Table favorites {
   Social Context の Favorite 関係。
   duplicate favorite / missing favorite removal は冪等に扱う。
   favoritesCount は article_id 単位の count、favorited は current user 視点で算出する。
+  現在の Favorite 状態だけを表す relation table のため、Unfavorite 時は物理削除し復元しない。
   '''
 }
 
 Ref: articles.author_user_id > users.id [delete: restrict, update: cascade]
-Ref: comments.article_id > articles.id [delete: restrict, update: cascade]
+Ref: comments.article_id > articles.id [delete: cascade, update: cascade]
 Ref: comments.author_user_id > users.id [delete: restrict, update: cascade]
-Ref: article_tag.article_id > articles.id [delete: restrict, update: cascade]
-Ref: article_tag.tag_id > tags.id [delete: restrict, update: cascade]
+Ref: article_tag.article_id > articles.id [delete: cascade, update: cascade]
+Ref: article_tag.tag_id > tags.id [delete: cascade, update: cascade]
 Ref: follows.follower_user_id > users.id [delete: restrict, update: cascade]
 Ref: follows.followee_user_id > users.id [delete: restrict, update: cascade]
 Ref: favorites.user_id > users.id [delete: restrict, update: cascade]
-Ref: favorites.article_id > articles.id [delete: restrict, update: cascade]
+Ref: favorites.article_id > articles.id [delete: cascade, update: cascade]


### PR DESCRIPTION
## 概要

- RealWorld MVP の ER 図 / DB スキーマ初版として `docs/db/dbschema.dbml` を作成
- Identity / Publishing / Social Context の主要テーブルを DBML で整理
- `users`, `articles`, `comments`, `tags`, `article_tag`, `follows`, `favorites` を定義
- 一意制約、外部キー、index、削除方針を記載
- Backend 実装 Issue で migration を作成する際の参照元を用意

## 背景

Backend Foundation の一部として、MVP 実装前にデータ構造の初版を固めるための対応です。

RealWorld MVP では、認証、プロフィール、記事、コメント、フォロー、お気に入り、タグを扱います。
これらは後続の Backend 実装 Issue で migration / Model / Repository / Query を作成する前提になるため、先に `docs/db/dbschema.dbml` に ER 図として整理します。

## 変更内容

### Identity Context

- `users` を追加
- `username` / `email` の一意制約を定義
- `password_hash` を定義し、平文 password を保存しない方針を明記
- `bio` / `image` を Profile 表示用の公開情報として保持
- `users.deleted_at` と `users_deleted_at_index` を定義

### Publishing Context

- `articles` を追加
- `comments` を追加
- `tags` を追加
- `article_tag` を追加
- Article author / Comment author の所有者判定に必要な外部キーを定義
- Article 一覧、author filter、tag filter、pagination を意識した index を定義
- Article / Comment / Tag / relation table は MVP では履歴要件がないため物理削除方針に整理

### Social Context

- `follows` を追加
- `favorites` を追加
- Follow / Favorite の重複防止のための一意制約を定義
- Feed 取得、following 判定、favorited 判定、favoritesCount 算出に必要な関係を定義
- Follow / Favorite は現在状態を表す relation table として、解除時は物理削除する方針を明記

## 設計方針

- DBML は domain table を中心に定義する
- Laravel Sanctum の token 管理テーブルは framework managed table として扱い、この DBML では domain table から分離する
- `password_hash` は練習目的で採用し、Laravel User Model 側で `authPasswordName` / casts / hidden を合わせる
- `users` は `deleted_at` による soft delete を前提にする
- Article / Comment / Tag / relation tables は MVP では履歴要件がないため、現在状態を物理削除で扱う
- self-follow の禁止など、DB制約だけで表現しづらい業務ルールは Domain rule / FormRequest / Policy 側で扱う
- Context 間では Domain Entity を直接共有せず、User ID / Article ID / slug / username などの識別子で連携する

## 受け入れ条件

- [x] `docs/db/dbschema.dbml` が空ではなく、MVP の主要 table と relation を表現している
- [x] email、username、slug、tag name、follow 関係、favorite 関係の一意性制約が検討されている
- [x] Article / Comment / Follow / Favorite の認可・所有者判定に必要な foreign key が表現されている
- [x] `docs/rules/db.md` の命名、timestamps、index 方針に沿っている
- [x] `users` の soft delete と、それ以外の MVP table の物理削除方針が明記されている
- [x] `docs/api-requirements.md` の response / query requirements と矛盾しない
- [x] パスワードは hash 保持前提で、token や secret を DBML に直書きしていない

## テスト計画

- [x] `git diff --check`
- [x] DBML の内容を目視確認
- [x] `docs/requirements.md` の MVP 対象機能を DB 上で表現できるか確認
- [x] `docs/api-requirements.md` の filter / pagination / Feed / Favorite count / following / favorited 判定に必要な index を確認
- [x] `docs/context-map.md` の Context 境界と矛盾していないことを確認

## 関連 Issue

Closes #86

Parent: #55

## 参照 docs

- `docs/requirements.md`
- `docs/context-map.md`
- `docs/ubiquitous-language.md`
- `docs/api-requirements.md`
- `docs/issue-breakdown.md`
- `docs/rules/db.md`
- `docs/rules/backend.md`
- `docs/rules/security.md`
