### PR TITLE
ci: git-secretsの誤検知を修正

### DIFF
--- a/.github/scripts/register-git-secrets-patterns.sh
+++ b/.github/scripts/register-git-secrets-patterns.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+scope="local"
+include_aws=1
+
+while (($# > 0)); do
+  case "$1" in
+    --global)
+      scope="global"
+      ;;
+    --no-aws)
+      include_aws=0
+      ;;
+    *)
+      echo "Usage: $0 [--global] [--no-aws]" >&2
+      exit 64
+      ;;
+  esac
+  shift
+done
+
+if ! command -v git-secrets >/dev/null 2>&1; then
+  echo "git-secrets is required but was not found in PATH." >&2
+  exit 127
+fi
+
+if ((include_aws)); then
+  if [[ "$scope" == "global" ]]; then
+    git secrets --register-aws --global
+  else
+    git secrets --register-aws
+  fi
+fi
+
+patterns=(
+  'password[[:space:]]*=[[:space:]]*[^[:space:]=>]+'
+  'secret[[:space:]]*=[[:space:]]*[^[:space:]=>]+'
+  'api_key[[:space:]]*=[[:space:]]*[^[:space:]=>]+'
+  'private_key[[:space:]]*=[[:space:]]*[^[:space:]=>]+'
+)
+
+pattern_exists() {
+  local pattern="$1"
+
+  if [[ "$scope" == "global" ]]; then
+    git config --global --get-all secrets.patterns | grep -Fqx "$pattern"
+  else
+    git config --get-all secrets.patterns | grep -Fqx "$pattern"
+  fi
+}
+
+for pattern in "${patterns[@]}"; do
+  if pattern_exists "$pattern"; then
+    continue
+  fi
+
+  if [[ "$scope" == "global" ]]; then
+    git secrets --add --global "$pattern"
+  else
+    git secrets --add "$pattern"
+  fi
+done

--- a/.github/scripts/verify-git-secrets-patterns.sh
+++ b/.github/scripts/verify-git-secrets-patterns.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+register_script="$repo_root/.github/scripts/register-git-secrets-patterns.sh"
+workdir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$workdir"
+}
+trap cleanup EXIT
+
+cd "$workdir"
+git init -q
+"$register_script" --no-aws >/dev/null
+
+positive_file="$workdir/positive.txt"
+negative_file="$workdir/negative.txt"
+positive_output="$workdir/positive.out"
+negative_output="$workdir/negative.out"
+
+touch "$positive_file" "$negative_file"
+
+write_assignment_case() {
+  local key="$1"
+  printf '%s=%s\n' "$key" "example-value" >> "$positive_file"
+  printf '%s %s %s\n' "$key" "=" "example-value" >> "$positive_file"
+}
+
+write_comparison_case() {
+  local key="$1"
+  local operator="$2"
+  printf '$dto->%s %s null;\n' "$key" "$operator" >> "$negative_file"
+}
+
+write_arrow_case() {
+  local key="$1"
+  printf "        '%s' => %s,\n" "$key" "'example-value'" >> "$negative_file"
+}
+
+keys=(password secret api_key private_key)
+
+for key in "${keys[@]}"; do
+  write_assignment_case "$key"
+  write_comparison_case "$key" "==="
+  write_comparison_case "$key" "!=="
+  write_arrow_case "$key"
+done
+
+if git secrets --scan "$positive_file" >"$positive_output" 2>&1; then
+  echo "Expected git-secrets to detect key-value secret patterns." >&2
+  exit 1
+fi
+
+if ! git secrets --scan "$negative_file" >"$negative_output" 2>&1; then
+  echo "Expected comparison and arrow syntax to be ignored, but git-secrets reported:" >&2
+  cat "$negative_output" >&2
+  exit 1
+fi
+
+echo "git-secrets custom pattern verification passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   # シークレット漏洩スキャン
   # ---------------------------------------------------------------
   secrets-scan:
-    name: Secrets Scan (git-secrets)
+    name: Secrets Scan
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -31,16 +31,13 @@ jobs:
           git clone --branch 1.3.0 --depth 1 --single-branch https://github.com/awslabs/git-secrets.git /tmp/git-secrets
           cd /tmp/git-secrets && sudo make install
 
-      - name: Register AWS patterns
+      - name: Verify custom git-secrets patterns
         run: |
-          git secrets --register-aws --global
+          .github/scripts/verify-git-secrets-patterns.sh
 
-      - name: Add common secret patterns
+      - name: Register git-secrets patterns
         run: |
-          git secrets --add --global 'password\s*=\s*\S+'
-          git secrets --add --global 'secret\s*=\s*\S+'
-          git secrets --add --global 'api_key\s*=\s*\S+'
-          git secrets --add --global 'private_key\s*=\s*\S+'
+          .github/scripts/register-git-secrets-patterns.sh
 
       - name: Scan repository for secrets
         run: |
@@ -50,7 +47,7 @@ jobs:
   # フロントエンド
   # ---------------------------------------------------------------
   frontend:
-    name: Frontend (Type Check / Lint / Test)
+    name: Frontend
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -85,7 +82,7 @@ jobs:
   # バックエンド
   # ---------------------------------------------------------------
   backend:
-    name: Backend (Test / Lint / Static Analysis)
+    name: Backend
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/docs/rules/git-flow.md
+++ b/docs/rules/git-flow.md
@@ -223,6 +223,18 @@ git secrets --install
 `.github/workflows/ci.yml` の `secrets-scan` ジョブで全コミット履歴をスキャンする。
 push のたびに自動実行されるため、ローカルでも常に `git secrets --scan` を実行して確認すること。
 
+CI と同じ custom pattern は `.github/scripts/register-git-secrets-patterns.sh` で管理する。
+ローカルで再現する場合は、リポジトリ内で以下を実行する。
+
+```bash
+.github/scripts/register-git-secrets-patterns.sh
+.github/scripts/verify-git-secrets-patterns.sh
+git secrets --scan
+```
+
+`verify-git-secrets-patterns.sh` は検知対象の key-value 形式と、PHP / TypeScript の比較演算子・配列 arrow を一時ファイルで検証する。
+`scan-history` は履歴全体を検査するため、Red テスト作成時でも secret pattern に引っかかる文字列を commit 対象へ直書きしない。
+
 ## ブランチ保護設定（GitHub Settings 推奨設定）
 
 以下を GitHub リポジトリの **Settings > Branches** で設定する。


### PR DESCRIPTION
## 概要
- Secrets Scan の custom pattern を shared script に切り出し、`===` / `!==` / `=>` を secret 代入として誤検知しないよう修正
- CI の required check 名を `Frontend` / `Backend` / `Secrets Scan` に合わせる
- CI とローカルで再現できる git-secrets pattern 検証スクリプトと手順を追加

## 関連 Issue
Closes #83

## テスト計画
- [x] `.github/scripts/verify-git-secrets-patterns.sh`
- [x] `git secrets --scan` / `git secrets --scan-history`（一時 `GIT_CONFIG_GLOBAL` で custom pattern 登録）
- [x] `cd frontend && pnpm exec tsc -b --noEmit`
- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm test`
- [x] `docker compose exec -T backend-php sh -lc 'APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= php artisan test'`
- [x] `docker compose exec -T backend-php sh -lc './vendor/bin/pint --test'`
- [x] `docker compose exec -T backend-php sh -lc './vendor/bin/phpstan analyse --no-progress --memory-limit=512M'`
