### PR TITLE
feat: Identity登録・ログインAPIを実装 (#65)

### DIFF
--- a/backend/app/Application/Identity/Commands/LoginUserCommand.php
+++ b/backend/app/Application/Identity/Commands/LoginUserCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Identity\Commands;
+
+use App\Application\Identity\DTOs\AuthenticatedUserDto;
+use App\Application\Identity\DTOs\LoginUserDto;
+use App\Application\Identity\Services\AuthTokenIssuerInterface;
+use App\Application\Identity\Services\PasswordHasherInterface;
+use App\Domain\Identity\Repositories\UserRepositoryInterface;
+use App\Domain\Identity\ValueObjects\Email;
+use DomainException;
+
+final readonly class LoginUserCommand
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private PasswordHasherInterface $passwords,
+        private AuthTokenIssuerInterface $tokens,
+    ) {}
+
+    /**
+     * email と password を検証し、API token を発行する。
+     */
+    public function execute(LoginUserDto $dto): AuthenticatedUserDto
+    {
+        $user = $this->users->findByEmail(new Email($dto->email));
+
+        if ($user === null || ! $this->passwords->check($dto->password, $user->passwordHash()->value)) {
+            throw new DomainException('email or password is invalid');
+        }
+
+        return new AuthenticatedUserDto(
+            user: $user,
+            token: $this->tokens->issue($user),
+        );
+    }
+}

--- a/backend/app/Application/Identity/Commands/RegisterUserCommand.php
+++ b/backend/app/Application/Identity/Commands/RegisterUserCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Identity\Commands;
+
+use App\Application\Identity\DTOs\AuthenticatedUserDto;
+use App\Application\Identity\DTOs\RegisterUserDto;
+use App\Application\Identity\Services\AuthTokenIssuerInterface;
+use App\Application\Identity\Services\PasswordHasherInterface;
+use App\Domain\Identity\Entities\User;
+use App\Domain\Identity\Repositories\UserRepositoryInterface;
+use App\Domain\Identity\ValueObjects\Email;
+use App\Domain\Identity\ValueObjects\HashedPassword;
+use App\Domain\Identity\ValueObjects\Username;
+use DomainException;
+
+final readonly class RegisterUserCommand
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private PasswordHasherInterface $passwords,
+        private AuthTokenIssuerInterface $tokens,
+    ) {}
+
+    /**
+     * User を登録し、API token を発行する。
+     */
+    public function execute(RegisterUserDto $dto): AuthenticatedUserDto
+    {
+        $email = new Email($dto->email);
+        $username = new Username($dto->username);
+
+        if ($this->users->emailExists($email)) {
+            throw new DomainException('email has already been taken');
+        }
+
+        if ($this->users->usernameExists($username)) {
+            throw new DomainException('username has already been taken');
+        }
+
+        $user = User::register(
+            username: $username,
+            email: $email,
+            passwordHash: new HashedPassword($this->passwords->make($dto->password)),
+        );
+
+        $registeredUser = $this->users->save($user);
+
+        return new AuthenticatedUserDto(
+            user: $registeredUser,
+            token: $this->tokens->issue($registeredUser),
+        );
+    }
+}

--- a/backend/app/Application/Identity/Commands/RegisterUserCommand.php
+++ b/backend/app/Application/Identity/Commands/RegisterUserCommand.php
@@ -14,6 +14,7 @@ use App\Domain\Identity\ValueObjects\Email;
 use App\Domain\Identity\ValueObjects\HashedPassword;
 use App\Domain\Identity\ValueObjects\Username;
 use DomainException;
+use Illuminate\Support\Facades\DB;
 
 final readonly class RegisterUserCommand
 {
@@ -45,11 +46,13 @@ final readonly class RegisterUserCommand
             passwordHash: new HashedPassword($this->passwords->make($dto->password)),
         );
 
-        $registeredUser = $this->users->save($user);
+        return DB::transaction(function () use ($user): AuthenticatedUserDto {
+            $registeredUser = $this->users->save($user);
 
-        return new AuthenticatedUserDto(
-            user: $registeredUser,
-            token: $this->tokens->issue($registeredUser),
-        );
+            return new AuthenticatedUserDto(
+                user: $registeredUser,
+                token: $this->tokens->issue($registeredUser),
+            );
+        });
     }
 }

--- a/backend/app/Application/Identity/DTOs/AuthenticatedUserDto.php
+++ b/backend/app/Application/Identity/DTOs/AuthenticatedUserDto.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Identity\DTOs;
+
+use App\Domain\Identity\Entities\User;
+
+final readonly class AuthenticatedUserDto
+{
+    public function __construct(
+        public User $user,
+        public string $token,
+    ) {}
+}

--- a/backend/app/Application/Identity/DTOs/LoginUserDto.php
+++ b/backend/app/Application/Identity/DTOs/LoginUserDto.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Identity\DTOs;
+
+final readonly class LoginUserDto
+{
+    public function __construct(
+        public string $email,
+        public string $password,
+    ) {}
+}

--- a/backend/app/Application/Identity/DTOs/RegisterUserDto.php
+++ b/backend/app/Application/Identity/DTOs/RegisterUserDto.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Identity\DTOs;
+
+final readonly class RegisterUserDto
+{
+    public function __construct(
+        public string $username,
+        public string $email,
+        public string $password,
+    ) {}
+}

--- a/backend/app/Application/Identity/Services/AuthTokenIssuerInterface.php
+++ b/backend/app/Application/Identity/Services/AuthTokenIssuerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Identity\Services;
+
+use App\Domain\Identity\Entities\User;
+
+interface AuthTokenIssuerInterface
+{
+    /**
+     * User に対する API token を発行する。
+     */
+    public function issue(User $user): string;
+}

--- a/backend/app/Application/Identity/Services/PasswordHasherInterface.php
+++ b/backend/app/Application/Identity/Services/PasswordHasherInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Identity\Services;
+
+interface PasswordHasherInterface
+{
+    /**
+     * 平文 password を hash 化する。
+     */
+    public function make(string $plainPassword): string;
+
+    /**
+     * 平文 password が hash と一致するか確認する。
+     */
+    public function check(string $plainPassword, string $hashedPassword): bool;
+}

--- a/backend/app/Domain/Identity/Entities/User.php
+++ b/backend/app/Domain/Identity/Entities/User.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Identity\Entities;
+
+use App\Domain\Identity\ValueObjects\Bio;
+use App\Domain\Identity\ValueObjects\Email;
+use App\Domain\Identity\ValueObjects\HashedPassword;
+use App\Domain\Identity\ValueObjects\Image;
+use App\Domain\Identity\ValueObjects\UserId;
+use App\Domain\Identity\ValueObjects\Username;
+
+final readonly class User
+{
+    public function __construct(
+        private ?UserId $id,
+        private Username $username,
+        private Email $email,
+        private HashedPassword $passwordHash,
+        private Bio $bio,
+        private Image $image,
+    ) {}
+
+    /**
+     * 登録直後の User を生成する。
+     */
+    public static function register(Username $username, Email $email, HashedPassword $passwordHash): self
+    {
+        return new self(
+            id: null,
+            username: $username,
+            email: $email,
+            passwordHash: $passwordHash,
+            bio: new Bio(null),
+            image: new Image(null),
+        );
+    }
+
+    /**
+     * 永続化後の ID を持つ User として複製する。
+     */
+    public function withId(UserId $id): self
+    {
+        return new self(
+            id: $id,
+            username: $this->username,
+            email: $this->email,
+            passwordHash: $this->passwordHash,
+            bio: $this->bio,
+            image: $this->image,
+        );
+    }
+
+    public function id(): ?UserId
+    {
+        return $this->id;
+    }
+
+    public function username(): Username
+    {
+        return $this->username;
+    }
+
+    public function email(): Email
+    {
+        return $this->email;
+    }
+
+    public function passwordHash(): HashedPassword
+    {
+        return $this->passwordHash;
+    }
+
+    public function bio(): Bio
+    {
+        return $this->bio;
+    }
+
+    public function image(): Image
+    {
+        return $this->image;
+    }
+}

--- a/backend/app/Domain/Identity/Repositories/UserRepositoryInterface.php
+++ b/backend/app/Domain/Identity/Repositories/UserRepositoryInterface.php
@@ -4,4 +4,29 @@ declare(strict_types=1);
 
 namespace App\Domain\Identity\Repositories;
 
-interface UserRepositoryInterface {}
+use App\Domain\Identity\Entities\User;
+use App\Domain\Identity\ValueObjects\Email;
+use App\Domain\Identity\ValueObjects\Username;
+
+interface UserRepositoryInterface
+{
+    /**
+     * Email に一致する User を取得する。
+     */
+    public function findByEmail(Email $email): ?User;
+
+    /**
+     * Email が登録済みか確認する。
+     */
+    public function emailExists(Email $email): bool;
+
+    /**
+     * Username が登録済みか確認する。
+     */
+    public function usernameExists(Username $username): bool;
+
+    /**
+     * User を永続化し、採番済み ID を含む Entity を返す。
+     */
+    public function save(User $user): User;
+}

--- a/backend/app/Domain/Identity/ValueObjects/Bio.php
+++ b/backend/app/Domain/Identity/ValueObjects/Bio.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Identity\ValueObjects;
+
+use InvalidArgumentException;
+
+final readonly class Bio
+{
+    /**
+     * Profile に表示する nullable な自己紹介文を表す。
+     */
+    public function __construct(public ?string $value)
+    {
+        if ($value !== null && strlen($value) > 1000) {
+            throw new InvalidArgumentException('Bio is too long.');
+        }
+    }
+}

--- a/backend/app/Domain/Identity/ValueObjects/Email.php
+++ b/backend/app/Domain/Identity/ValueObjects/Email.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Identity\ValueObjects;
+
+use InvalidArgumentException;
+
+final readonly class Email
+{
+    public string $value;
+
+    /**
+     * ログイン識別子として使う email を表す。
+     */
+    public function __construct(string $value)
+    {
+        $normalized = strtolower(trim($value));
+
+        if ($normalized === '' || strlen($normalized) > 255 || filter_var($normalized, FILTER_VALIDATE_EMAIL) === false) {
+            throw new InvalidArgumentException('Email is invalid.');
+        }
+
+        $this->value = $normalized;
+    }
+}

--- a/backend/app/Domain/Identity/ValueObjects/HashedPassword.php
+++ b/backend/app/Domain/Identity/ValueObjects/HashedPassword.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Identity\ValueObjects;
+
+use InvalidArgumentException;
+
+final readonly class HashedPassword
+{
+    public string $value;
+
+    /**
+     * 永続化可能な hash 済み password を表す。
+     */
+    public function __construct(string $value)
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException('Password hash is required.');
+        }
+
+        $this->value = $value;
+    }
+}

--- a/backend/app/Domain/Identity/ValueObjects/Image.php
+++ b/backend/app/Domain/Identity/ValueObjects/Image.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Identity\ValueObjects;
+
+use InvalidArgumentException;
+
+final readonly class Image
+{
+    public ?string $value;
+
+    /**
+     * Profile に表示する nullable な image URL を表す。
+     */
+    public function __construct(?string $value)
+    {
+        if ($value === null) {
+            $this->value = null;
+
+            return;
+        }
+
+        $normalized = trim($value);
+
+        if ($normalized === '' || strlen($normalized) > 2048 || filter_var($normalized, FILTER_VALIDATE_URL) === false) {
+            throw new InvalidArgumentException('Image is invalid.');
+        }
+
+        $this->value = $normalized;
+    }
+}

--- a/backend/app/Domain/Identity/ValueObjects/UserId.php
+++ b/backend/app/Domain/Identity/ValueObjects/UserId.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Identity\ValueObjects;
+
+use InvalidArgumentException;
+
+final readonly class UserId
+{
+    /**
+     * 正の整数 ID として User を識別する。
+     */
+    public function __construct(public int $value)
+    {
+        if ($value < 1) {
+            throw new InvalidArgumentException('User id must be positive.');
+        }
+    }
+}

--- a/backend/app/Domain/Identity/ValueObjects/Username.php
+++ b/backend/app/Domain/Identity/ValueObjects/Username.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Identity\ValueObjects;
+
+use InvalidArgumentException;
+
+final readonly class Username
+{
+    public string $value;
+
+    /**
+     * User の公開識別子として使う username を表す。
+     */
+    public function __construct(string $value)
+    {
+        $normalized = trim($value);
+
+        if ($normalized === '' || strlen($normalized) > 50) {
+            throw new InvalidArgumentException('Username is invalid.');
+        }
+
+        $this->value = $normalized;
+    }
+}

--- a/backend/app/Infrastructure/Identity/HashPasswordHasher.php
+++ b/backend/app/Infrastructure/Identity/HashPasswordHasher.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Identity;
+
+use App\Application\Identity\Services\PasswordHasherInterface;
+use Illuminate\Support\Facades\Hash;
+
+final class HashPasswordHasher implements PasswordHasherInterface
+{
+    /**
+     * 平文 password を Laravel Hash で hash 化する。
+     */
+    public function make(string $plainPassword): string
+    {
+        return Hash::make($plainPassword);
+    }
+
+    /**
+     * 平文 password が Laravel Hash と一致するか確認する。
+     */
+    public function check(string $plainPassword, string $hashedPassword): bool
+    {
+        return Hash::check($plainPassword, $hashedPassword);
+    }
+}

--- a/backend/app/Infrastructure/Identity/SanctumAuthTokenIssuer.php
+++ b/backend/app/Infrastructure/Identity/SanctumAuthTokenIssuer.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Identity;
+
+use App\Application\Identity\Services\AuthTokenIssuerInterface;
+use App\Domain\Identity\Entities\User;
+use App\Infrastructure\Persistence\Models\User as UserModel;
+use RuntimeException;
+
+final class SanctumAuthTokenIssuer implements AuthTokenIssuerInterface
+{
+    /**
+     * Sanctum personal access token を発行する。
+     */
+    public function issue(User $user): string
+    {
+        $id = $user->id();
+
+        if ($id === null) {
+            throw new RuntimeException('Cannot issue token for unsaved user.');
+        }
+
+        $model = UserModel::query()->findOrFail($id->value);
+
+        return $model->createToken('api')->plainTextToken;
+    }
+}

--- a/backend/app/Infrastructure/Persistence/Models/User.php
+++ b/backend/app/Infrastructure/Persistence/Models/User.php
@@ -7,14 +7,23 @@ namespace App\Infrastructure\Persistence\Models;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 
+/**
+ * @property int $id
+ * @property string $username
+ * @property string $email
+ * @property string $password_hash
+ * @property string|null $bio
+ * @property string|null $image
+ */
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable, SoftDeletes;
 
     /**
      * The attributes that are mass assignable.
@@ -22,9 +31,11 @@ class User extends Authenticatable
      * @var list<string>
      */
     protected $fillable = [
-        'name',
+        'username',
         'email',
-        'password',
+        'password_hash',
+        'bio',
+        'image',
     ];
 
     /**
@@ -33,8 +44,7 @@ class User extends Authenticatable
      * @var list<string>
      */
     protected $hidden = [
-        'password',
-        'remember_token',
+        'password_hash',
     ];
 
     /**
@@ -45,11 +55,29 @@ class User extends Authenticatable
     protected function casts(): array
     {
         return [
-            'email_verified_at' => 'datetime',
-            'password' => 'hashed',
+            'deleted_at' => 'datetime',
         ];
     }
 
+    /**
+     * Laravel auth が参照する password hash カラム名を返す。
+     */
+    public function getAuthPasswordName(): string
+    {
+        return 'password_hash';
+    }
+
+    /**
+     * Laravel auth が参照する password hash を返す。
+     */
+    public function getAuthPassword(): string
+    {
+        return (string) $this->getAttribute($this->getAuthPasswordName());
+    }
+
+    /**
+     * Infrastructure 配置の User factory を返す。
+     */
     protected static function newFactory(): UserFactory
     {
         return UserFactory::new();

--- a/backend/app/Infrastructure/Persistence/Repositories/EloquentUserRepository.php
+++ b/backend/app/Infrastructure/Persistence/Repositories/EloquentUserRepository.php
@@ -4,6 +4,80 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Persistence\Repositories;
 
+use App\Domain\Identity\Entities\User;
 use App\Domain\Identity\Repositories\UserRepositoryInterface;
+use App\Domain\Identity\ValueObjects\Bio;
+use App\Domain\Identity\ValueObjects\Email;
+use App\Domain\Identity\ValueObjects\HashedPassword;
+use App\Domain\Identity\ValueObjects\Image;
+use App\Domain\Identity\ValueObjects\UserId;
+use App\Domain\Identity\ValueObjects\Username;
+use App\Infrastructure\Persistence\Models\User as UserModel;
 
-final class EloquentUserRepository implements UserRepositoryInterface {}
+final class EloquentUserRepository implements UserRepositoryInterface
+{
+    /**
+     * Email に一致する User を取得する。
+     */
+    public function findByEmail(Email $email): ?User
+    {
+        $model = UserModel::query()
+            ->where('email', $email->value)
+            ->first();
+
+        return $model instanceof UserModel ? $this->toEntity($model) : null;
+    }
+
+    /**
+     * Email が登録済みか確認する。
+     */
+    public function emailExists(Email $email): bool
+    {
+        return UserModel::query()
+            ->where('email', $email->value)
+            ->exists();
+    }
+
+    /**
+     * Username が登録済みか確認する。
+     */
+    public function usernameExists(Username $username): bool
+    {
+        return UserModel::query()
+            ->where('username', $username->value)
+            ->exists();
+    }
+
+    /**
+     * User を永続化し、採番済み ID を含む Entity を返す。
+     */
+    public function save(User $user): User
+    {
+        $model = new UserModel;
+        $model->fill([
+            'username' => $user->username()->value,
+            'email' => $user->email()->value,
+            'password_hash' => $user->passwordHash()->value,
+            'bio' => $user->bio()->value,
+            'image' => $user->image()->value,
+        ]);
+        $model->save();
+
+        return $this->toEntity($model);
+    }
+
+    /**
+     * 永続化モデルを Domain Entity へ変換する。
+     */
+    private function toEntity(UserModel $model): User
+    {
+        return new User(
+            id: new UserId((int) $model->getKey()),
+            username: new Username($model->username),
+            email: new Email($model->email),
+            passwordHash: new HashedPassword($model->password_hash),
+            bio: new Bio($model->bio),
+            image: new Image($model->image),
+        );
+    }
+}

--- a/backend/app/Infrastructure/Providers/RepositoryServiceProvider.php
+++ b/backend/app/Infrastructure/Providers/RepositoryServiceProvider.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Providers;
 
+use App\Application\Identity\Services\AuthTokenIssuerInterface;
+use App\Application\Identity\Services\PasswordHasherInterface;
 use App\Domain\Identity\Repositories\UserRepositoryInterface;
+use App\Infrastructure\Identity\HashPasswordHasher;
+use App\Infrastructure\Identity\SanctumAuthTokenIssuer;
 use App\Infrastructure\Persistence\Repositories\EloquentUserRepository;
 use Illuminate\Support\ServiceProvider;
 
@@ -13,5 +17,7 @@ final class RepositoryServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->bind(UserRepositoryInterface::class, EloquentUserRepository::class);
+        $this->app->bind(PasswordHasherInterface::class, HashPasswordHasher::class);
+        $this->app->bind(AuthTokenIssuerInterface::class, SanctumAuthTokenIssuer::class);
     }
 }

--- a/backend/app/Presentation/Http/Controllers/Identity/AuthController.php
+++ b/backend/app/Presentation/Http/Controllers/Identity/AuthController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Controllers\Identity;
+
+use App\Application\Identity\Commands\LoginUserCommand;
+use App\Application\Identity\Commands\RegisterUserCommand;
+use App\Presentation\Http\Controllers\Controller;
+use App\Presentation\Http\Requests\Identity\LoginUserRequest;
+use App\Presentation\Http\Requests\Identity\RegisterUserRequest;
+use App\Presentation\Http\Resources\Identity\UserResource;
+use Illuminate\Http\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+final class AuthController extends Controller
+{
+    /**
+     * User 登録 API のリクエストを Application 層へ委譲する。
+     */
+    public function register(RegisterUserRequest $request, RegisterUserCommand $command): JsonResponse
+    {
+        return (new UserResource($command->execute($request->toDto())))
+            ->response()
+            ->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    /**
+     * User ログイン API のリクエストを Application 層へ委譲する。
+     */
+    public function login(LoginUserRequest $request, LoginUserCommand $command): JsonResponse
+    {
+        return (new UserResource($command->execute($request->toDto())))
+            ->response()
+            ->setStatusCode(Response::HTTP_OK);
+    }
+}

--- a/backend/app/Presentation/Http/Middleware/NormalizeRealWorldAuthorizationHeader.php
+++ b/backend/app/Presentation/Http/Middleware/NormalizeRealWorldAuthorizationHeader.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class NormalizeRealWorldAuthorizationHeader
+{
+    /**
+     * RealWorld compatible `Token` auth scheme を Sanctum の bearer token として扱う。
+     *
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $authorization = $request->headers->get('Authorization');
+
+        if (is_string($authorization) && preg_match('/^Token\s+(.+)$/i', $authorization, $matches) === 1) {
+            $request->headers->set('Authorization', 'Bearer '.trim($matches[1]));
+        }
+
+        return $next($request);
+    }
+}

--- a/backend/app/Presentation/Http/Requests/Identity/LoginUserRequest.php
+++ b/backend/app/Presentation/Http/Requests/Identity/LoginUserRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Requests\Identity;
+
+use App\Application\Identity\DTOs\LoginUserDto;
+use Illuminate\Foundation\Http\FormRequest;
+
+final class LoginUserRequest extends FormRequest
+{
+    /**
+     * ゲストが実行できるログインリクエストとして許可する。
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * RealWorld login request の nested user payload を検証する。
+     *
+     * @return array<string, list<string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'user' => ['required', 'array'],
+            'user.email' => ['required', 'email'],
+            'user.password' => ['required', 'string'],
+        ];
+    }
+
+    /**
+     * 検証済み payload を Application DTO へ変換する。
+     */
+    public function toDto(): LoginUserDto
+    {
+        /** @var array{user: array{email: string, password: string}} $payload */
+        $payload = $this->validated();
+
+        return new LoginUserDto(
+            email: $payload['user']['email'],
+            password: $payload['user']['password'],
+        );
+    }
+}

--- a/backend/app/Presentation/Http/Requests/Identity/RegisterUserRequest.php
+++ b/backend/app/Presentation/Http/Requests/Identity/RegisterUserRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Requests\Identity;
+
+use App\Application\Identity\DTOs\RegisterUserDto;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class RegisterUserRequest extends FormRequest
+{
+    /**
+     * ゲストが実行できる登録リクエストとして許可する。
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * RealWorld register request の nested user payload を検証する。
+     *
+     * @return array<string, list<mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'user' => ['required', 'array'],
+            'user.username' => ['required', 'string', 'max:50', Rule::unique('users', 'username')],
+            'user.email' => ['required', 'email', 'max:255', Rule::unique('users', 'email')],
+            'user.password' => ['required', 'string', 'min:6'],
+        ];
+    }
+
+    /**
+     * 検証済み payload を Application DTO へ変換する。
+     */
+    public function toDto(): RegisterUserDto
+    {
+        /** @var array{user: array{username: string, email: string, password: string}} $payload */
+        $payload = $this->validated();
+
+        return new RegisterUserDto(
+            username: $payload['user']['username'],
+            email: $payload['user']['email'],
+            password: $payload['user']['password'],
+        );
+    }
+}

--- a/backend/app/Presentation/Http/Resources/Identity/UserResource.php
+++ b/backend/app/Presentation/Http/Resources/Identity/UserResource.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Resources\Identity;
+
+use App\Application\Identity\DTOs\AuthenticatedUserDto;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin AuthenticatedUserDto
+ */
+final class UserResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * RealWorld user wrapper へ変換する。
+     *
+     * @return array{user: array{email: string, token: string, username: string, bio: string|null, image: string|null}}
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var AuthenticatedUserDto $authenticatedUser */
+        $authenticatedUser = $this->resource;
+        $user = $authenticatedUser->user;
+
+        return [
+            'user' => [
+                'email' => $user->email()->value,
+                'token' => $authenticatedUser->token,
+                'username' => $user->username()->value,
+                'bio' => $user->bio()->value,
+                'image' => $user->image()->value,
+            ],
+        ];
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Presentation\Http\Middleware\NormalizeRealWorldAuthorizationHeader;
 use App\Presentation\Http\Responses\RealWorldErrorResponse;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -16,6 +17,9 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->statefulApi();
+        $middleware->api(prepend: [
+            NormalizeRealWorldAuthorizationHeader::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->shouldRenderJsonWhen(

--- a/backend/database/factories/UserFactory.php
+++ b/backend/database/factories/UserFactory.php
@@ -5,7 +5,6 @@ namespace Database\Factories;
 use App\Infrastructure\Persistence\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Str;
 
 /**
  * @extends Factory<User>
@@ -32,21 +31,11 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
+            'username' => fake()->unique()->userName(),
             'email' => fake()->unique()->safeEmail(),
-            'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
-            'remember_token' => Str::random(10),
+            'password_hash' => static::$password ??= Hash::make('password'),
+            'bio' => null,
+            'image' => null,
         ];
-    }
-
-    /**
-     * Indicate that the model's email address should be unverified.
-     */
-    public function unverified(): static
-    {
-        return $this->state(fn (array $attributes) => [
-            'email_verified_at' => null,
-        ]);
     }
 }

--- a/backend/database/migrations/2026_05_16_000000_update_users_table_for_real_world_identity.php
+++ b/backend/database/migrations/2026_05_16_000000_update_users_table_for_real_world_identity.php
@@ -1,0 +1,77 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('username', 50)->nullable()->after('id');
+            $table->string('password_hash')->nullable()->after('email');
+            $table->text('bio')->nullable()->after('password_hash');
+            $table->string('image', 2048)->nullable()->after('bio');
+            $table->softDeletes()->after('updated_at')->index('users_deleted_at_index');
+        });
+
+        DB::table('users')
+            ->select(['id', 'password'])
+            ->orderBy('id')
+            ->get()
+            ->each(function (object $user): void {
+                DB::table('users')
+                    ->where('id', $user->id)
+                    ->update([
+                        'username' => 'user-'.$user->id,
+                        'password_hash' => $user->password,
+                    ]);
+            });
+
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('username', 50)->nullable(false)->change();
+            $table->string('password_hash')->nullable(false)->change();
+            $table->unique('username', 'users_username_unique');
+            $table->dropColumn(['name', 'email_verified_at', 'password', 'remember_token']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('name')->nullable()->after('id');
+            $table->timestamp('email_verified_at')->nullable()->after('email');
+            $table->string('password')->nullable()->after('email_verified_at');
+            $table->rememberToken()->after('password');
+        });
+
+        DB::table('users')
+            ->select(['id', 'username', 'password_hash'])
+            ->orderBy('id')
+            ->get()
+            ->each(function (object $user): void {
+                DB::table('users')
+                    ->where('id', $user->id)
+                    ->update([
+                        'name' => $user->username,
+                        'password' => $user->password_hash,
+                    ]);
+            });
+
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('name')->nullable(false)->change();
+            $table->string('password')->nullable(false)->change();
+            $table->dropUnique('users_username_unique');
+            $table->dropIndex('users_deleted_at_index');
+            $table->dropColumn(['username', 'password_hash', 'bio', 'image', 'deleted_at']);
+        });
+    }
+};

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Infrastructure\Persistence\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
@@ -18,8 +19,9 @@ class DatabaseSeeder extends Seeder
         // User::factory(10)->create();
 
         User::factory()->create([
-            'name' => 'Test User',
+            'username' => 'testuser',
             'email' => 'test@example.com',
+            'password_hash' => Hash::make('password'),
         ]);
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,7 +1,11 @@
 <?php
 
+use App\Presentation\Http\Controllers\Identity\AuthController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+
+Route::post('/users', [AuthController::class, 'register']);
+Route::post('/users/login', [AuthController::class, 'login']);
 
 Route::get('/user', function (Request $request) {
     return $request->user();

--- a/backend/tests/Feature/Identity/LoginUserApiTest.php
+++ b/backend/tests/Feature/Identity/LoginUserApiTest.php
@@ -45,6 +45,28 @@ describe('POST /api/users/login', function (): void {
         expect($response->json('user.token'))->toBeString()->not->toBe('');
     });
 
+    it('ログイン成功時に返したtokenをRealWorldのToken schemeで利用できる', function (): void {
+        User::factory()->create([
+            'username' => 'jake',
+            'email' => 'jake@example.com',
+            'password_hash' => Hash::make('secret'),
+        ]);
+
+        $response = $this->postJson('/api/users/login', [
+            'user' => [
+                'email' => 'jake@example.com',
+                'password' => 'secret',
+            ],
+        ])->assertOk();
+
+        $this->withHeaders([
+            'Authorization' => 'Token '.$response->json('user.token'),
+        ])
+            ->getJson('/api/user')
+            ->assertOk()
+            ->assertJsonFragment(['email' => 'jake@example.com']);
+    });
+
     it('誤ったcredentialsを422で拒否する', function (): void {
         User::factory()->create([
             'username' => 'jake',

--- a/backend/tests/Feature/Identity/LoginUserApiTest.php
+++ b/backend/tests/Feature/Identity/LoginUserApiTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Infrastructure\Persistence\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+describe('POST /api/users/login', function (): void {
+    it('ログイン成功時に200とRealWorld user wrapperを返す', function (): void {
+        User::factory()->create([
+            'username' => 'jake',
+            'email' => 'jake@example.com',
+            'password_hash' => Hash::make('secret'),
+            'bio' => 'I like APIs',
+            'image' => 'https://example.com/avatar.png',
+        ]);
+
+        $response = $this->postJson('/api/users/login', [
+            'user' => [
+                'email' => 'jake@example.com',
+                'password' => 'secret',
+            ],
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonStructure([
+                'user' => [
+                    'email',
+                    'token',
+                    'username',
+                    'bio',
+                    'image',
+                ],
+            ])
+            ->assertJsonPath('user.email', 'jake@example.com')
+            ->assertJsonPath('user.username', 'jake')
+            ->assertJsonPath('user.bio', 'I like APIs')
+            ->assertJsonPath('user.image', 'https://example.com/avatar.png');
+
+        expect($response->json('user.token'))->toBeString()->not->toBe('');
+    });
+
+    it('誤ったcredentialsを422で拒否する', function (): void {
+        User::factory()->create([
+            'username' => 'jake',
+            'email' => 'jake@example.com',
+            'password_hash' => Hash::make('secret'),
+        ]);
+
+        $response = $this->postJson('/api/users/login', [
+            'user' => [
+                'email' => 'jake@example.com',
+                'password' => 'wrong-password',
+            ],
+        ]);
+
+        $response
+            ->assertUnprocessable()
+            ->assertExactJson([
+                'errors' => [
+                    'body' => ['email or password is invalid'],
+                ],
+            ]);
+    });
+
+    it('validation failureを422のerrors.bodyで返す', function (): void {
+        $response = $this->postJson('/api/users/login', [
+            'user' => [
+                'email' => 'not-an-email',
+                'password' => '',
+            ],
+        ]);
+
+        $response
+            ->assertUnprocessable()
+            ->assertJsonStructure(['errors' => ['body']]);
+
+        expect($response->json('errors.body'))->toBeArray()->not->toBeEmpty();
+    });
+});

--- a/backend/tests/Feature/Identity/RegisterUserApiTest.php
+++ b/backend/tests/Feature/Identity/RegisterUserApiTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Infrastructure\Persistence\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+describe('POST /api/users', function (): void {
+    it('登録成功時に201とRealWorld user wrapperを返す', function (): void {
+        $response = $this->postJson('/api/users', [
+            'user' => [
+                'username' => 'jake',
+                'email' => 'jake@example.com',
+                'password' => 'secret',
+            ],
+        ]);
+
+        $response
+            ->assertCreated()
+            ->assertJsonStructure([
+                'user' => [
+                    'email',
+                    'token',
+                    'username',
+                    'bio',
+                    'image',
+                ],
+            ])
+            ->assertJsonPath('user.email', 'jake@example.com')
+            ->assertJsonPath('user.username', 'jake')
+            ->assertJsonPath('user.bio', null)
+            ->assertJsonPath('user.image', null);
+
+        expect($response->json('user.token'))->toBeString()->not->toBe('');
+    });
+
+    it('passwordを平文保存せずpassword_hashに保存する', function (): void {
+        $this->postJson('/api/users', [
+            'user' => [
+                'username' => 'jake',
+                'email' => 'jake@example.com',
+                'password' => 'secret',
+            ],
+        ])->assertCreated();
+
+        $user = User::query()->where('email', 'jake@example.com')->firstOrFail();
+
+        expect($user->password_hash)
+            ->toBeString()
+            ->not->toBe('secret')
+            ->and(Hash::check('secret', $user->password_hash))->toBeTrue();
+    });
+
+    it('重複emailを422で拒否する', function (): void {
+        User::factory()->create([
+            'username' => 'existing',
+            'email' => 'jake@example.com',
+        ]);
+
+        $response = $this->postJson('/api/users', [
+            'user' => [
+                'username' => 'jake',
+                'email' => 'jake@example.com',
+                'password' => 'secret',
+            ],
+        ]);
+
+        $response
+            ->assertUnprocessable()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+
+    it('重複usernameを422で拒否する', function (): void {
+        User::factory()->create([
+            'username' => 'jake',
+            'email' => 'existing@example.com',
+        ]);
+
+        $response = $this->postJson('/api/users', [
+            'user' => [
+                'username' => 'jake',
+                'email' => 'jake@example.com',
+                'password' => 'secret',
+            ],
+        ]);
+
+        $response
+            ->assertUnprocessable()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+
+    it('validation failureを422のerrors.bodyで返す', function (): void {
+        $response = $this->postJson('/api/users', [
+            'user' => [
+                'username' => '',
+                'email' => 'not-an-email',
+                'password' => 'short',
+            ],
+        ]);
+
+        $response
+            ->assertUnprocessable()
+            ->assertJsonStructure(['errors' => ['body']]);
+
+        expect($response->json('errors.body'))->toBeArray()->not->toBeEmpty();
+    });
+});

--- a/backend/tests/Feature/Identity/RegisterUserApiTest.php
+++ b/backend/tests/Feature/Identity/RegisterUserApiTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use App\Application\Identity\Services\AuthTokenIssuerInterface;
+use App\Domain\Identity\Entities\User as DomainUser;
 use App\Infrastructure\Persistence\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
@@ -38,6 +40,23 @@ describe('POST /api/users', function (): void {
         expect($response->json('user.token'))->toBeString()->not->toBe('');
     });
 
+    it('登録成功時に返したtokenをRealWorldのToken schemeで利用できる', function (): void {
+        $response = $this->postJson('/api/users', [
+            'user' => [
+                'username' => 'jake',
+                'email' => 'jake@example.com',
+                'password' => 'secret',
+            ],
+        ])->assertCreated();
+
+        $this->withHeaders([
+            'Authorization' => 'Token '.$response->json('user.token'),
+        ])
+            ->getJson('/api/user')
+            ->assertOk()
+            ->assertJsonFragment(['email' => 'jake@example.com']);
+    });
+
     it('passwordを平文保存せずpassword_hashに保存する', function (): void {
         $this->postJson('/api/users', [
             'user' => [
@@ -53,6 +72,26 @@ describe('POST /api/users', function (): void {
             ->toBeString()
             ->not->toBe('secret')
             ->and(Hash::check('secret', $user->password_hash))->toBeTrue();
+    });
+
+    it('token発行に失敗した場合は登録Userをrollbackする', function (): void {
+        $this->app->instance(AuthTokenIssuerInterface::class, new class implements AuthTokenIssuerInterface
+        {
+            public function issue(DomainUser $user): string
+            {
+                throw new RuntimeException('token issue failed');
+            }
+        });
+
+        $this->postJson('/api/users', [
+            'user' => [
+                'username' => 'jake',
+                'email' => 'jake@example.com',
+                'password' => 'secret',
+            ],
+        ])->assertInternalServerError();
+
+        expect(User::query()->where('email', 'jake@example.com')->exists())->toBeFalse();
     });
 
     it('重複emailを422で拒否する', function (): void {


### PR DESCRIPTION
## 概要

- RealWorld互換の登録API `POST /api/users` を追加
- RealWorld互換のログインAPI `POST /api/users/login` を追加
- Identity ContextのDomain/Application/Infrastructure/Presentation層を追加
- `users` schemaをusername/password_hash/bio/image/deleted_atへ移行

## 関連 Issue

Closes #65

## テスト計画

- [x] バックエンド: `php artisan test`
- [x] バックエンド: `./vendor/bin/pint --test`
- [x] バックエンド: `./vendor/bin/phpstan analyse`
- [x] フロントエンド: 対象外