### PR TITLE
docs: RealWorld仕様チェック用skillを追加 (#90)

### DIFF
--- a/.agents/skills/realworld-spec-check/SKILL.md
+++ b/.agents/skills/realworld-spec-check/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: realworld-spec-check
+description: >
+  実装済みまたは変更中の機能が RealWorld / Conduit 仕様に沿っているかを、
+  PR前またはレビュー時に部分的に確認するスキル。全機能の実装有無を網羅監査するのではなく、
+  差分や指定された機能に関係する Backend API、Frontend routes/UI contract、DB設計、テスト、
+  エラー形式、認証・認可を docs.realworld.show の公式仕様と突き合わせたいときに使用する。
+  「RealWorld仕様チェック」「Conduit spec」「PR前に仕様確認」「API spec準拠確認」
+  「公式仕様に沿ってるか見て」などがトリガー。
+---
+
+# RealWorld Spec Check
+
+RealWorld / Conduit の公式仕様と、このリポジトリのルールを突き合わせて、実装済みまたは変更中の機能に限って仕様逸脱を見つける。
+
+## Scope
+
+- 差分、Issue、PR、またはユーザーが指定した機能だけを対象にする。
+- RealWorld 全機能の未実装一覧は作らない。ユーザーが明示的に「全体の実装状況を棚卸しして」と依頼した場合だけ行う。
+- 対象外機能の不足は、変更中の契約を壊す場合を除き findings にしない。
+
+## Workflow
+
+1. 変更範囲を確認する。
+   - ユーザーが base commit / branch を指定した場合はそれを使う。
+   - 指定がなければ `develop` との merge-base を基準に `git diff` と `git diff --stat` を確認する。
+   - Issue / PR / branch 名から対象機能を推定し、レビュー対象外の機能を広げすぎない。
+2. 必要なローカルルールを読む。
+   - 常に `docs/ai/harness.md` と `docs/rules/security.md` を確認する。
+   - `frontend/` 変更時は `docs/rules/frontend.md`、`backend/` 変更時は `docs/rules/backend.md`、DB/マイグレーション/DBML変更時は `docs/rules/db.md` を確認する。
+3. `references/realworld-spec.md` を読む。
+   - API endpoint、request/response envelope、認証、エラー形式、Frontend route、E2E selector contract のうち、差分または指定機能に関係する項目だけを重点確認する。
+   - 仕様が変わっている可能性がある、またはユーザーが「最新」を求める場合は `https://docs.realworld.show/` とリンク先の OpenAPI / selector contract を確認する。
+4. 仕様との対応をレビューする。
+   - Backend 変更なら endpoint path/method、必須/任意フィールド、認証必須/任意、status code、JSON key、camelCase、権限、ページング、並び順を確認する。
+   - Frontend 変更なら route、token保存、API呼び出し、画面状態、フォーム名、必須CSS class/text、エラー表示、権限に応じた表示を確認する。
+   - DB変更なら内部実装として対象機能を支えられるかを確認し、外部APIへ内部IDや `password_hash` などを漏らしていないかを確認する。
+   - テスト変更なら対象機能の正常系だけでなく、認証、認可、validation、境界値、RealWorld固有の返却形式を検証しているかを見る。
+5. 必要なら `verify-qa` skill を併用する。
+   - 型チェック、Feature/Unit test、lint、静的解析、audit がPR前の根拠になる場合に実行する。
+   - 実行できないチェックがあれば、理由と残リスクを明記する。
+
+## Review Priorities
+
+重大度は、公式クライアントや公式テストとの互換性を壊すものを高く扱う。
+
+- High: endpoint path/method/auth/response envelope/status code が仕様と違う、所有者以外が更新/削除できる、tokenや秘密情報を漏らす。
+- Medium: pagination/default order/filter、`favorited` / `following` / `favoritesCount`、slug更新、article list body除外などの仕様差分。
+- Low: READMEや補助ドキュメントの不足、テスト名や軽微な整理。ただしPRを止めるほどでなければ所感に留める。
+
+## Output
+
+レビューとして依頼された場合は findings を先に出し、重大度順に並べる。
+
+```markdown
+## Findings
+
+- [High] path/to/file:123
+  問題:
+  仕様:
+  修正方向:
+  追加・修正すべきテスト:
+
+## Spec Coverage
+
+- 対象機能:
+- 確認したRealWorld仕様:
+- 対象外:
+- 未確認/未実行:
+
+## Summary
+
+- 重大な指摘がない場合は「重大な仕様逸脱はありません」と明記する。
+```
+
+PR本文やチェックリスト作成を依頼された場合は、対象機能の仕様準拠、テスト済み項目、残リスク、対象外の4分類で短くまとめる。

--- a/.agents/skills/realworld-spec-check/agents/openai.yaml
+++ b/.agents/skills/realworld-spec-check/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "RealWorld Spec Check"
+  short_description: "Check PRs against the RealWorld spec"
+  default_prompt: "Use $realworld-spec-check to review this PR against the RealWorld spec before opening it."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/realworld-spec-check/references/realworld-spec.md
+++ b/.agents/skills/realworld-spec-check/references/realworld-spec.md
@@ -1,0 +1,142 @@
+# RealWorld / Conduit Spec Reference
+
+Use this as a compact local checklist for the feature currently being changed or reviewed. Do not treat this file as a mandate to audit every missing RealWorld feature unless the user explicitly asks for a full implementation inventory. When exact wording or the latest contract matters, verify against the official docs:
+
+- Introduction: https://docs.realworld.show/introduction/
+- Features: https://docs.realworld.show/implementation-creation/features/
+- Expectations: https://docs.realworld.show/implementation-creation/expectations/
+- Frontend routing: https://docs.realworld.show/specifications/frontend/routing/
+- Frontend API/testing: https://docs.realworld.show/specifications/frontend/api/ and https://docs.realworld.show/specifications/frontend/tests/
+- Backend endpoints: https://docs.realworld.show/specifications/backend/endpoints/
+- Backend response format: https://docs.realworld.show/specifications/backend/api-response-format/
+- Backend errors/CORS/Hurl: https://docs.realworld.show/specifications/backend/error-handling/, https://docs.realworld.show/specifications/backend/cors/, https://docs.realworld.show/specifications/backend/hurl/
+- OpenAPI source: https://github.com/realworld-apps/realworld/blob/main/specs/api/openapi.yml
+- Frontend selector contract: https://github.com/realworld-apps/realworld/blob/main/specs/e2e/SELECTORS.md
+
+## Product Scope
+
+Overall RealWorld feature areas:
+
+- JWT authentication: login, signup, logout from settings.
+- User create/read/update; user deletion is not required.
+- Article CRUD.
+- Comment create/read/delete; comment update is not required.
+- Paginated article lists.
+- Favorite/unfavorite articles.
+- Follow/unfollow users.
+
+Implementation quality should be MVP-like: functionally complete and stable, but not unnecessarily over-engineered. At least one unit test is expected, while stronger coverage is preferred.
+
+## Backend Contract
+
+Authentication header:
+
+- Use `Authorization: Token <jwt>`.
+- Distinguish authentication-required endpoints from authentication-optional endpoints.
+- Return 401 when authentication is required and missing/invalid.
+- Return 403 when the user is authenticated but not allowed.
+- Return 404 when the target resource is not found.
+- Return 422 for validation failures with an `errors` object.
+
+Common response rules:
+
+- Return JSON with a correct JSON content type.
+- Use RealWorld envelopes: `user`, `profile`, `article`, `articles`, `comment`, `comments`, `tags`, and `articlesCount`.
+- API field names are camelCase where the spec uses them: `tagList`, `createdAt`, `updatedAt`, `favoritesCount`.
+- Do not expose internal-only fields such as numeric user IDs, password hashes, deleted timestamps, or framework token records.
+- User responses include `email`, `token`, `username`, `bio`, `image`.
+- Profile responses include `username`, `bio`, `image`, `following`.
+- Article responses include `slug`, `title`, `description`, `body` for single article responses, `tagList`, timestamps, `favorited`, `favoritesCount`, and embedded author profile.
+- Article list responses include `articles` and `articlesCount`; list endpoints should not include `body` in article items.
+- Comment responses include `id`, timestamps, `body`, and embedded author profile.
+
+Endpoint matrix:
+
+| Method | Path | Auth | Request | Response / behavior |
+|---|---|---:|---|---|
+| POST | `/api/users/login` | No | `user.email`, `user.password` | `user` |
+| POST | `/api/users` | No | `user.email`, `user.username`, `user.password` | `user` |
+| GET | `/api/user` | Yes | none | current `user` |
+| PUT | `/api/user` | Yes | optional `email`, `username`, `password`, `image`, `bio` | updated `user` |
+| GET | `/api/profiles/:username` | Optional | none | `profile` |
+| POST | `/api/profiles/:username/follow` | Yes | none | followed `profile` |
+| DELETE | `/api/profiles/:username/follow` | Yes | none | unfollowed `profile` |
+| GET | `/api/articles` | Optional | `tag`, `author`, `favorited`, `limit`, `offset` | recent `articles` |
+| GET | `/api/articles/feed` | Yes | `limit`, `offset` | followed authors' recent `articles` |
+| GET | `/api/articles/:slug` | No | none | `article` |
+| POST | `/api/articles` | Yes | required `title`, `description`, `body`; optional `tagList` | created `article` |
+| PUT | `/api/articles/:slug` | Yes | optional `title`, `description`, `body` | updated `article`; title changes update slug |
+| DELETE | `/api/articles/:slug` | Yes | none | delete article; author-only |
+| POST | `/api/articles/:slug/comments` | Yes | required `comment.body` | created `comment` |
+| GET | `/api/articles/:slug/comments` | Optional | none | `comments` |
+| DELETE | `/api/articles/:slug/comments/:id` | Yes | none | delete comment; author-only |
+| POST | `/api/articles/:slug/favorite` | Yes | none | favorited `article` |
+| DELETE | `/api/articles/:slug/favorite` | Yes | none | unfavorited `article` |
+| GET | `/api/tags` | No | none | `tags` |
+
+Behavior checks:
+
+- `GET /api/articles` defaults to most recent first, `limit=20`, `offset=0`.
+- `tag`, `author`, and `favorited` filters match the spec and can combine safely only where intended by implementation.
+- `GET /api/articles/feed` returns articles written by followed users and is ordered most recent first.
+- Article title update updates the slug and preserves uniqueness.
+- Favorite/unfavorite and follow/unfollow are safe under duplicate/repeated requests if the implementation chooses idempotent behavior.
+- `favorited` and `following` are computed from the current authenticated user when present; unauthenticated requests should return false.
+- `favoritesCount` is computed from current favorites.
+- Delete/update article requires article author. Delete comment requires comment author.
+- Validation errors use the envelope shape `{ "errors": { "<field>": ["message"] } }`.
+- If frontend and backend use different origins, CORS handles `OPTIONS`, `Access-Control-Allow-Origin`, and needed headers such as `Content-Type` and `Authorization`.
+
+## Frontend Contract
+
+Routes:
+
+- `/`: home page with tags, article list from feed/global/tag, and pagination.
+- `/login` and `/register`: auth pages using JWT; token is stored in localStorage unless the project deliberately documents a session/cookie variant.
+- `/settings`: update user settings and expose logout.
+- `/editor` and `/editor/:slug`: create/edit article.
+- `/article/:slug`: article page with markdown rendered client-side, comments, author-only delete article, comment author-only delete comment.
+- `/profile/:username` and `/profile/:username/favorites`: profile info, authored articles, favorited articles.
+
+Frontend API behavior:
+
+- Point requests at the configured RealWorld-compatible API base.
+- Preserve the RealWorld request body envelopes: `user`, `article`, `comment`.
+- Render server validation errors in the expected error list area.
+- Hide or disable author-only controls for non-owners; do not rely on UI-only enforcement.
+- Keep logged-in/logged-out navigation and feed tabs consistent with auth state.
+
+E2E selector contract:
+
+- The official Playwright suite depends on the selector contract, including form input `name` attributes, required CSS classes, required button/link text, routes, debug interface, localStorage token key, and default avatar behavior.
+- When changing UI markup, verify it still satisfies the selectors contract or document an intentional divergence.
+
+## Database / Internal Model Checks
+
+- Internal schema does not need to mirror API shapes exactly, but it must support the contract without leaking internals.
+- Numeric internal IDs are acceptable if API uses slugs/usernames/comment IDs as specified and internal user IDs are not exposed.
+- Required domain concepts: users, profiles/user public fields, articles with author and slug, comments with author and article, tags, article-tag relation, follows, favorites.
+- Enforce uniqueness needed by the API: username, email, article slug, tag name, article-tag pair, follower/followee pair, user/article favorite pair.
+- Model deletes according to project rules, but ensure API behavior for deleted resources is 404/forbidden as appropriate.
+
+## Test Expectations For Partial PR Checks
+
+Apply these expectations only to the changed or requested feature area. Do not require tests for unrelated RealWorld features in a partial review.
+
+Backend changes should usually include Feature tests covering:
+
+- Exact endpoint path/method and JSON envelope.
+- Required vs optional auth.
+- Validation failures with 422 error envelope.
+- Authorization failures for non-owner update/delete.
+- Pagination/filter/order behavior for list endpoints.
+- `favorited`, `following`, and `favoritesCount` from current-user perspective.
+
+Frontend changes should usually include tests covering:
+
+- User-visible flows and routes rather than implementation details.
+- Authenticated and unauthenticated states.
+- API request body/response mapping.
+- Validation/error rendering.
+- Owner-only controls.
+- Selector contract risk when changing markup, names, classes, or link/button text.


### PR DESCRIPTION
## 概要

- 実装済みまたは変更中の機能がRealWorld仕様に沿っているかを部分チェックするskillを追加
- 全機能の棚卸しではなく、差分・Issue・指定機能に関係する仕様準拠を確認する運用を明記
- 公式仕様の参照チェックリストとUIメタデータを追加

## 関連 Issue

Closes #90

## テスト計画

- [x] ドキュメント: skill validation（quick_validate.py）
- [x] ドキュメント: git diff --check
- [ ] フロントエンド: 対象外
- [ ] バックエンド: 対象外