### PR TITLE
chore: Xdebug trigger起動とdevcontainer設定を整備 (#115)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,8 @@
       "extensions": [
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
-        "eamodio.gitlens"
+        "eamodio.gitlens",
+        "xdebug.php-debug"
       ],
       "settings": {
         "editor.formatOnSave": true,

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,10 @@
 services:
+  backend-php:
+    environment:
+      XDEBUG_MODE: "${XDEBUG_MODE:-develop,debug}"
+      XDEBUG_START_WITH_REQUEST: "${XDEBUG_START_WITH_REQUEST:-trigger}"
+      XDEBUG_CONFIG: "client_host=devcontainer client_port=9003"
+
   devcontainer:
     build:
       context: .devcontainer

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for Xdebug (backend-php)",
+      "type": "php",
+      "request": "launch",
+      "port": 9003,
+      "hostname": "0.0.0.0",
+      "pathMappings": {
+        "/var/www/html": "${workspaceFolder}/backend"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -56,6 +56,32 @@ docker compose down
 | バックエンド API | http://localhost:8080 |
 | Mailpit | http://localhost:8025 |
 
+## バックエンドのデバッグ
+
+Xdebug は通常の Docker 起動では `XDEBUG_MODE=off` のため、リクエストへ介入しません。
+devcontainer では `XDEBUG_TRIGGER` を指定したときだけデバッグセッションを開始します。
+
+VS Code の devcontainer でデバッグする場合:
+
+1. VS Code の Run and Debug で `Listen for Xdebug (backend-php)` を開始する
+2. trigger 付きで backend API へリクエストする
+
+```bash
+curl -H 'XDEBUG_TRIGGER: 1' http://localhost:8080/api/health
+```
+
+CLI で artisan やテストをデバッグする場合:
+
+```bash
+docker compose exec -e XDEBUG_TRIGGER=1 backend-php php artisan test
+```
+
+devcontainer 外で Xdebug を有効にする場合は、明示的に `XDEBUG_MODE` を指定して起動します。
+
+```bash
+XDEBUG_MODE=develop,debug docker compose up -d backend-php backend-nginx
+```
+
 ## テスト・リント
 
 フロントエンド:

--- a/compose.yml
+++ b/compose.yml
@@ -25,6 +25,8 @@ services:
       - ./backend:/var/www/html
     environment:
       XDEBUG_MODE: "off"
+      XDEBUG_START_WITH_REQUEST: "trigger"
+      XDEBUG_CONFIG: "client_host=host.docker.internal client_port=9003"
     depends_on:
       - db
     extra_hosts:

--- a/docker/backend/php/xdebug.ini
+++ b/docker/backend/php/xdebug.ini
@@ -1,5 +1,5 @@
 [xdebug]
 xdebug.mode=${XDEBUG_MODE:-develop,debug}
-xdebug.start_with_request=yes
+xdebug.start_with_request=${XDEBUG_START_WITH_REQUEST:-trigger}
 xdebug.client_host=host.docker.internal
 xdebug.client_port=9003

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "prepare": "husky"
+    "prepare": "husky",
+    "test:infra": "node --test tests/*.test.mjs"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.0",

--- a/tests/devcontainer-xdebug.test.mjs
+++ b/tests/devcontainer-xdebug.test.mjs
@@ -12,6 +12,32 @@ const readJson = (path) =>
 
 const readText = (path) => readFileSync(resolve(repoRoot, path), "utf8");
 
+const composeConfig = (files) => {
+  const args = files.flatMap((file) => ["-f", file]);
+
+  return JSON.parse(
+    execFileSync(
+      "docker",
+      [
+        "compose",
+        ...args,
+        "config",
+        "--format",
+        "json",
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          XDEBUG_MODE: "",
+          XDEBUG_START_WITH_REQUEST: "",
+        },
+      },
+    ),
+  );
+};
+
 const normalizeEnvironment = (environment) => {
   if (Array.isArray(environment)) {
     return Object.fromEntries(
@@ -26,24 +52,21 @@ const normalizeEnvironment = (environment) => {
   return environment ?? {};
 };
 
-test("devcontainer compose enables backend Xdebug only by trigger", () => {
-  const resolvedConfig = JSON.parse(
-    execFileSync(
-      "docker",
-      [
-        "compose",
-        "-f",
-        "compose.yml",
-        "-f",
-        ".devcontainer/docker-compose.yml",
-        "config",
-        "--format",
-        "json",
-      ],
-      { cwd: repoRoot, encoding: "utf8" },
-    ),
-  );
+test("default compose keeps backend Xdebug disabled and trigger-gated", () => {
+  const resolvedConfig = composeConfig(["compose.yml"]);
+  const backendPhp = resolvedConfig.services["backend-php"];
+  const environment = normalizeEnvironment(backendPhp.environment);
 
+  assert.equal(environment.XDEBUG_MODE, "off");
+  assert.equal(environment.XDEBUG_START_WITH_REQUEST, "trigger");
+  assert.equal(environment.XDEBUG_CONFIG, "client_host=host.docker.internal client_port=9003");
+});
+
+test("devcontainer compose enables backend Xdebug only by trigger", () => {
+  const resolvedConfig = composeConfig([
+    "compose.yml",
+    ".devcontainer/docker-compose.yml",
+  ]);
   const backendPhp = resolvedConfig.services["backend-php"];
   const environment = normalizeEnvironment(backendPhp.environment);
 

--- a/tests/devcontainer-xdebug.test.mjs
+++ b/tests/devcontainer-xdebug.test.mjs
@@ -59,7 +59,10 @@ test("default compose keeps backend Xdebug disabled and trigger-gated", () => {
 
   assert.equal(environment.XDEBUG_MODE, "off");
   assert.equal(environment.XDEBUG_START_WITH_REQUEST, "trigger");
-  assert.equal(environment.XDEBUG_CONFIG, "client_host=host.docker.internal client_port=9003");
+  assert.equal(
+    environment.XDEBUG_CONFIG,
+    "client_host=host.docker.internal client_port=9003",
+  );
 });
 
 test("devcontainer compose enables backend Xdebug only by trigger", () => {
@@ -72,7 +75,10 @@ test("devcontainer compose enables backend Xdebug only by trigger", () => {
 
   assert.equal(environment.XDEBUG_MODE, "develop,debug");
   assert.equal(environment.XDEBUG_START_WITH_REQUEST, "trigger");
-  assert.equal(environment.XDEBUG_CONFIG, "client_host=devcontainer client_port=9003");
+  assert.equal(
+    environment.XDEBUG_CONFIG,
+    "client_host=devcontainer client_port=9003",
+  );
 });
 
 test("PHP Xdebug ini defaults to trigger start", () => {

--- a/tests/devcontainer-xdebug.test.mjs
+++ b/tests/devcontainer-xdebug.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const readJson = (path) =>
+  JSON.parse(readFileSync(resolve(repoRoot, path), "utf8"));
+
+const readText = (path) => readFileSync(resolve(repoRoot, path), "utf8");
+
+const normalizeEnvironment = (environment) => {
+  if (Array.isArray(environment)) {
+    return Object.fromEntries(
+      environment.map((entry) => {
+        const [key, ...valueParts] = entry.split("=");
+
+        return [key, valueParts.join("=")];
+      }),
+    );
+  }
+
+  return environment ?? {};
+};
+
+test("devcontainer compose enables backend Xdebug only by trigger", () => {
+  const resolvedConfig = JSON.parse(
+    execFileSync(
+      "docker",
+      [
+        "compose",
+        "-f",
+        "compose.yml",
+        "-f",
+        ".devcontainer/docker-compose.yml",
+        "config",
+        "--format",
+        "json",
+      ],
+      { cwd: repoRoot, encoding: "utf8" },
+    ),
+  );
+
+  const backendPhp = resolvedConfig.services["backend-php"];
+  const environment = normalizeEnvironment(backendPhp.environment);
+
+  assert.equal(environment.XDEBUG_MODE, "develop,debug");
+  assert.equal(environment.XDEBUG_START_WITH_REQUEST, "trigger");
+  assert.equal(environment.XDEBUG_CONFIG, "client_host=devcontainer client_port=9003");
+});
+
+test("PHP Xdebug ini defaults to trigger start", () => {
+  const xdebugIni = readText("docker/backend/php/xdebug.ini");
+
+  assert.match(
+    xdebugIni,
+    /^xdebug\.start_with_request=\$\{XDEBUG_START_WITH_REQUEST:-trigger\}$/m,
+  );
+  assert.doesNotMatch(xdebugIni, /^xdebug\.start_with_request=yes$/m);
+});
+
+test("devcontainer installs PHP debug support", () => {
+  const devcontainer = readJson(".devcontainer/devcontainer.json");
+  const extensions = devcontainer.customizations.vscode.extensions;
+
+  assert.ok(extensions.includes("xdebug.php-debug"));
+});
+
+test("VS Code listens for backend PHP Xdebug sessions", () => {
+  const launch = readJson(".vscode/launch.json");
+  const configuration = launch.configurations.find(
+    (candidate) =>
+      candidate.type === "php" &&
+      candidate.request === "launch" &&
+      candidate.port === 9003,
+  );
+
+  assert.ok(configuration, "expected a PHP launch listener on port 9003");
+  assert.equal(configuration.hostname, "0.0.0.0");
+  assert.equal(
+    configuration.pathMappings["/var/www/html"],
+    "${workspaceFolder}/backend",
+  );
+});


### PR DESCRIPTION
## 概要

- `backend-php` の Xdebug 設定を通常起動では `off`、devcontainer では `develop,debug` + trigger 起動に分離
- VS Code の PHP Debug 拡張と `.vscode/launch.json` の listen / path mapping を追加
- Docker Compose の実効設定と Xdebug/devcontainer 設定を検証する `test:infra` を追加
- README に Xdebug trigger を使った Web / CLI デバッグ手順を追加

## 関連 Issue

Closes #115

## テスト計画

- [x] `pnpm test:infra`
- [x] `docker compose config`
- [x] `docker compose -f compose.yml -f .devcontainer/docker-compose.yml config`
- [x] `git diff --check HEAD`
- [x] README のデバッグ手順確認
- [ ] backend container 起動 / trigger ありの実デバッグ接続確認（既存 `real-world` compose project への副作用を避けるため未実行）