### PR TITLE
chore: .devcontainer を復元する (#109)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,54 @@
+FROM node:24-bookworm-slim
+
+ARG TZ=Asia/Tokyo
+ARG GIT_DELTA_VERSION=0.18.2
+ARG ZSH_IN_DOCKER_VERSION=1.2.0
+
+ENV TZ=$TZ
+ENV DEBIAN_FRONTEND=noninteractive
+
+# GitHub CLI + Docker CLI のリポジトリを追加してパッケージをインストール
+RUN apt-get update && apt-get install -y ca-certificates curl gnupg \
+    && install -m 0755 -d /etc/apt/keyrings \
+    # GitHub CLI
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | dd of=/etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    # Docker CLI（ASCII armored 形式で保存することで APT が正しく処理できる）
+    && curl -fsSL https://download.docker.com/linux/debian/gpg \
+        -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" \
+        > /etc/apt/sources.list.d/docker.list \
+    && apt-get update && apt-get install -y \
+    git wget zsh jq gh sudo make \
+    docker-ce-cli docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN arch="$(dpkg --print-architecture)" \
+    && case "$arch" in \
+        amd64|arm64) delta_arch="$arch" ;; \
+        *) echo "Unsupported architecture for git-delta: $arch" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/git-delta_${GIT_DELTA_VERSION}_${delta_arch}.deb" -o delta.deb \
+    && dpkg -i delta.deb && rm delta.deb
+
+# git-secrets のインストール
+RUN git clone https://github.com/awslabs/git-secrets.git /tmp/git-secrets \
+    && cd /tmp/git-secrets && make install \
+    && rm -rf /tmp/git-secrets
+
+RUN corepack enable
+
+RUN sh -c "$(curl -fsSL https://github.com/deluan/zsh-in-docker/releases/download/v${ZSH_IN_DOCKER_VERSION}/zsh-in-docker.sh)" -- \
+    -t robbyrussell
+
+COPY bin/ /usr/local/bin/
+
+RUN chmod 755 /usr/local/bin/docker /usr/local/bin/delegate-backend-php /usr/local/bin/php /usr/local/bin/composer \
+    && printf '%s\n' 'node ALL=(root) NOPASSWD: /usr/bin/docker *' > /etc/sudoers.d/node-docker \
+    && chmod 440 /etc/sudoers.d/node-docker \
+    && touch /home/node/.zshrc \
+    && chown node:node /home/node/.zshrc

--- a/.devcontainer/bin/composer
+++ b/.devcontainer/bin/composer
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+
+exec "$SCRIPT_DIR/delegate-backend-php" composer "$@"

--- a/.devcontainer/bin/delegate-backend-php
+++ b/.devcontainer/bin/delegate-backend-php
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eu
+
+COMPOSE_FILE="${CODEX_COMPOSE_FILE:-/workspace/compose.yml}"
+SERVICE="${CODEX_BACKEND_PHP_SERVICE:-backend-php}"
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: delegate-backend-php <command> [args...]" >&2
+  exit 64
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker CLI is not available in the devcontainer." >&2
+  exit 127
+fi
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+  echo "Compose file not found: $COMPOSE_FILE" >&2
+  exit 66
+fi
+
+if [ ! -t 0 ] || [ ! -t 1 ]; then
+  exec docker compose -f "$COMPOSE_FILE" exec -T "$SERVICE" "$@"
+fi
+
+exec docker compose -f "$COMPOSE_FILE" exec "$SERVICE" "$@"

--- a/.devcontainer/bin/docker
+++ b/.devcontainer/bin/docker
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+DOCKER_BIN=/usr/bin/docker
+
+if [ "$(id -u)" -eq 0 ]; then
+  exec "$DOCKER_BIN" "$@"
+fi
+
+if command -v sudo >/dev/null 2>&1; then
+  exec sudo "$DOCKER_BIN" "$@"
+fi
+
+exec "$DOCKER_BIN" "$@"

--- a/.devcontainer/bin/php
+++ b/.devcontainer/bin/php
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+
+exec "$SCRIPT_DIR/delegate-backend-php" php "$@"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+{
+  "name": "Real World Dev Container",
+  "dockerComposeFile": [
+    "../compose.yml",
+    "docker-compose.yml"
+  ],
+  "service": "devcontainer",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "eamodio.gitlens"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.codeActionsOnSave": {
+          "source.fixAll.eslint": "explicit"
+        },
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "bash",
+            "icon": "terminal-bash"
+          },
+          "zsh": {
+            "path": "zsh"
+          }
+        }
+      }
+    }
+  },
+  "remoteUser": "node",
+  "workspaceFolder": "/workspace",
+  "remoteEnv": {
+    "GH_TOKEN": "${localEnv:GH_TOKEN}"
+  },
+  "postCreateCommand": "cd /workspace && pnpm install && git config commit.template .github/commit_message_template && cd frontend && pnpm install && cd /workspace && git secrets --register-aws --global && git secrets --add --global 'password\\s*=\\s*\\S+' && git secrets --add --global 'secret\\s*=\\s*\\S+' && git secrets --add --global 'api_key\\s*=\\s*\\S+' && git secrets --add --global 'private_key\\s*=\\s*\\S+' && git secrets --install -f"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  devcontainer:
+    build:
+      context: .devcontainer
+      dockerfile: Dockerfile
+      args:
+        TZ: "${TZ:-Asia/Tokyo}"
+        GIT_DELTA_VERSION: "0.18.2"
+        ZSH_IN_DOCKER_VERSION: "1.2.0"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - .:/workspace:cached
+      - devcontainer-bashhistory:/commandhistory
+      - pnpm-store:/home/node/.local/share/pnpm/store
+      - "${HOME}/.config/gh:/home/node/.config/gh"
+    environment:
+      NODE_OPTIONS: "--max-old-space-size=4096 --dns-result-order=ipv4first"
+      POWERLEVEL9K_DISABLE_GITSTATUS: "true"
+    command: sleep infinity
+    networks:
+      - app-network
+    depends_on:
+      - db
+      - backend-php
+      - backend-nginx
+      - frontend
+
+volumes:
+  devcontainer-bashhistory:
+  pnpm-store:


### PR DESCRIPTION
## 概要

- 誤削除された `.devcontainer` を復元
- Claude / Anthropic 固有設定を除外
- Dev Container の Dockerfile / compose / wrapper script を現行構成に合わせて確認

## 関連 Issue

Closes #109

## テスト計画

- [x] `.devcontainer/devcontainer.json` の JSON 構文確認: `jq empty .devcontainer/devcontainer.json`
- [x] wrapper script の shell 構文確認: `sh -n .devcontainer/bin/*`
- [x] Compose 構成確認: `docker compose -f compose.yml -f .devcontainer/docker-compose.yml config --quiet`
- [x] Claude / Anthropic 文字列なし: `rg -n -i 'claude|anthropic' .devcontainer`
- [x] 代表的なシークレット値パターンなし: `rg -n 'ghp_|github_pat_|sk-[A-Za-z0-9]|AKIA|BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY' .devcontainer`
- [x] Docker build: `docker compose -f compose.yml -f .devcontainer/docker-compose.yml build devcontainer`
- [ ] フロントエンド/バックエンド全体テストは対象外（実装コード変更なし）