### PR TITLE
docs: worktree作成先を明文化 (#102)

### DIFF
--- a/.agents/skills/tdd-issue/SKILL.md
+++ b/.agents/skills/tdd-issue/SKILL.md
@@ -36,10 +36,17 @@ GitHub Issueを起点に、要件整理・設計・タスク分解を経てTDD�
 
 ### worktreeモードの場合
 
-Step 4（ブランチ作成）の前にworktreeを作成する:
+Step 4（ブランチ作成）の前に、repo root 配下の `.worktree/<task-name>` に worktree を作成する。
+標準の作成先として repo 外の一時ディレクトリは使わない。
 
-```
-EnterWorktree でworktreeに入る
+`<task-name>` は `issue-<issue番号>-<issue-slug>` を基本形にする。
+
+repo root で実行:
+
+```bash
+mkdir -p .worktree
+git worktree add -b "feature/#<issue番号>-<issue-slug>" ".worktree/issue-<issue番号>-<issue-slug>" develop
+cd ".worktree/issue-<issue番号>-<issue-slug>"
 ```
 
 worktreeには `node_modules/` や `vendor/` が含まれないため、
@@ -53,10 +60,10 @@ cd frontend && pnpm install
 cd backend && composer install
 ```
 
-Step 10のPR作成後にworktreeをクリーンアップする:
+Step 10のPR作成と必要な引き継ぎが済んだら、repo root から worktree を削除する:
 
-```
-ExitWorktree でworktreeを退出・クリーンアップ
+```bash
+git worktree remove ".worktree/issue-<issue番号>-<issue-slug>"
 ```
 
 ## ワークフロー
@@ -95,9 +102,13 @@ Issueのタイトル・本文・ラベルを読み取り、実装スコープを
 
 #### Step 4: ブランチ作成
 
+localモードの場合:
+
 ```
 git checkout -b feature/#<issue番号>-<issue-slug>
 ```
+
+worktreeモードの場合は、上記の `git worktree add -b` でブランチ作成済みのため、この手順では作業ブランチ名だけを確認する。
 
 - `<issue-slug>`: Issueタイトルから英語kebab-caseで短く生成
 - 例: `feature/#42-add-user-auth`
@@ -195,7 +206,7 @@ EOF
 
 ### Step 11: クリーンアップ（worktreeモードの場合）
 
-worktreeモードで作業した場合は、ExitWorktreeでクリーンアップする。
+worktreeモードで作業した場合は、PR作成と必要な引き継ぎが済んだ後に `.worktree/<task-name>` の worktree をクリーンアップする。
 
 ## 注意事項
 

--- a/.agents/skills/worktree-issue/SKILL.md
+++ b/.agents/skills/worktree-issue/SKILL.md
@@ -40,20 +40,21 @@ Issueのタイトル・本文・ラベル・コメントを読み取り、実装
 
 ### Step 3: worktree作成・ブランチ切り替え
 
-EnterWorktreeツールを使用してworktreeを作成する。
+repo root 配下の `.worktree/<task-name>` に worktree を作成する。
+標準の作成先として repo 外の一時ディレクトリは使わない。
 
-```
-EnterWorktree でworktreeに入る
-```
+`<task-name>` は `issue-<issue番号>-<issue-slug>` を基本形にする。
 
-worktree内でブランチを作成:
+repo root で実行:
 
 ```bash
-git checkout -b feature/#<issue番号>-<issue-slug>
+mkdir -p .worktree
+git worktree add -b "feature/#<issue番号>-<issue-slug>" ".worktree/issue-<issue番号>-<issue-slug>" develop
+cd ".worktree/issue-<issue番号>-<issue-slug>"
 ```
 
 - `<issue-slug>`: Issueタイトルから英語kebab-caseで短く生成
-- 例: `feature/#42-update-docs`
+- 例: `.worktree/issue-42-update-docs` / `feature/#42-update-docs`
 - developブランチの最新から切ること
 
 ### Step 4: 依存関係インストール
@@ -141,10 +142,10 @@ EOF
 
 ### Step 9: worktreeクリーンアップ
 
-ExitWorktreeツールを使用してworktreeから退出する。
+PR作成と必要な引き継ぎが済んだら、repo root から worktree を削除する。
 
-```
-ExitWorktree でworktreeを退出・クリーンアップ
+```bash
+git worktree remove ".worktree/issue-<issue番号>-<issue-slug>"
 ```
 
 ## 注意事項

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,12 @@ React 19 + TypeScript / Laravel 13 のモノレポ。API、CRUD、新しい技�
 3. `docs/ai/harness.md` と必要な `docs/rules/*` を確認する。
 4. テストの妥当性、アーキテクチャ、セキュリティを重点的に確認する。
 
+## Worktree 運用
+
+- Issue 対応を worktree で行う場合、repo root 配下の `.worktree/<task-name>` に作成する。
+- `.worktree` は gitignored の非追跡作業領域として扱い、作業完了後にクリーンアップする。
+- 詳細な作成手順と命名は `docs/ai/harness.md` と該当 skill を正本とする。
+
 ## Skill の使い分け
 
 - `.agents/skills/code-review/` - コードレビュー、テスト妥当性、アーキテクチャ確認。

--- a/docs/ai/harness.md
+++ b/docs/ai/harness.md
@@ -27,6 +27,18 @@ ADR は廃止方向とし、判断は要件・ルール・ドメイン設計・�
 - https://openai.com/ja-JP/index/harness-engineering/
 - https://developers.openai.com/codex/skills
 
+## Worktree Policy
+
+AI agent が Issue 対応で worktree を使う場合、作業用 checkout は repo root 配下の `.worktree/<task-name>` に作成する。
+session をまたいでも作業場所を再発見できるように、標準の作成先として repo 外の一時ディレクトリは使わない。
+
+- `.worktree` は `.gitignore` 済みの非追跡作業領域として扱い、配下の内容は git 管理しない。
+- `<task-name>` は `issue-<issue-number>-<short-slug>` を基本形にする。
+- ブランチ名は `docs/rules/git-flow.md` に従い、例として `feature/#102-worktree-location` のようにする。
+- 手動で作成する場合は repo root で `git worktree add -b "feature/#<issue-number>-<slug>" ".worktree/issue-<issue-number>-<slug>" develop` を実行する。
+- worktree には `node_modules/` や `vendor/` が含まれないため、対象レイヤーに応じて worktree 内で依存関係を入れる。
+- 作業完了後、PR 作成と必要な引き継ぎが済んだ worktree はクリーンアップする。
+
 ## Skill Trigger Policy
 
 - Repository skill は `.agents/skills/<skill-name>/SKILL.md` に置く。


### PR DESCRIPTION
## 概要

- `AGENTS.md` に worktree 作業場所として `.worktree/<task-name>` を使う方針を追記
- `docs/ai/harness.md` に worktree 作成先、命名、依存関係、cleanup の運用を明文化
- `worktree-issue` / `tdd-issue` skill の手順を `.worktree/issue-<issue番号>-<issue-slug>` 前提に更新

## 関連 Issue

Related #102

## テスト計画

- [x] ドキュメント: `rg -n "/private/tmp" AGENTS.md docs .agents/skills`
- [x] ドキュメント: `rg -n "git worktree add" AGENTS.md docs .agents/skills`
- [x] ドキュメント: `git diff --check`
- [ ] フロントエンド: 対象外（ドキュメント / skill のみ）
- [ ] バックエンド: 対象外（ドキュメント / skill のみ）