### PR TITLE
feat: 現在ユーザー取得・更新APIを実装 (#66)

### DIFF
--- a/backend/app/Application/Identity/Commands/UpdateCurrentUserCommand.php
+++ b/backend/app/Application/Identity/Commands/UpdateCurrentUserCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Identity\Commands;
+
+use App\Application\Identity\DTOs\UpdateCurrentUserDto;
+use App\Application\Identity\Services\PasswordHasherInterface;
+use App\Domain\Identity\Entities\User;
+use App\Domain\Identity\Repositories\UserRepositoryInterface;
+use App\Domain\Identity\ValueObjects\Bio;
+use App\Domain\Identity\ValueObjects\Email;
+use App\Domain\Identity\ValueObjects\HashedPassword;
+use App\Domain\Identity\ValueObjects\Image;
+use App\Domain\Identity\ValueObjects\UserId;
+use App\Domain\Identity\ValueObjects\Username;
+use DomainException;
+use Illuminate\Support\Facades\DB;
+
+final readonly class UpdateCurrentUserCommand
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private PasswordHasherInterface $passwords,
+    ) {}
+
+    /**
+     * 現在 User の Identity 情報と profile fields を更新する。
+     */
+    public function execute(int $userId, UpdateCurrentUserDto $dto): User
+    {
+        $id = new UserId($userId);
+        $currentUser = $this->users->findById($id);
+
+        if ($currentUser === null) {
+            throw new DomainException('user not found');
+        }
+
+        $email = $dto->email === null ? $currentUser->email() : new Email($dto->email);
+        $username = $dto->username === null ? $currentUser->username() : new Username($dto->username);
+
+        if ($dto->email !== null && $this->users->emailExistsExceptUser($email, $id)) {
+            throw new DomainException('email has already been taken');
+        }
+
+        if ($dto->username !== null && $this->users->usernameExistsExceptUser($username, $id)) {
+            throw new DomainException('username has already been taken');
+        }
+
+        $passwordHash = $dto->password !== null
+            ? new HashedPassword($this->passwords->make($dto->password))
+            : $currentUser->passwordHash();
+
+        $updatedUser = $currentUser->withUpdatedIdentity(
+            username: $username,
+            email: $email,
+            passwordHash: $passwordHash,
+            bio: $dto->hasBio ? new Bio($dto->bio) : $currentUser->bio(),
+            image: $dto->hasImage ? new Image($dto->image) : $currentUser->image(),
+        );
+
+        return DB::transaction(fn (): User => $this->users->update($updatedUser));
+    }
+}

--- a/backend/app/Application/Identity/DTOs/UpdateCurrentUserDto.php
+++ b/backend/app/Application/Identity/DTOs/UpdateCurrentUserDto.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Identity\DTOs;
+
+final readonly class UpdateCurrentUserDto
+{
+    public function __construct(
+        public ?string $email,
+        public ?string $username,
+        public ?string $password,
+        public bool $hasBio,
+        public ?string $bio,
+        public bool $hasImage,
+        public ?string $image,
+    ) {}
+}

--- a/backend/app/Application/Identity/Queries/GetCurrentUserQuery.php
+++ b/backend/app/Application/Identity/Queries/GetCurrentUserQuery.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Identity\Queries;
+
+use App\Domain\Identity\Entities\User;
+use App\Domain\Identity\Repositories\UserRepositoryInterface;
+use App\Domain\Identity\ValueObjects\UserId;
+use DomainException;
+
+final readonly class GetCurrentUserQuery
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {}
+
+    /**
+     * 認証済み User ID に一致する現在 User を取得する。
+     */
+    public function execute(int $userId): User
+    {
+        $user = $this->users->findById(new UserId($userId));
+
+        if ($user === null) {
+            throw new DomainException('user not found');
+        }
+
+        return $user;
+    }
+}

--- a/backend/app/Domain/Identity/Entities/User.php
+++ b/backend/app/Domain/Identity/Entities/User.php
@@ -52,6 +52,26 @@ final readonly class User
         );
     }
 
+    /**
+     * 更新後の Identity 情報と profile fields を持つ User として複製する。
+     */
+    public function withUpdatedIdentity(
+        Username $username,
+        Email $email,
+        HashedPassword $passwordHash,
+        Bio $bio,
+        Image $image,
+    ): self {
+        return new self(
+            id: $this->id,
+            username: $username,
+            email: $email,
+            passwordHash: $passwordHash,
+            bio: $bio,
+            image: $image,
+        );
+    }
+
     public function id(): ?UserId
     {
         return $this->id;

--- a/backend/app/Domain/Identity/Repositories/UserRepositoryInterface.php
+++ b/backend/app/Domain/Identity/Repositories/UserRepositoryInterface.php
@@ -6,10 +6,16 @@ namespace App\Domain\Identity\Repositories;
 
 use App\Domain\Identity\Entities\User;
 use App\Domain\Identity\ValueObjects\Email;
+use App\Domain\Identity\ValueObjects\UserId;
 use App\Domain\Identity\ValueObjects\Username;
 
 interface UserRepositoryInterface
 {
+    /**
+     * ID に一致する User を取得する。
+     */
+    public function findById(UserId $id): ?User;
+
     /**
      * Email に一致する User を取得する。
      */
@@ -21,12 +27,27 @@ interface UserRepositoryInterface
     public function emailExists(Email $email): bool;
 
     /**
+     * 指定 User を除き、Email が登録済みか確認する。
+     */
+    public function emailExistsExceptUser(Email $email, UserId $exceptUserId): bool;
+
+    /**
      * Username が登録済みか確認する。
      */
     public function usernameExists(Username $username): bool;
 
     /**
+     * 指定 User を除き、Username が登録済みか確認する。
+     */
+    public function usernameExistsExceptUser(Username $username, UserId $exceptUserId): bool;
+
+    /**
      * User を永続化し、採番済み ID を含む Entity を返す。
      */
     public function save(User $user): User;
+
+    /**
+     * 既存 User を更新し、更新後の Entity を返す。
+     */
+    public function update(User $user): User;
 }

--- a/backend/app/Infrastructure/Persistence/Repositories/EloquentUserRepository.php
+++ b/backend/app/Infrastructure/Persistence/Repositories/EloquentUserRepository.php
@@ -13,9 +13,20 @@ use App\Domain\Identity\ValueObjects\Image;
 use App\Domain\Identity\ValueObjects\UserId;
 use App\Domain\Identity\ValueObjects\Username;
 use App\Infrastructure\Persistence\Models\User as UserModel;
+use InvalidArgumentException;
 
 final class EloquentUserRepository implements UserRepositoryInterface
 {
+    /**
+     * ID に一致する User を取得する。
+     */
+    public function findById(UserId $id): ?User
+    {
+        $model = UserModel::query()->find($id->value);
+
+        return $model instanceof UserModel ? $this->toEntity($model) : null;
+    }
+
     /**
      * Email に一致する User を取得する。
      */
@@ -39,6 +50,17 @@ final class EloquentUserRepository implements UserRepositoryInterface
     }
 
     /**
+     * 指定 User を除き、Email が登録済みか確認する。
+     */
+    public function emailExistsExceptUser(Email $email, UserId $exceptUserId): bool
+    {
+        return UserModel::query()
+            ->where('email', $email->value)
+            ->whereKeyNot($exceptUserId->value)
+            ->exists();
+    }
+
+    /**
      * Username が登録済みか確認する。
      */
     public function usernameExists(Username $username): bool
@@ -49,11 +71,46 @@ final class EloquentUserRepository implements UserRepositoryInterface
     }
 
     /**
+     * 指定 User を除き、Username が登録済みか確認する。
+     */
+    public function usernameExistsExceptUser(Username $username, UserId $exceptUserId): bool
+    {
+        return UserModel::query()
+            ->where('username', $username->value)
+            ->whereKeyNot($exceptUserId->value)
+            ->exists();
+    }
+
+    /**
      * User を永続化し、採番済み ID を含む Entity を返す。
      */
     public function save(User $user): User
     {
         $model = new UserModel;
+        $model->fill([
+            'username' => $user->username()->value,
+            'email' => $user->email()->value,
+            'password_hash' => $user->passwordHash()->value,
+            'bio' => $user->bio()->value,
+            'image' => $user->image()->value,
+        ]);
+        $model->save();
+
+        return $this->toEntity($model);
+    }
+
+    /**
+     * 既存 User を更新し、更新後の Entity を返す。
+     */
+    public function update(User $user): User
+    {
+        $id = $user->id();
+
+        if ($id === null) {
+            throw new InvalidArgumentException('Cannot update an unsaved user.');
+        }
+
+        $model = UserModel::query()->findOrFail($id->value);
         $model->fill([
             'username' => $user->username()->value,
             'email' => $user->email()->value,

--- a/backend/app/Presentation/Http/Controllers/Identity/CurrentUserController.php
+++ b/backend/app/Presentation/Http/Controllers/Identity/CurrentUserController.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Controllers\Identity;
+
+use App\Application\Identity\Commands\UpdateCurrentUserCommand;
+use App\Application\Identity\DTOs\AuthenticatedUserDto;
+use App\Application\Identity\Queries\GetCurrentUserQuery;
+use App\Domain\Identity\Entities\User;
+use App\Presentation\Http\Controllers\Controller;
+use App\Presentation\Http\Requests\Identity\UpdateCurrentUserRequest;
+use App\Presentation\Http\Resources\Identity\UserResource;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CurrentUserController extends Controller
+{
+    /**
+     * 現在 User を RealWorld user wrapper で返す。
+     */
+    public function show(Request $request, GetCurrentUserQuery $query): JsonResponse
+    {
+        return $this->userResponse(
+            request: $request,
+            user: $query->execute($this->authenticatedUserId($request)),
+        );
+    }
+
+    /**
+     * 現在 User を更新し、更新後の User を RealWorld user wrapper で返す。
+     */
+    public function update(UpdateCurrentUserRequest $request, UpdateCurrentUserCommand $command): JsonResponse
+    {
+        return $this->userResponse(
+            request: $request,
+            user: $command->execute($this->authenticatedUserId($request), $request->toDto()),
+        );
+    }
+
+    /**
+     * 認証済み User の ID を取得する。
+     */
+    private function authenticatedUserId(Request $request): int
+    {
+        $userId = $request->user()?->getAuthIdentifier();
+
+        if (! is_numeric($userId)) {
+            throw new AuthenticationException;
+        }
+
+        return (int) $userId;
+    }
+
+    /**
+     * 現在の bearer token を含む RealWorld user response を生成する。
+     */
+    private function userResponse(Request $request, User $user): JsonResponse
+    {
+        $token = $request->bearerToken();
+
+        if ($token === null || $token === '') {
+            throw new AuthenticationException;
+        }
+
+        return (new UserResource(new AuthenticatedUserDto(
+            user: $user,
+            token: $token,
+        )))
+            ->response()
+            ->setStatusCode(Response::HTTP_OK);
+    }
+}

--- a/backend/app/Presentation/Http/Requests/Identity/UpdateCurrentUserRequest.php
+++ b/backend/app/Presentation/Http/Requests/Identity/UpdateCurrentUserRequest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Requests\Identity;
+
+use App\Application\Identity\DTOs\UpdateCurrentUserDto;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class UpdateCurrentUserRequest extends FormRequest
+{
+    /**
+     * 認証済み User が自身の情報を更新するリクエストとして許可する。
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * RealWorld update user request の nested user payload を検証する。
+     *
+     * @return array<string, list<mixed>>
+     */
+    public function rules(): array
+    {
+        $userId = $this->user()?->getAuthIdentifier();
+
+        return [
+            'user' => ['required', 'array'],
+            'user.email' => ['sometimes', 'email', 'max:255', Rule::unique('users', 'email')->ignore($userId)],
+            'user.username' => ['sometimes', 'string', 'max:50', Rule::unique('users', 'username')->ignore($userId)],
+            'user.password' => ['sometimes', 'string', 'min:6'],
+            'user.bio' => ['sometimes', 'nullable', 'string', 'max:1000'],
+            'user.image' => ['sometimes', 'nullable', 'url', 'max:2048'],
+        ];
+    }
+
+    /**
+     * 検証済み payload を Application DTO へ変換する。
+     */
+    public function toDto(): UpdateCurrentUserDto
+    {
+        /** @var array{user: array{email?: string, username?: string, password?: string, bio?: string|null, image?: string|null}} $payload */
+        $payload = $this->validated();
+        $user = $payload['user'];
+
+        return new UpdateCurrentUserDto(
+            email: $user['email'] ?? null,
+            username: $user['username'] ?? null,
+            password: $user['password'] ?? null,
+            hasBio: array_key_exists('bio', $user),
+            bio: $user['bio'] ?? null,
+            hasImage: array_key_exists('image', $user),
+            image: $user['image'] ?? null,
+        );
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,12 +1,13 @@
 <?php
 
 use App\Presentation\Http\Controllers\Identity\AuthController;
-use Illuminate\Http\Request;
+use App\Presentation\Http\Controllers\Identity\CurrentUserController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/users', [AuthController::class, 'register']);
 Route::post('/users/login', [AuthController::class, 'login']);
 
-Route::get('/user', function (Request $request) {
-    return $request->user();
-})->middleware('auth:sanctum');
+Route::middleware('auth:sanctum')->group(function (): void {
+    Route::get('/user', [CurrentUserController::class, 'show']);
+    Route::put('/user', [CurrentUserController::class, 'update']);
+});

--- a/backend/tests/Feature/Identity/CurrentUserApiTest.php
+++ b/backend/tests/Feature/Identity/CurrentUserApiTest.php
@@ -9,11 +9,6 @@ use Tests\TestCase;
 
 uses(TestCase::class, RefreshDatabase::class);
 
-function realWorldTokenFor(User $user): string
-{
-    return $user->createToken('api')->plainTextToken;
-}
-
 describe('GET /api/user', function (): void {
     it('未認証リクエストを401で拒否する', function (): void {
         $this->getJson('/api/user')
@@ -28,9 +23,9 @@ describe('GET /api/user', function (): void {
             'bio' => 'I like APIs',
             'image' => 'https://example.com/avatar.png',
         ]);
-        $token = realWorldTokenFor($user);
+        $token = $this->issueRealWorldTokenFor($user);
 
-        $this->withHeaders(['Authorization' => 'Token '.$token])
+        $this->withRealWorldToken($token)
             ->getJson('/api/user')
             ->assertOk()
             ->assertExactJson([
@@ -64,9 +59,9 @@ describe('PUT /api/user', function (): void {
             'bio' => null,
             'image' => null,
         ]);
-        $token = realWorldTokenFor($user);
+        $token = $this->issueRealWorldTokenFor($user);
 
-        $this->withHeaders(['Authorization' => 'Token '.$token])
+        $this->withRealWorldToken($token)
             ->putJson('/api/user', [
                 'user' => [
                     'email' => 'new-jake@example.com',
@@ -104,9 +99,9 @@ describe('PUT /api/user', function (): void {
             'bio' => 'I like APIs',
             'image' => 'https://example.com/avatar.png',
         ]);
-        $token = realWorldTokenFor($user);
+        $token = $this->issueRealWorldTokenFor($user);
 
-        $this->withHeaders(['Authorization' => 'Token '.$token])
+        $this->withRealWorldToken($token)
             ->putJson('/api/user', [
                 'user' => [
                     'bio' => null,
@@ -131,9 +126,9 @@ describe('PUT /api/user', function (): void {
             'email' => 'jake@example.com',
             'bio' => null,
         ]);
-        $token = realWorldTokenFor($user);
+        $token = $this->issueRealWorldTokenFor($user);
 
-        $this->withHeaders(['Authorization' => 'Token '.$token])
+        $this->withRealWorldToken($token)
             ->putJson('/api/user', [
                 'user' => [
                     'email' => 'jake@example.com',
@@ -156,9 +151,9 @@ describe('PUT /api/user', function (): void {
             'username' => 'jake',
             'email' => 'jake@example.com',
         ]);
-        $token = realWorldTokenFor($user);
+        $token = $this->issueRealWorldTokenFor($user);
 
-        $response = $this->withHeaders(['Authorization' => 'Token '.$token])
+        $response = $this->withRealWorldToken($token)
             ->putJson('/api/user', [
                 'user' => [
                     'email' => 'existing@example.com',

--- a/backend/tests/Feature/Identity/CurrentUserApiTest.php
+++ b/backend/tests/Feature/Identity/CurrentUserApiTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Infrastructure\Persistence\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+function realWorldTokenFor(User $user): string
+{
+    return $user->createToken('api')->plainTextToken;
+}
+
+describe('GET /api/user', function (): void {
+    it('未認証リクエストを401で拒否する', function (): void {
+        $this->getJson('/api/user')
+            ->assertUnauthorized()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+
+    it('認証済みUserをRealWorld user wrapperで返す', function (): void {
+        $user = User::factory()->create([
+            'username' => 'jake',
+            'email' => 'jake@example.com',
+            'bio' => 'I like APIs',
+            'image' => 'https://example.com/avatar.png',
+        ]);
+        $token = realWorldTokenFor($user);
+
+        $this->withHeaders(['Authorization' => 'Token '.$token])
+            ->getJson('/api/user')
+            ->assertOk()
+            ->assertExactJson([
+                'user' => [
+                    'email' => 'jake@example.com',
+                    'token' => $token,
+                    'username' => 'jake',
+                    'bio' => 'I like APIs',
+                    'image' => 'https://example.com/avatar.png',
+                ],
+            ]);
+    });
+});
+
+describe('PUT /api/user', function (): void {
+    it('未認証リクエストを401で拒否する', function (): void {
+        $this->putJson('/api/user', [
+            'user' => [
+                'bio' => 'I like APIs',
+            ],
+        ])
+            ->assertUnauthorized()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+
+    it('現在Userのemail username password bio imageを更新してuser wrapperを返す', function (): void {
+        $user = User::factory()->create([
+            'username' => 'jake',
+            'email' => 'jake@example.com',
+            'password_hash' => Hash::make('secret'),
+            'bio' => null,
+            'image' => null,
+        ]);
+        $token = realWorldTokenFor($user);
+
+        $this->withHeaders(['Authorization' => 'Token '.$token])
+            ->putJson('/api/user', [
+                'user' => [
+                    'email' => 'new-jake@example.com',
+                    'username' => 'new-jake',
+                    'password' => 'new-secret',
+                    'bio' => 'I like secure APIs',
+                    'image' => 'https://example.com/new-avatar.png',
+                ],
+            ])
+            ->assertOk()
+            ->assertExactJson([
+                'user' => [
+                    'email' => 'new-jake@example.com',
+                    'token' => $token,
+                    'username' => 'new-jake',
+                    'bio' => 'I like secure APIs',
+                    'image' => 'https://example.com/new-avatar.png',
+                ],
+            ]);
+
+        $user->refresh();
+
+        expect($user->email)->toBe('new-jake@example.com')
+            ->and($user->username)->toBe('new-jake')
+            ->and($user->bio)->toBe('I like secure APIs')
+            ->and($user->image)->toBe('https://example.com/new-avatar.png')
+            ->and($user->password_hash)->not->toBe('new-secret')
+            ->and(Hash::check('new-secret', $user->password_hash))->toBeTrue();
+    });
+
+    it('nullable profile fieldsをnullでクリアできる', function (): void {
+        $user = User::factory()->create([
+            'username' => 'jake',
+            'email' => 'jake@example.com',
+            'bio' => 'I like APIs',
+            'image' => 'https://example.com/avatar.png',
+        ]);
+        $token = realWorldTokenFor($user);
+
+        $this->withHeaders(['Authorization' => 'Token '.$token])
+            ->putJson('/api/user', [
+                'user' => [
+                    'bio' => null,
+                    'image' => null,
+                ],
+            ])
+            ->assertOk()
+            ->assertJsonPath('user.bio', null)
+            ->assertJsonPath('user.image', null)
+            ->assertJsonPath('user.email', 'jake@example.com')
+            ->assertJsonPath('user.username', 'jake');
+
+        $user->refresh();
+
+        expect($user->bio)->toBeNull()
+            ->and($user->image)->toBeNull();
+    });
+
+    it('現在User自身のemailとusernameはunique衝突として扱わない', function (): void {
+        $user = User::factory()->create([
+            'username' => 'jake',
+            'email' => 'jake@example.com',
+            'bio' => null,
+        ]);
+        $token = realWorldTokenFor($user);
+
+        $this->withHeaders(['Authorization' => 'Token '.$token])
+            ->putJson('/api/user', [
+                'user' => [
+                    'email' => 'jake@example.com',
+                    'username' => 'jake',
+                    'bio' => 'Still Jake',
+                ],
+            ])
+            ->assertOk()
+            ->assertJsonPath('user.email', 'jake@example.com')
+            ->assertJsonPath('user.username', 'jake')
+            ->assertJsonPath('user.bio', 'Still Jake');
+    });
+
+    it('重複email username 無効URL 短すぎるpasswordを422で拒否する', function (): void {
+        User::factory()->create([
+            'username' => 'existing',
+            'email' => 'existing@example.com',
+        ]);
+        $user = User::factory()->create([
+            'username' => 'jake',
+            'email' => 'jake@example.com',
+        ]);
+        $token = realWorldTokenFor($user);
+
+        $response = $this->withHeaders(['Authorization' => 'Token '.$token])
+            ->putJson('/api/user', [
+                'user' => [
+                    'email' => 'existing@example.com',
+                    'username' => 'existing',
+                    'password' => 'short',
+                    'image' => 'not-a-url',
+                ],
+            ]);
+
+        $response
+            ->assertUnprocessable()
+            ->assertJsonStructure(['errors' => ['body']]);
+
+        expect($response->json('errors.body'))->toBeArray()->toHaveCount(4);
+    });
+});

--- a/backend/tests/Feature/SanctumCorsTest.php
+++ b/backend/tests/Feature/SanctumCorsTest.php
@@ -60,8 +60,9 @@ describe('API認証', function (): void {
 
     it('認証済みユーザーの情報を返す', function (): void {
         $user = User::factory()->create();
+        $token = $this->issueRealWorldTokenFor($user);
 
-        $this->actingAs($user, 'sanctum')
+        $this->withRealWorldToken($token)
             ->getJson('/api/user')
             ->assertOk()
             ->assertJsonFragment(['email' => $user->email]);

--- a/backend/tests/TestCase.php
+++ b/backend/tests/TestCase.php
@@ -2,9 +2,24 @@
 
 namespace Tests;
 
+use App\Infrastructure\Persistence\Models\User;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    /**
+     * RealWorld API 互換の plain text token を発行する。
+     */
+    protected function issueRealWorldTokenFor(User $user): string
+    {
+        return $user->createToken('api')->plainTextToken;
+    }
+
+    /**
+     * RealWorld API 互換の `Token` auth scheme をテストリクエストへ設定する。
+     */
+    protected function withRealWorldToken(string $token): static
+    {
+        return $this->withHeaders(['Authorization' => 'Token '.$token]);
+    }
 }


### PR DESCRIPTION
## 概要

- GET /api/user を CurrentUserController + Query で RealWorld user wrapper 化
- PUT /api/user を FormRequest + Command で部分更新対応
- unique except current User / nullable fields / password hash の Feature test を追加

## 関連 Issue

Closes #66

## テスト計画

- [x] バックエンド: `APP_KEY=base64:... php artisan test` (Docker)
- [x] バックエンド: `./vendor/bin/pint --test` (Docker)
- [x] バックエンド: `./vendor/bin/phpstan analyse` (Docker)
- [x] フロントエンド: 対象外

補足: worktree には .env を作成せず、Pest 実行時のみテスト用 APP_KEY を環境変数で注入しました。Dotenv の .env 不在 warning はありますが、テストは通過しています。