### PR TITLE
feat: API client と error normalization を実装 (#64)

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -17,6 +17,7 @@ description: >
 2. AI ハーネス正本として `docs/ai/harness.md` を読む。
 3. `docs/rules/security.md` を必ず読む。
 4. 変更範囲に応じて `docs/rules/frontend.md`、`docs/rules/backend.md`、`docs/rules/db.md` を読む。
+   - Frontend 変更では `docs/rules/frontend.md` の React 設計原則を確認し、必要に応じて React 公式 `Thinking in React`（https://react.dev/learn/thinking-in-react）を参照する。
 5. テスト、アーキテクチャ、API/CRUD設計、セキュリティ、保守性の順に確認する。
 6. 実行系の検証が必要な場合は `verify-qa` skill を併用する。
 
@@ -29,6 +30,7 @@ description: >
 - API/CRUD はリクエスト/レスポンス、ステータスコード、バリデーション、認可、ページングや並び順が一貫しているか。
 - Laravel は Controller を薄く保ち、FormRequest、Domain/Application/Infrastructure/Presentation の責務を混ぜていないか。
 - React は `app/`、`features/`、`shared/`、`lib/` の境界、Hooks と Component の責務を崩していないか。
+- React component は関心の分離と単一責任を守り、component hierarchy、最小 state、state 所有者、一方向データフローが妥当か。
 - `.env` 編集、シークレット直書き、危険な動的実行、SQL 文字列結合、サーバーサイド検証の省略がないか。
 
 ## 出力形式

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -18,6 +18,7 @@ description: >
 3. `docs/rules/security.md` を必ず読む。
 4. 変更範囲に応じて `docs/rules/frontend.md`、`docs/rules/backend.md`、`docs/rules/db.md` を読む。
    - Frontend 変更では `docs/rules/frontend.md` の React 設計原則を確認する。
+   - React component 設計の妥当性を見る場合は `references/react-thinking-in-react.md` を読む。
 5. テスト、アーキテクチャ、API/CRUD設計、セキュリティ、保守性の順に確認する。
 6. 実行系の検証が必要な場合は `verify-qa` skill を併用する。
 

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -17,7 +17,7 @@ description: >
 2. AI ハーネス正本として `docs/ai/harness.md` を読む。
 3. `docs/rules/security.md` を必ず読む。
 4. 変更範囲に応じて `docs/rules/frontend.md`、`docs/rules/backend.md`、`docs/rules/db.md` を読む。
-   - Frontend 変更では `docs/rules/frontend.md` の React 設計原則を確認し、必要に応じて React 公式 `Thinking in React`（https://react.dev/learn/thinking-in-react）を参照する。
+   - Frontend 変更では `docs/rules/frontend.md` の React 設計原則を確認する。
 5. テスト、アーキテクチャ、API/CRUD設計、セキュリティ、保守性の順に確認する。
 6. 実行系の検証が必要な場合は `verify-qa` skill を併用する。
 

--- a/.agents/skills/code-review/references/react-thinking-in-react.md
+++ b/.agents/skills/code-review/references/react-thinking-in-react.md
@@ -1,0 +1,53 @@
+# React Thinking in React Reference
+
+> 確認日: 2026-05-20
+> 参照元URL: https://react.dev/learn/thinking-in-react
+
+この reference は、フロントエンドレビュー時に React 公式 "Thinking in React" の考え方をローカルで参照するための要点メモ。
+URL先を毎回読ませるのではなく、レビュー判断に必要な最小限の観点をここに固定する。
+
+## 設計手順
+
+1. UI を component hierarchy に分解する。
+2. props だけで静的に描画できる構造を先に考える。
+3. UI state の最小集合を特定する。
+4. 各 state の所有者を決める。
+5. 一方向データフローで component をつなぐ。
+
+## Component 分解
+
+- component は原則として1つの関心だけを持つ。
+- component が複数の責務を持ち始めたら、subcomponent、custom hook、utility へ分解する。
+- UI の情報構造と data model の構造が対応するように component 境界を切る。
+- デザイン上のまとまり、CSS selector の単位、関数分割と同じ判断軸で component 粒度を確認する。
+
+## State 設計
+
+state にするのは、時間で変化し、props や既存 state から計算できない最小集合だけにする。
+
+state にしないもの:
+
+- props として渡されるデータ
+- 時間で変化しない定数
+- 既存 state / props から計算できる derived data
+
+derived data の例:
+
+- filter 済み一覧
+- 件数
+- 表示用ラベル
+- sort / filter 条件から再計算できる表示結果
+
+## State 所有者
+
+state を使うすべての component を確認し、その最も近い共通親へ state を置く。
+共通親に置くと責務が曖昧になる場合は、state 保持専用の component / Provider / hook を作る。
+
+## レビュー観点
+
+- component hierarchy が画面・data model の構造に合っているか。
+- component が表示、hook が状態・副作用、api 層が通信、lib が技術基盤に分かれているか。
+- state が最小集合か。
+- derived data を state として重複保持していないか。
+- state 所有者が近すぎず遠すぎないか。
+- props が親から子へ一方向に流れているか。

--- a/.agents/skills/tdd-issue/SKILL.md
+++ b/.agents/skills/tdd-issue/SKILL.md
@@ -83,7 +83,7 @@ Issueのタイトル・本文・ラベルを読み取り、実装スコープを
 `docs/ai/harness.md` と `docs/rules/` ディレクトリ内の関連ルールファイルを確認する。
 対象技術スタック（frontend / backend）に応じて該当ファイルを読む。
 **`docs/rules/security.md` は必ず確認する。**
-フロントエンドを含む場合は `docs/rules/frontend.md` の React 設計原則を確認し、設計・Plan 時に React 公式の `Thinking in React`（https://react.dev/learn/thinking-in-react）を必要に応じて参照する。
+フロントエンドを含む場合は `docs/rules/frontend.md` の React 設計原則を確認し、設計・Plan 時に参照する。
 
 #### Step 3: 要件整理・設計ドキュメント作成
 

--- a/.agents/skills/tdd-issue/SKILL.md
+++ b/.agents/skills/tdd-issue/SKILL.md
@@ -83,7 +83,8 @@ Issueのタイトル・本文・ラベルを読み取り、実装スコープを
 `docs/ai/harness.md` と `docs/rules/` ディレクトリ内の関連ルールファイルを確認する。
 対象技術スタック（frontend / backend）に応じて該当ファイルを読む。
 **`docs/rules/security.md` は必ず確認する。**
-フロントエンドを含む場合は `docs/rules/frontend.md` の React 設計原則を確認し、設計・Plan 時に参照する。
+フロントエンドを含む場合は `docs/rules/frontend.md` の React 設計原則を確認する。
+React component の設計・Plan が必要な場合は `references/react-thinking-in-react.md` を読む。
 
 #### Step 3: 要件整理・設計ドキュメント作成
 

--- a/.agents/skills/tdd-issue/SKILL.md
+++ b/.agents/skills/tdd-issue/SKILL.md
@@ -83,6 +83,7 @@ Issueのタイトル・本文・ラベルを読み取り、実装スコープを
 `docs/ai/harness.md` と `docs/rules/` ディレクトリ内の関連ルールファイルを確認する。
 対象技術スタック（frontend / backend）に応じて該当ファイルを読む。
 **`docs/rules/security.md` は必ず確認する。**
+フロントエンドを含む場合は `docs/rules/frontend.md` の React 設計原則を確認し、設計・Plan 時に React 公式の `Thinking in React`（https://react.dev/learn/thinking-in-react）を必要に応じて参照する。
 
 #### Step 3: 要件整理・設計ドキュメント作成
 
@@ -95,6 +96,8 @@ Issueのタイトル・本文・ラベルを読み取り、実装スコープを
    - **API 設計**: エンドポイント、リクエスト/レスポンス、バリデーション（バックエンド関与時）
    - **ドメインモデル設計**: Entity / ValueObject / Repository（DDD 適用時）
    - **フロントエンド設計**: Feature 構成、コンポーネント分割、状態管理（フロントエンド関与時）
+     - React component hierarchy、関心の分離、単一責任の原則を明記する
+     - state は最小集合か、derived data を state にしていないか、state 所有者は妥当かを確認する
    - **DB 設計**: テーブル、マイグレーション（DB 変更時）
    - **セキュリティ確認**: `docs/rules/security.md` の禁止事項に抵触しないか
 3. **タスク分解**: TDD サイクルのコミット単位でタスクを列挙

--- a/.agents/skills/tdd-issue/references/react-thinking-in-react.md
+++ b/.agents/skills/tdd-issue/references/react-thinking-in-react.md
@@ -1,0 +1,53 @@
+# React Thinking in React Reference
+
+> 確認日: 2026-05-20
+> 参照元URL: https://react.dev/learn/thinking-in-react
+
+この reference は、フロントエンド設計・Plan 時に React 公式 "Thinking in React" の考え方をローカルで参照するための要点メモ。
+URL先を毎回読ませるのではなく、設計判断に必要な最小限の観点をここに固定する。
+
+## 設計手順
+
+1. UI を component hierarchy に分解する。
+2. props だけで静的に描画できる構造を先に考える。
+3. UI state の最小集合を特定する。
+4. 各 state の所有者を決める。
+5. 一方向データフローで component をつなぐ。
+
+## Component 分解
+
+- component は原則として1つの関心だけを持つ。
+- component が複数の責務を持ち始めたら、subcomponent、custom hook、utility へ分解する。
+- UI の情報構造と data model の構造が対応するように component 境界を切る。
+- デザイン上のまとまり、CSS selector の単位、関数分割と同じ判断軸で component 粒度を確認する。
+
+## State 設計
+
+state にするのは、時間で変化し、props や既存 state から計算できない最小集合だけにする。
+
+state にしないもの:
+
+- props として渡されるデータ
+- 時間で変化しない定数
+- 既存 state / props から計算できる derived data
+
+derived data の例:
+
+- filter 済み一覧
+- 件数
+- 表示用ラベル
+- sort / filter 条件から再計算できる表示結果
+
+## State 所有者
+
+state を使うすべての component を確認し、その最も近い共通親へ state を置く。
+共通親に置くと責務が曖昧になる場合は、state 保持専用の component / Provider / hook を作る。
+
+## レビュー観点
+
+- component hierarchy が画面・data model の構造に合っているか。
+- component が表示、hook が状態・副作用、api 層が通信、lib が技術基盤に分かれているか。
+- state が最小集合か。
+- derived data を state として重複保持していないか。
+- state 所有者が近すぎず遠すぎないか。
+- props が親から子へ一方向に流れているか。

--- a/docs/rules/backend.md
+++ b/docs/rules/backend.md
@@ -342,6 +342,7 @@ public function execute(CreateOrderDto $dto): Order
 
 - Feature テスト: HTTP リクエスト経由でエンドポイントをテスト
 - Unit テスト: Service クラスのロジックをテスト
+- Pest の `describe` / `it` / `test` のテスト名は日本語で書き、仕様・振る舞いがレビュー時に読める表現にする
 - テストデータは Factory + Faker で生成
 - テスト間の独立性: `RefreshDatabase` トレイト使用
 

--- a/docs/rules/frontend.md
+++ b/docs/rules/frontend.md
@@ -21,7 +21,7 @@
 - Functional Components + Hooks のみ（クラスコンポーネント禁止）
 - `React.FC` 不使用。Props を引数で直接型付けする
 - 名前付きエクスポート（`export default` 禁止）
-- React の設計判断は、設計・Plan・Review 時に公式の [Thinking in React](https://react.dev/learn/thinking-in-react) を参照する
+- React の設計判断は、設計・Plan・Review 時に公式 `Thinking in React` の考え方を参照する
 
 ```tsx
 // Good

--- a/docs/rules/frontend.md
+++ b/docs/rules/frontend.md
@@ -382,6 +382,7 @@ features/user/components/
 
 - カバレッジ目標: 80%
 - コンポーネントテストはユーザー視点で書く（実装詳細に依存しない）
+- `describe` / `it` のテスト名は日本語で書き、仕様・振る舞いがレビュー時に読める表現にする
 - `getByRole`, `getByLabelText` を優先（`getByTestId` は最終手段）
 - テストファイル配置: `__tests__/<ComponentName>.test.tsx`
 

--- a/docs/rules/frontend.md
+++ b/docs/rules/frontend.md
@@ -45,6 +45,12 @@ export default UserCard;
 | ファイル（フック） | camelCase.ts | `useAuth.ts` |
 | ファイル（ユーティリティ） | camelCase.ts | `formatDate.ts` |
 
+### JSDoc / コメント方針
+
+- export する関数には JSDoc を付け、処理内容ではなく関数が担う契約・意図を短く書く
+- 複雑な private helper には、呼び出し側から見えにくい判断理由を短いコメントで補足する
+- 単純な代入、型から明らかな処理、React / browser API 既定動作の説明だけのコメントは避ける
+
 ## ディレクトリ構成
 
 ```

--- a/docs/rules/frontend.md
+++ b/docs/rules/frontend.md
@@ -21,6 +21,7 @@
 - Functional Components + Hooks のみ（クラスコンポーネント禁止）
 - `React.FC` 不使用。Props を引数で直接型付けする
 - 名前付きエクスポート（`export default` 禁止）
+- React の設計判断は、設計・Plan・Review 時に公式の [Thinking in React](https://react.dev/learn/thinking-in-react) を参照する
 
 ```tsx
 // Good
@@ -33,6 +34,19 @@ export function UserCard({ name }: Props) { ... }
 const UserCard: React.FC<Props> = ({ name }) => { ... }
 export default UserCard;
 ```
+
+### React 設計原則
+
+React component は `Thinking in React` を基準に、関心の分離（separation of concerns）と単一責任の原則を守る。
+
+- UI を component hierarchy に分解し、component ごとの責務を1つに絞る
+- component が複数の関心を持ち始めたら、より小さい subcomponent / hook / utility へ分解する
+- data model と UI の情報構造を対応させ、props は親から子へ流す
+- まず props だけで静的に描画できる構造を考え、interactivity はその後に追加する
+- state は「時間で変化し、props や既存 state から計算できない最小集合」だけにする
+- state の所有者は、その state を使う component 群の最も近い共通親か、明確に state を保持するための component / Provider に置く
+- derived data（filter済み一覧、件数、表示用ラベルなど）を state に重複保持しない
+- component は表示、hook は状態・副作用、`features/*/api` は通信、`lib` は技術基盤に責務を分ける
 
 ### 命名規則
 

--- a/frontend/src/lib/__tests__/apiClient.test.ts
+++ b/frontend/src/lib/__tests__/apiClient.test.ts
@@ -33,6 +33,7 @@ function getRequestOptions(fetchMock: ReturnType<typeof vi.fn>): RequestInit {
     throw new Error('fetchがrequest options付きで呼ばれていません');
   }
 
+  // Vitestのmock call引数は広い型なので、以降の検証対象としてRequestInitへ絞る。
   return call[1] as RequestInit;
 }
 

--- a/frontend/src/lib/__tests__/apiClient.test.ts
+++ b/frontend/src/lib/__tests__/apiClient.test.ts
@@ -3,6 +3,9 @@ import { createApiClient } from '../apiClient';
 import { clearAuthToken, setAuthToken } from '../authToken';
 import { isApiError } from '../apiError';
 
+/**
+ * API clientが扱うJSONレスポンスをテスト用に生成する。
+ */
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   const headers = new Headers(init.headers);
   headers.set('Content-Type', 'application/json');
@@ -13,10 +16,16 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   });
 }
 
+/**
+ * fetch差し替え時にResponseを返すmockを生成する。
+ */
 function createFetchMock(response: Response): ReturnType<typeof vi.fn> {
   return vi.fn().mockResolvedValue(response);
 }
 
+/**
+ * fetchへ渡されたrequest optionsを検証用に取り出す。
+ */
 function getRequestOptions(fetchMock: ReturnType<typeof vi.fn>): RequestInit {
   const call = fetchMock.mock.calls.at(0);
 

--- a/frontend/src/lib/__tests__/apiClient.test.ts
+++ b/frontend/src/lib/__tests__/apiClient.test.ts
@@ -21,19 +21,19 @@ function getRequestOptions(fetchMock: ReturnType<typeof vi.fn>): RequestInit {
   const call = fetchMock.mock.calls.at(0);
 
   if (call === undefined || call[1] === undefined) {
-    throw new Error('fetch was not called with request options');
+    throw new Error('fetchがrequest options付きで呼ばれていません');
   }
 
   return call[1] as RequestInit;
 }
 
-describe('apiClient', () => {
+describe('共通API client', () => {
   beforeEach(() => {
     clearAuthToken();
     vi.unstubAllGlobals();
   });
 
-  it('injects the RealWorld auth header when a token exists', async () => {
+  it('トークンが存在する場合はRealWorld形式の認証ヘッダーを付与する', async () => {
     const fetchMock = createFetchMock(jsonResponse({ user: { username: 'jake' } }));
     vi.stubGlobal('fetch', fetchMock);
     setAuthToken('secret-token');
@@ -52,7 +52,7 @@ describe('apiClient', () => {
     expect(headers.get('Authorization')).toBe('Token secret-token');
   });
 
-  it('normalizes unauthorized responses for invalid token handling', async () => {
+  it('invalid tokenを扱えるよう401レスポンスをunauthorized errorへ正規化する', async () => {
     vi.stubGlobal(
       'fetch',
       createFetchMock(jsonResponse({ errors: { body: ['Unauthorized'] } }, { status: 401 })),
@@ -61,7 +61,7 @@ describe('apiClient', () => {
 
     try {
       await client.get('/api/user');
-      throw new Error('Expected request to fail');
+      throw new Error('requestが失敗する想定です');
     } catch (error: unknown) {
       expect(isApiError(error)).toBe(true);
 
@@ -75,7 +75,7 @@ describe('apiClient', () => {
     }
   });
 
-  it('normalizes validation responses with RealWorld body errors', async () => {
+  it('RealWorld形式のbody errorsを持つ422レスポンスをvalidation errorへ正規化する', async () => {
     vi.stubGlobal(
       'fetch',
       createFetchMock(
@@ -94,7 +94,7 @@ describe('apiClient', () => {
           password: 'x',
         },
       });
-      throw new Error('Expected request to fail');
+      throw new Error('requestが失敗する想定です');
     } catch (error: unknown) {
       expect(isApiError(error)).toBe(true);
 
@@ -111,13 +111,13 @@ describe('apiClient', () => {
     }
   });
 
-  it('normalizes network failures', async () => {
+  it('network failureをnetwork errorへ正規化する', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
     const client = createApiClient();
 
     try {
       await client.get('/api/tags');
-      throw new Error('Expected request to fail');
+      throw new Error('requestが失敗する想定です');
     } catch (error: unknown) {
       expect(isApiError(error)).toBe(true);
 
@@ -131,7 +131,7 @@ describe('apiClient', () => {
     }
   });
 
-  it('normalizes JSON parse failures as unexpected errors', async () => {
+  it('JSON parse failureをunexpected errorへ正規化する', async () => {
     vi.stubGlobal(
       'fetch',
       createFetchMock(
@@ -147,7 +147,7 @@ describe('apiClient', () => {
 
     try {
       await client.get('/api/tags');
-      throw new Error('Expected request to fail');
+      throw new Error('requestが失敗する想定です');
     } catch (error: unknown) {
       expect(isApiError(error)).toBe(true);
 

--- a/frontend/src/lib/__tests__/apiClient.test.ts
+++ b/frontend/src/lib/__tests__/apiClient.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApiClient } from '../apiClient';
+import { clearAuthToken, setAuthToken } from '../authToken';
+import { isApiError } from '../apiError';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  headers.set('Content-Type', 'application/json');
+
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers,
+  });
+}
+
+function createFetchMock(response: Response): ReturnType<typeof vi.fn> {
+  return vi.fn().mockResolvedValue(response);
+}
+
+function getRequestOptions(fetchMock: ReturnType<typeof vi.fn>): RequestInit {
+  const call = fetchMock.mock.calls.at(0);
+
+  if (call === undefined || call[1] === undefined) {
+    throw new Error('fetch was not called with request options');
+  }
+
+  return call[1] as RequestInit;
+}
+
+describe('apiClient', () => {
+  beforeEach(() => {
+    clearAuthToken();
+    vi.unstubAllGlobals();
+  });
+
+  it('injects the RealWorld auth header when a token exists', async () => {
+    const fetchMock = createFetchMock(jsonResponse({ user: { username: 'jake' } }));
+    vi.stubGlobal('fetch', fetchMock);
+    setAuthToken('secret-token');
+
+    const client = createApiClient({ baseUrl: 'https://api.example.test' });
+
+    await client.get('/api/user');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.test/api/user',
+      expect.any(Object),
+    );
+
+    const requestOptions = getRequestOptions(fetchMock);
+    const headers = new Headers(requestOptions.headers);
+    expect(headers.get('Authorization')).toBe('Token secret-token');
+  });
+
+  it('normalizes unauthorized responses for invalid token handling', async () => {
+    vi.stubGlobal(
+      'fetch',
+      createFetchMock(jsonResponse({ errors: { body: ['Unauthorized'] } }, { status: 401 })),
+    );
+    const client = createApiClient();
+
+    try {
+      await client.get('/api/user');
+      throw new Error('Expected request to fail');
+    } catch (error: unknown) {
+      expect(isApiError(error)).toBe(true);
+
+      if (!isApiError(error)) {
+        throw error;
+      }
+
+      expect(error.kind).toBe('unauthorized');
+      expect(error.status).toBe(401);
+      expect(error.bodyErrors).toEqual(['Unauthorized']);
+    }
+  });
+
+  it('normalizes validation responses with RealWorld body errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      createFetchMock(
+        jsonResponse(
+          { errors: { body: ['email is invalid', 'password is too short'] } },
+          { status: 422 },
+        ),
+      ),
+    );
+    const client = createApiClient();
+
+    try {
+      await client.post('/api/users', {
+        user: {
+          email: 'invalid',
+          password: 'x',
+        },
+      });
+      throw new Error('Expected request to fail');
+    } catch (error: unknown) {
+      expect(isApiError(error)).toBe(true);
+
+      if (!isApiError(error)) {
+        throw error;
+      }
+
+      expect(error.kind).toBe('validation');
+      expect(error.status).toBe(422);
+      expect(error.bodyErrors).toEqual([
+        'email is invalid',
+        'password is too short',
+      ]);
+    }
+  });
+
+  it('normalizes network failures', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+    const client = createApiClient();
+
+    try {
+      await client.get('/api/tags');
+      throw new Error('Expected request to fail');
+    } catch (error: unknown) {
+      expect(isApiError(error)).toBe(true);
+
+      if (!isApiError(error)) {
+        throw error;
+      }
+
+      expect(error.kind).toBe('network');
+      expect(error.status).toBeUndefined();
+      expect(error.bodyErrors).toEqual([]);
+    }
+  });
+
+  it('normalizes JSON parse failures as unexpected errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      createFetchMock(
+        new Response('not json', {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          status: 200,
+        }),
+      ),
+    );
+    const client = createApiClient();
+
+    try {
+      await client.get('/api/tags');
+      throw new Error('Expected request to fail');
+    } catch (error: unknown) {
+      expect(isApiError(error)).toBe(true);
+
+      if (!isApiError(error)) {
+        throw error;
+      }
+
+      expect(error.kind).toBe('unexpected');
+      expect(error.status).toBeUndefined();
+    }
+  });
+});

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -48,9 +48,15 @@ export interface ApiClient {
   ) => Promise<TResponse>;
 }
 
+/**
+ * feature API が raw fetch と token storage を直接扱わないための共通API clientを生成する。
+ */
 export function createApiClient(config: ApiClientConfig = {}): ApiClient {
   const baseUrl = config.baseUrl ?? DEFAULT_API_BASE_URL;
 
+  /**
+   * HTTP methodを含む低レベルrequestを実行し、成功レスポンスまたはtyped ApiErrorへ正規化する。
+   */
   async function request<TResponse>(
     path: string,
     options: ApiRequestOptionsWithMethod = {},
@@ -114,6 +120,9 @@ export function createApiClient(config: ApiClientConfig = {}): ApiClient {
 
 export const apiClient = createApiClient();
 
+/**
+ * fetch例外をnetwork ApiErrorに変換し、JSON bodyは送信直前にserializeする。
+ */
 async function fetchResponse(
   fetcher: typeof fetch,
   url: string,
@@ -137,6 +146,9 @@ async function fetchResponse(
   }
 }
 
+/**
+ * JSON APIとして必要な共通ヘッダーとRealWorld形式の認証ヘッダーを組み立てる。
+ */
 function createHeaders({
   auth,
   body,
@@ -165,6 +177,9 @@ function createHeaders({
   return requestHeaders;
 }
 
+/**
+ * 環境ごとのbase URL設定とAPI pathを安全に結合する。
+ */
 function resolveUrl(path: string, baseUrl: string): string {
   if (baseUrl === '') {
     return path;
@@ -173,10 +188,16 @@ function resolveUrl(path: string, baseUrl: string): string {
   return new URL(path, normalizeBaseUrl(baseUrl)).toString();
 }
 
+/**
+ * URL constructorでpath結合するときにpath segmentが欠落しないbase URLへ整える。
+ */
 function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
 }
 
+/**
+ * 成功レスポンスをtyped JSONへ変換し、bodyなしレスポンスはnullとして扱う。
+ */
 async function parseSuccessResponse<TResponse>(
   response: Response,
 ): Promise<TResponse> {
@@ -187,6 +208,9 @@ async function parseSuccessResponse<TResponse>(
   return parseJson(response) as Promise<TResponse>;
 }
 
+/**
+ * HTTP errorレスポンスをfeature層が扱えるtyped ApiErrorへ変換する。
+ */
 async function createHttpError(response: Response): Promise<ApiError> {
   const bodyErrors = hasJsonContent(response)
     ? extractBodyErrors(await parseJson(response))
@@ -202,6 +226,9 @@ async function createHttpError(response: Response): Promise<ApiError> {
   });
 }
 
+/**
+ * JSON parse failureをunexpected ApiErrorとして扱い、raw Responseの解釈をlib内へ閉じ込める。
+ */
 async function parseJson(response: Response): Promise<unknown> {
   try {
     return await response.json();
@@ -214,10 +241,16 @@ async function parseJson(response: Response): Promise<unknown> {
   }
 }
 
+/**
+ * レスポンスbodyをJSONとして読むべきかContent-Typeから判定する。
+ */
 function hasJsonContent(response: Response): boolean {
   return response.headers.get('Content-Type')?.includes('application/json') ?? false;
 }
 
+/**
+ * HTTP status codeを画面・Provider側で分岐しやすいApiError kindへ対応付ける。
+ */
 function getErrorKind(status: number): ApiErrorKind {
   if (status === 401) {
     return 'unauthorized';
@@ -238,6 +271,9 @@ function getErrorKind(status: number): ApiErrorKind {
   return 'unexpected';
 }
 
+/**
+ * RealWorld形式のerrors.bodyだけをform/global errorへ渡せる文字列配列として取り出す。
+ */
 function extractBodyErrors(payload: unknown): string[] {
   if (!isRecord(payload) || !isRecord(payload.errors)) {
     return [];
@@ -252,6 +288,9 @@ function extractBodyErrors(payload: unknown): string[] {
   return body.filter((entry): entry is string => typeof entry === 'string');
 }
 
+/**
+ * unknown payloadをproperty access可能なrecordへ絞り込む。
+ */
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,0 +1,257 @@
+import { ApiError, type ApiErrorKind } from './apiError';
+import { getAuthToken } from './authToken';
+
+const DEFAULT_API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
+
+interface ApiClientConfig {
+  baseUrl?: string;
+  fetcher?: typeof fetch;
+}
+
+interface ApiRequestOptions {
+  auth?: boolean;
+  body?: unknown;
+  headers?: HeadersInit;
+  signal?: AbortSignal;
+}
+
+interface ApiRequestOptionsWithMethod extends ApiRequestOptions {
+  method?: string;
+}
+
+interface FetchResponseOptions extends Omit<RequestInit, 'body'> {
+  body?: unknown;
+}
+
+export interface ApiClient {
+  delete: <TResponse>(
+    path: string,
+    options?: Omit<ApiRequestOptions, 'body'>,
+  ) => Promise<TResponse>;
+  get: <TResponse>(
+    path: string,
+    options?: Omit<ApiRequestOptions, 'body'>,
+  ) => Promise<TResponse>;
+  post: <TResponse>(
+    path: string,
+    body?: unknown,
+    options?: Omit<ApiRequestOptions, 'body'>,
+  ) => Promise<TResponse>;
+  put: <TResponse>(
+    path: string,
+    body?: unknown,
+    options?: Omit<ApiRequestOptions, 'body'>,
+  ) => Promise<TResponse>;
+  request: <TResponse>(
+    path: string,
+    options?: ApiRequestOptionsWithMethod,
+  ) => Promise<TResponse>;
+}
+
+export function createApiClient(config: ApiClientConfig = {}): ApiClient {
+  const baseUrl = config.baseUrl ?? DEFAULT_API_BASE_URL;
+
+  async function request<TResponse>(
+    path: string,
+    options: ApiRequestOptionsWithMethod = {},
+  ): Promise<TResponse> {
+    const fetcher = config.fetcher ?? globalThis.fetch.bind(globalThis);
+    const { auth = true, body, headers, method = 'GET', signal } = options;
+    const response = await fetchResponse(fetcher, resolveUrl(path, baseUrl), {
+      body,
+      headers: createHeaders({ auth, body, headers }),
+      method,
+      signal,
+    });
+
+    if (!response.ok) {
+      throw await createHttpError(response);
+    }
+
+    return parseSuccessResponse<TResponse>(response);
+  }
+
+  return {
+    delete: <TResponse>(
+      path: string,
+      options: Omit<ApiRequestOptions, 'body'> = {},
+    ): Promise<TResponse> =>
+      request<TResponse>(path, {
+        ...options,
+        method: 'DELETE',
+      }),
+    get: <TResponse>(
+      path: string,
+      options: Omit<ApiRequestOptions, 'body'> = {},
+    ): Promise<TResponse> =>
+      request<TResponse>(path, {
+        ...options,
+        method: 'GET',
+      }),
+    post: <TResponse>(
+      path: string,
+      body?: unknown,
+      options: Omit<ApiRequestOptions, 'body'> = {},
+    ): Promise<TResponse> =>
+      request<TResponse>(path, {
+        ...options,
+        body,
+        method: 'POST',
+      }),
+    put: <TResponse>(
+      path: string,
+      body?: unknown,
+      options: Omit<ApiRequestOptions, 'body'> = {},
+    ): Promise<TResponse> =>
+      request<TResponse>(path, {
+        ...options,
+        body,
+        method: 'PUT',
+      }),
+    request,
+  };
+}
+
+export const apiClient = createApiClient();
+
+async function fetchResponse(
+  fetcher: typeof fetch,
+  url: string,
+  options: FetchResponseOptions,
+): Promise<Response> {
+  const { body, ...requestOptions } = options;
+  const init: RequestInit = { ...requestOptions };
+
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+
+  try {
+    return await fetcher(url, init);
+  } catch (cause: unknown) {
+    throw new ApiError('Network request failed', {
+      bodyErrors: [],
+      cause,
+      kind: 'network',
+    });
+  }
+}
+
+function createHeaders({
+  auth,
+  body,
+  headers,
+}: {
+  auth: boolean;
+  body: unknown;
+  headers?: HeadersInit;
+}): Headers {
+  const requestHeaders = new Headers(headers);
+
+  if (!requestHeaders.has('Accept')) {
+    requestHeaders.set('Accept', 'application/json');
+  }
+
+  if (body !== undefined && !requestHeaders.has('Content-Type')) {
+    requestHeaders.set('Content-Type', 'application/json');
+  }
+
+  const token = getAuthToken();
+
+  if (auth && token !== null && token !== '' && !requestHeaders.has('Authorization')) {
+    requestHeaders.set('Authorization', `Token ${token}`);
+  }
+
+  return requestHeaders;
+}
+
+function resolveUrl(path: string, baseUrl: string): string {
+  if (baseUrl === '') {
+    return path;
+  }
+
+  return new URL(path, normalizeBaseUrl(baseUrl)).toString();
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+}
+
+async function parseSuccessResponse<TResponse>(
+  response: Response,
+): Promise<TResponse> {
+  if (response.status === 204 || !hasJsonContent(response)) {
+    return null as TResponse;
+  }
+
+  return parseJson(response) as Promise<TResponse>;
+}
+
+async function createHttpError(response: Response): Promise<ApiError> {
+  const bodyErrors = hasJsonContent(response)
+    ? extractBodyErrors(await parseJson(response))
+    : [];
+  const kind = getErrorKind(response.status);
+  const message =
+    bodyErrors.at(0) ?? `API request failed with status ${response.status}`;
+
+  return new ApiError(message, {
+    bodyErrors,
+    kind,
+    status: response.status,
+  });
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch (cause: unknown) {
+    throw new ApiError('Unexpected API response', {
+      bodyErrors: [],
+      cause,
+      kind: 'unexpected',
+    });
+  }
+}
+
+function hasJsonContent(response: Response): boolean {
+  return response.headers.get('Content-Type')?.includes('application/json') ?? false;
+}
+
+function getErrorKind(status: number): ApiErrorKind {
+  if (status === 401) {
+    return 'unauthorized';
+  }
+
+  if (status === 403) {
+    return 'forbidden';
+  }
+
+  if (status === 404) {
+    return 'not_found';
+  }
+
+  if (status === 422) {
+    return 'validation';
+  }
+
+  return 'unexpected';
+}
+
+function extractBodyErrors(payload: unknown): string[] {
+  if (!isRecord(payload) || !isRecord(payload.errors)) {
+    return [];
+  }
+
+  const { body } = payload.errors;
+
+  if (!Array.isArray(body)) {
+    return [];
+  }
+
+  return body.filter((entry): entry is string => typeof entry === 'string');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,26 +1,17 @@
-import { ApiError, type ApiErrorKind } from './apiError';
-import { getAuthToken } from './authToken';
+import { createHttpError, parseSuccessResponse } from './apiResponse';
+import {
+  createHeaders,
+  fetchResponse,
+  resolveUrl,
+  type ApiRequestOptions,
+  type ApiRequestOptionsWithMethod,
+} from './apiRequest';
 
 const DEFAULT_API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
 
-interface ApiClientConfig {
+export interface ApiClientConfig {
   baseUrl?: string;
   fetcher?: typeof fetch;
-}
-
-interface ApiRequestOptions {
-  auth?: boolean;
-  body?: unknown;
-  headers?: HeadersInit;
-  signal?: AbortSignal;
-}
-
-interface ApiRequestOptionsWithMethod extends ApiRequestOptions {
-  method?: string;
-}
-
-interface FetchResponseOptions extends Omit<RequestInit, 'body'> {
-  body?: unknown;
 }
 
 export interface ApiClient {
@@ -119,178 +110,3 @@ export function createApiClient(config: ApiClientConfig = {}): ApiClient {
 }
 
 export const apiClient = createApiClient();
-
-/**
- * fetch例外をnetwork ApiErrorに変換し、JSON bodyは送信直前にserializeする。
- */
-async function fetchResponse(
-  fetcher: typeof fetch,
-  url: string,
-  options: FetchResponseOptions,
-): Promise<Response> {
-  const { body, ...requestOptions } = options;
-  const init: RequestInit = { ...requestOptions };
-
-  if (body !== undefined) {
-    init.body = JSON.stringify(body);
-  }
-
-  try {
-    return await fetcher(url, init);
-  } catch (cause: unknown) {
-    throw new ApiError('Network request failed', {
-      bodyErrors: [],
-      cause,
-      kind: 'network',
-    });
-  }
-}
-
-/**
- * JSON APIとして必要な共通ヘッダーとRealWorld形式の認証ヘッダーを組み立てる。
- */
-function createHeaders({
-  auth,
-  body,
-  headers,
-}: {
-  auth: boolean;
-  body: unknown;
-  headers?: HeadersInit;
-}): Headers {
-  const requestHeaders = new Headers(headers);
-
-  if (!requestHeaders.has('Accept')) {
-    requestHeaders.set('Accept', 'application/json');
-  }
-
-  if (body !== undefined && !requestHeaders.has('Content-Type')) {
-    requestHeaders.set('Content-Type', 'application/json');
-  }
-
-  const token = getAuthToken();
-
-  if (auth && token !== null && token !== '' && !requestHeaders.has('Authorization')) {
-    requestHeaders.set('Authorization', `Token ${token}`);
-  }
-
-  return requestHeaders;
-}
-
-/**
- * 環境ごとのbase URL設定とAPI pathを安全に結合する。
- */
-function resolveUrl(path: string, baseUrl: string): string {
-  if (baseUrl === '') {
-    return path;
-  }
-
-  return new URL(path, normalizeBaseUrl(baseUrl)).toString();
-}
-
-/**
- * URL constructorでpath結合するときにpath segmentが欠落しないbase URLへ整える。
- */
-function normalizeBaseUrl(baseUrl: string): string {
-  return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
-}
-
-/**
- * 成功レスポンスをtyped JSONへ変換し、bodyなしレスポンスはnullとして扱う。
- */
-async function parseSuccessResponse<TResponse>(
-  response: Response,
-): Promise<TResponse> {
-  if (response.status === 204 || !hasJsonContent(response)) {
-    return null as TResponse;
-  }
-
-  return parseJson(response) as Promise<TResponse>;
-}
-
-/**
- * HTTP errorレスポンスをfeature層が扱えるtyped ApiErrorへ変換する。
- */
-async function createHttpError(response: Response): Promise<ApiError> {
-  const bodyErrors = hasJsonContent(response)
-    ? extractBodyErrors(await parseJson(response))
-    : [];
-  const kind = getErrorKind(response.status);
-  const message =
-    bodyErrors.at(0) ?? `API request failed with status ${response.status}`;
-
-  return new ApiError(message, {
-    bodyErrors,
-    kind,
-    status: response.status,
-  });
-}
-
-/**
- * JSON parse failureをunexpected ApiErrorとして扱い、raw Responseの解釈をlib内へ閉じ込める。
- */
-async function parseJson(response: Response): Promise<unknown> {
-  try {
-    return await response.json();
-  } catch (cause: unknown) {
-    throw new ApiError('Unexpected API response', {
-      bodyErrors: [],
-      cause,
-      kind: 'unexpected',
-    });
-  }
-}
-
-/**
- * レスポンスbodyをJSONとして読むべきかContent-Typeから判定する。
- */
-function hasJsonContent(response: Response): boolean {
-  return response.headers.get('Content-Type')?.includes('application/json') ?? false;
-}
-
-/**
- * HTTP status codeを画面・Provider側で分岐しやすいApiError kindへ対応付ける。
- */
-function getErrorKind(status: number): ApiErrorKind {
-  if (status === 401) {
-    return 'unauthorized';
-  }
-
-  if (status === 403) {
-    return 'forbidden';
-  }
-
-  if (status === 404) {
-    return 'not_found';
-  }
-
-  if (status === 422) {
-    return 'validation';
-  }
-
-  return 'unexpected';
-}
-
-/**
- * RealWorld形式のerrors.bodyだけをform/global errorへ渡せる文字列配列として取り出す。
- */
-function extractBodyErrors(payload: unknown): string[] {
-  if (!isRecord(payload) || !isRecord(payload.errors)) {
-    return [];
-  }
-
-  const { body } = payload.errors;
-
-  if (!Array.isArray(body)) {
-    return [];
-  }
-
-  return body.filter((entry): entry is string => typeof entry === 'string');
-}
-
-/**
- * unknown payloadをproperty access可能なrecordへ絞り込む。
- */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}

--- a/frontend/src/lib/apiError.ts
+++ b/frontend/src/lib/apiError.ts
@@ -1,0 +1,32 @@
+export type ApiErrorKind =
+  | 'forbidden'
+  | 'network'
+  | 'not_found'
+  | 'unauthorized'
+  | 'unexpected'
+  | 'validation';
+
+interface ApiErrorDetails {
+  bodyErrors?: string[];
+  cause?: unknown;
+  kind: ApiErrorKind;
+  status?: number;
+}
+
+export class ApiError extends Error {
+  readonly bodyErrors: string[];
+  readonly kind: ApiErrorKind;
+  readonly status?: number;
+
+  constructor(message: string, details: ApiErrorDetails) {
+    super(message, { cause: details.cause });
+    this.name = 'ApiError';
+    this.bodyErrors = details.bodyErrors ?? [];
+    this.kind = details.kind;
+    this.status = details.status;
+  }
+}
+
+export function isApiError(error: unknown): error is ApiError {
+  return error instanceof ApiError;
+}

--- a/frontend/src/lib/apiError.ts
+++ b/frontend/src/lib/apiError.ts
@@ -13,6 +13,9 @@ interface ApiErrorDetails {
   status?: number;
 }
 
+/**
+ * API clientが返す失敗をHTTP statusや原因別に扱えるtyped errorとして表す。
+ */
 export class ApiError extends Error {
   readonly bodyErrors: string[];
   readonly kind: ApiErrorKind;
@@ -27,6 +30,9 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * unknown errorをApiErrorとして扱えるか判定する。
+ */
 export function isApiError(error: unknown): error is ApiError {
   return error instanceof ApiError;
 }

--- a/frontend/src/lib/apiRequest.ts
+++ b/frontend/src/lib/apiRequest.ts
@@ -1,0 +1,92 @@
+import { ApiError } from './apiError';
+import { getAuthToken } from './authToken';
+
+export interface ApiRequestOptions {
+  auth?: boolean;
+  body?: unknown;
+  headers?: HeadersInit;
+  signal?: AbortSignal;
+}
+
+export interface ApiRequestOptionsWithMethod extends ApiRequestOptions {
+  method?: string;
+}
+
+interface FetchResponseOptions extends Omit<RequestInit, 'body'> {
+  body?: unknown;
+}
+
+/**
+ * fetch例外をnetwork ApiErrorに変換し、JSON bodyは送信直前にserializeする。
+ */
+export async function fetchResponse(
+  fetcher: typeof fetch,
+  url: string,
+  options: FetchResponseOptions,
+): Promise<Response> {
+  const { body, ...requestOptions } = options;
+  const init: RequestInit = { ...requestOptions };
+
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+
+  try {
+    return await fetcher(url, init);
+  } catch (cause: unknown) {
+    throw new ApiError('Network request failed', {
+      bodyErrors: [],
+      cause,
+      kind: 'network',
+    });
+  }
+}
+
+/**
+ * JSON APIとして必要な共通ヘッダーとRealWorld形式の認証ヘッダーを組み立てる。
+ */
+export function createHeaders({
+  auth,
+  body,
+  headers,
+}: {
+  auth: boolean;
+  body: unknown;
+  headers?: HeadersInit;
+}): Headers {
+  const requestHeaders = new Headers(headers);
+
+  if (!requestHeaders.has('Accept')) {
+    requestHeaders.set('Accept', 'application/json');
+  }
+
+  if (body !== undefined && !requestHeaders.has('Content-Type')) {
+    requestHeaders.set('Content-Type', 'application/json');
+  }
+
+  const token = getAuthToken();
+
+  if (auth && token !== null && token !== '' && !requestHeaders.has('Authorization')) {
+    requestHeaders.set('Authorization', `Token ${token}`);
+  }
+
+  return requestHeaders;
+}
+
+/**
+ * 環境ごとのbase URL設定とAPI pathを安全に結合する。
+ */
+export function resolveUrl(path: string, baseUrl: string): string {
+  if (baseUrl === '') {
+    return path;
+  }
+
+  return new URL(path, normalizeBaseUrl(baseUrl)).toString();
+}
+
+/**
+ * URL constructorでpath結合するときにpath segmentが欠落しないbase URLへ整える。
+ */
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+}

--- a/frontend/src/lib/apiResponse.ts
+++ b/frontend/src/lib/apiResponse.ts
@@ -1,0 +1,105 @@
+import { ApiError, type ApiErrorKind } from './apiError';
+
+/**
+ * 成功レスポンスをtyped JSONへ変換し、bodyなしレスポンスはnullとして扱う。
+ */
+export async function parseSuccessResponse<TResponse>(
+  response: Response,
+): Promise<TResponse> {
+  if (response.status === 204 || !hasJsonContent(response)) {
+    // 204/no-body endpointは呼び出し側がTResponseにnullを指定する前提で扱う。
+    return null as TResponse;
+  }
+
+  const payload = await parseJson(response);
+
+  // endpoint固有のresponse shapeはfeature API側のTResponse指定で境界を作る。
+  return payload as TResponse;
+}
+
+/**
+ * HTTP errorレスポンスをfeature層が扱えるtyped ApiErrorへ変換する。
+ */
+export async function createHttpError(response: Response): Promise<ApiError> {
+  const bodyErrors = hasJsonContent(response)
+    ? extractBodyErrors(await parseJson(response))
+    : [];
+  const kind = getErrorKind(response.status);
+  const message =
+    bodyErrors.at(0) ?? `API request failed with status ${response.status}`;
+
+  return new ApiError(message, {
+    bodyErrors,
+    kind,
+    status: response.status,
+  });
+}
+
+/**
+ * JSON parse failureをunexpected ApiErrorとして扱い、raw Responseの解釈をlib内へ閉じ込める。
+ */
+async function parseJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch (cause: unknown) {
+    throw new ApiError('Unexpected API response', {
+      bodyErrors: [],
+      cause,
+      kind: 'unexpected',
+    });
+  }
+}
+
+/**
+ * レスポンスbodyをJSONとして読むべきかContent-Typeから判定する。
+ */
+function hasJsonContent(response: Response): boolean {
+  return response.headers.get('Content-Type')?.includes('application/json') ?? false;
+}
+
+/**
+ * HTTP status codeを画面・Provider側で分岐しやすいApiError kindへ対応付ける。
+ */
+function getErrorKind(status: number): ApiErrorKind {
+  if (status === 401) {
+    return 'unauthorized';
+  }
+
+  if (status === 403) {
+    return 'forbidden';
+  }
+
+  if (status === 404) {
+    return 'not_found';
+  }
+
+  if (status === 422) {
+    return 'validation';
+  }
+
+  return 'unexpected';
+}
+
+/**
+ * RealWorld形式のerrors.bodyだけをform/global errorへ渡せる文字列配列として取り出す。
+ */
+function extractBodyErrors(payload: unknown): string[] {
+  if (!isRecord(payload) || !isRecord(payload.errors)) {
+    return [];
+  }
+
+  const { body } = payload.errors;
+
+  if (!Array.isArray(body)) {
+    return [];
+  }
+
+  return body.filter((entry): entry is string => typeof entry === 'string');
+}
+
+/**
+ * unknown payloadをproperty access可能なrecordへ絞り込む。
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/frontend/src/lib/authToken.ts
+++ b/frontend/src/lib/authToken.ts
@@ -1,0 +1,27 @@
+const AUTH_TOKEN_STORAGE_KEY = 'realworld.authToken';
+
+interface AuthTokenStorage {
+  getItem: (key: string) => string | null;
+  removeItem: (key: string) => void;
+  setItem: (key: string, value: string) => void;
+}
+
+function getStorage(): AuthTokenStorage | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  return window.localStorage;
+}
+
+export function getAuthToken(): string | null {
+  return getStorage()?.getItem(AUTH_TOKEN_STORAGE_KEY) ?? null;
+}
+
+export function setAuthToken(token: string): void {
+  getStorage()?.setItem(AUTH_TOKEN_STORAGE_KEY, token);
+}
+
+export function clearAuthToken(): void {
+  getStorage()?.removeItem(AUTH_TOKEN_STORAGE_KEY);
+}

--- a/frontend/src/lib/authToken.ts
+++ b/frontend/src/lib/authToken.ts
@@ -6,6 +6,9 @@ interface AuthTokenStorage {
   setItem: (key: string, value: string) => void;
 }
 
+/**
+ * SSRやテスト環境でwindowがない場合にtoken storageへ触らないようにする。
+ */
 function getStorage(): AuthTokenStorage | null {
   if (typeof window === 'undefined') {
     return null;
@@ -14,14 +17,23 @@ function getStorage(): AuthTokenStorage | null {
   return window.localStorage;
 }
 
+/**
+ * API clientが送信時点の認証トークンを取得する。
+ */
 export function getAuthToken(): string | null {
   return getStorage()?.getItem(AUTH_TOKEN_STORAGE_KEY) ?? null;
 }
 
+/**
+ * login/register成功後にRealWorld API tokenを保存する。
+ */
 export function setAuthToken(token: string): void {
   getStorage()?.setItem(AUTH_TOKEN_STORAGE_KEY, token);
 }
 
+/**
+ * logoutやinvalid token検出時に保存済み認証トークンを削除する。
+ */
 export function clearAuthToken(): void {
   getStorage()?.removeItem(AUTH_TOKEN_STORAGE_KEY);
 }

--- a/specs/_template-feature-spec.md
+++ b/specs/_template-feature-spec.md
@@ -102,6 +102,21 @@ features/<feature>/
 └── index.ts
 ```
 
+### React 設計確認
+
+- Component hierarchy:
+  -
+- 関心の分離 / 単一責任:
+  -
+- 最小 state:
+  -
+- State 所有者:
+  -
+- Derived data を state にしていないか:
+  -
+- Props / data flow:
+  -
+
 ### コンポーネント分割
 
 | コンポーネント | 責務 | Props |


### PR DESCRIPTION
## 概要

- Frontend 共通の `apiClient` を追加
- `Authorization: Token <token>` の付与を `apiClient` に集約
- `authToken` で token persistence を抽象化
- 401 / 403 / 404 / 422 / network failure / parse failure を typed `ApiError` に正規化

## 関連 Issue

Closes #64

## テスト計画

- [x] フロントエンド: `pnpm tsc -b --noEmit`
- [x] フロントエンド: `pnpm vitest run`
- [x] フロントエンド: `pnpm eslint .`
- [x] バックエンド: 対象外
