### PR TITLE
[#67]: Auth Providerと認証フォームを実装

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8080

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { RouterProvider } from 'react-router-dom';
-import { AppProviders } from './app/providers/AppProviders';
-import { createAppRouter } from './app/routes/router';
+import { AppProviders } from '@/app/providers/AppProviders';
+import { createAppRouter } from '@/app/routes/router';
 
 const router = createAppRouter();
 

--- a/frontend/src/app/layouts/AppShell.tsx
+++ b/frontend/src/app/layouts/AppShell.tsx
@@ -7,11 +7,11 @@ interface AppShellProps {
 }
 
 export function AppShell({ children }: AppShellProps): ReactElement {
-  const { isAuthenticated, signOut, user } = useAuth();
+  const { isAuthenticated, logout, user } = useAuth();
   const navigate = useNavigate();
 
   function handleSignOut(): void {
-    signOut();
+    logout();
     navigate('/', { replace: true });
   }
 

--- a/frontend/src/app/layouts/AppShell.tsx
+++ b/frontend/src/app/layouts/AppShell.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from 'react';
 import { Link, NavLink, Outlet, useNavigate } from 'react-router-dom';
-import { useAuth } from '../providers/useAuth';
+import { useAuth } from '@/app/providers/useAuth';
 
 interface AppShellProps {
   children?: ReactNode;

--- a/frontend/src/app/providers/AppProviders.tsx
+++ b/frontend/src/app/providers/AppProviders.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from 'react';
+import type { AuthApi, AuthUser } from '@/features/auth';
 import { AuthProvider } from './AuthProvider';
-import type { AuthApi, AuthUser } from '../../features/auth';
 
 interface AppProvidersProps {
   authApi?: AuthApi;
@@ -8,6 +8,9 @@ interface AppProvidersProps {
   initialUser?: AuthUser | null;
 }
 
+/**
+ * アプリ全体で共有するProviderを束ね、テストでは認証APIの差し替えを許可する。
+ */
 export function AppProviders({
   authApi,
   children,

--- a/frontend/src/app/providers/AppProviders.tsx
+++ b/frontend/src/app/providers/AppProviders.tsx
@@ -1,15 +1,21 @@
 import type { ReactElement, ReactNode } from 'react';
 import { AuthProvider } from './AuthProvider';
-import type { AuthUser } from './authContext';
+import type { AuthApi, AuthUser } from '../../features/auth';
 
 interface AppProvidersProps {
+  authApi?: AuthApi;
   children: ReactNode;
   initialUser?: AuthUser | null;
 }
 
 export function AppProviders({
+  authApi,
   children,
   initialUser = null,
 }: AppProvidersProps): ReactElement {
-  return <AuthProvider initialUser={initialUser}>{children}</AuthProvider>;
+  return (
+    <AuthProvider authApi={authApi} initialUser={initialUser}>
+      {children}
+    </AuthProvider>
+  );
 }

--- a/frontend/src/app/providers/AuthProvider.tsx
+++ b/frontend/src/app/providers/AuthProvider.tsx
@@ -1,6 +1,7 @@
 import {
   type ReactElement,
   useCallback,
+  useEffect,
   useMemo,
   useState,
   type ReactNode,
@@ -12,9 +13,9 @@ import {
   type AuthUser,
   type LoginCredentials,
   type RegisterCredentials,
-} from '../../features/auth';
-import { clearAuthToken, getAuthToken, setAuthToken } from '../../lib/authToken';
-import { isApiError } from '../../lib/apiError';
+} from '@/features/auth';
+import { isApiError } from '@/lib/apiError';
+import { clearAuthToken, getAuthToken, setAuthToken } from '@/lib/authToken';
 import { AuthContext, type AuthContextValue } from './authContext';
 
 interface AuthProviderProps {
@@ -23,13 +24,18 @@ interface AuthProviderProps {
   initialUser?: AuthUser | null;
 }
 
+/**
+ * 認証APIとtoken storageをAuthContextへ接続し、アプリ全体のcurrent User状態を所有する。
+ */
 export function AuthProvider({
   authApi = defaultAuthApi,
   children,
   initialUser = null,
 }: AuthProviderProps): ReactElement {
   const [user, setUser] = useState<AuthUser | null>(initialUser);
-  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(
+    () => initialUser === null && hasStoredAuthToken(),
+  );
 
   const applySession = useCallback((session: AuthSession): void => {
     setAuthToken(session.token);
@@ -55,29 +61,76 @@ export function AuthProvider({
     setUser(null);
   }, []);
 
+  const handleRefreshFailure = useCallback(
+    (error: unknown): void => {
+      if (isApiError(error) && error.kind === 'unauthorized') {
+        logout();
+        return;
+      }
+
+      setUser(null);
+    },
+    [logout],
+  );
+
   const refresh = useCallback(async (): Promise<void> => {
     const token = getAuthToken();
 
     if (token === null || token === '') {
       setUser(null);
+      setIsRefreshing(false);
       return;
     }
 
     setIsRefreshing(true);
 
     try {
-      applySession(await authApi.getCurrentUser());
-    } catch (error: unknown) {
-      if (isApiError(error) && error.kind === 'unauthorized') {
-        logout();
-        return;
-      }
+      const session = await authApi.getCurrentUser();
 
-      throw error;
+      if (getAuthToken() === token) {
+        applySession(session);
+      }
+    } catch (error: unknown) {
+      handleRefreshFailure(error);
     } finally {
       setIsRefreshing(false);
     }
-  }, [applySession, authApi, logout]);
+  }, [applySession, authApi, handleRefreshFailure]);
+
+  useEffect(() => {
+    const token = getAuthToken();
+
+    if (token === null || token === '') {
+      void Promise.resolve().then(() => setIsRefreshing(false));
+      return;
+    }
+
+    let isCurrent = true;
+
+    async function restoreCurrentUser(): Promise<void> {
+      try {
+        const session = await authApi.getCurrentUser();
+
+        if (isCurrent && getAuthToken() === token) {
+          applySession(session);
+        }
+      } catch (error: unknown) {
+        if (isCurrent) {
+          handleRefreshFailure(error);
+        }
+      } finally {
+        if (isCurrent) {
+          setIsRefreshing(false);
+        }
+      }
+    }
+
+    void restoreCurrentUser();
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [applySession, authApi, handleRefreshFailure]);
 
   const value = useMemo<AuthContextValue>(
     () => ({
@@ -93,4 +146,13 @@ export function AuthProvider({
   );
 
   return <AuthContext value={value}>{children}</AuthContext>;
+}
+
+/**
+ * 保存済みtokenがcurrent User復元を試すべき値かを判定する。
+ */
+function hasStoredAuthToken(): boolean {
+  const token = getAuthToken();
+
+  return token !== null && token !== '';
 }

--- a/frontend/src/app/providers/AuthProvider.tsx
+++ b/frontend/src/app/providers/AuthProvider.tsx
@@ -1,30 +1,95 @@
-import { type ReactElement, useMemo, useState, type ReactNode } from 'react';
-import { AuthContext, type AuthContextValue, type AuthUser } from './authContext';
-
-const DEMO_USER: AuthUser = {
-  image: '',
-  username: 'demo-user',
-};
+import {
+  type ReactElement,
+  useCallback,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  authApi as defaultAuthApi,
+  type AuthApi,
+  type AuthSession,
+  type AuthUser,
+  type LoginCredentials,
+  type RegisterCredentials,
+} from '../../features/auth';
+import { clearAuthToken, getAuthToken, setAuthToken } from '../../lib/authToken';
+import { isApiError } from '../../lib/apiError';
+import { AuthContext, type AuthContextValue } from './authContext';
 
 interface AuthProviderProps {
+  authApi?: AuthApi;
   children: ReactNode;
   initialUser?: AuthUser | null;
 }
 
 export function AuthProvider({
+  authApi = defaultAuthApi,
   children,
   initialUser = null,
 }: AuthProviderProps): ReactElement {
   const [user, setUser] = useState<AuthUser | null>(initialUser);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const applySession = useCallback((session: AuthSession): void => {
+    setAuthToken(session.token);
+    setUser(session.user);
+  }, []);
+
+  const login = useCallback(
+    async (credentials: LoginCredentials): Promise<void> => {
+      applySession(await authApi.login(credentials));
+    },
+    [applySession, authApi],
+  );
+
+  const register = useCallback(
+    async (credentials: RegisterCredentials): Promise<void> => {
+      applySession(await authApi.register(credentials));
+    },
+    [applySession, authApi],
+  );
+
+  const logout = useCallback((): void => {
+    clearAuthToken();
+    setUser(null);
+  }, []);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    const token = getAuthToken();
+
+    if (token === null || token === '') {
+      setUser(null);
+      return;
+    }
+
+    setIsRefreshing(true);
+
+    try {
+      applySession(await authApi.getCurrentUser());
+    } catch (error: unknown) {
+      if (isApiError(error) && error.kind === 'unauthorized') {
+        logout();
+        return;
+      }
+
+      throw error;
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [applySession, authApi, logout]);
 
   const value = useMemo<AuthContextValue>(
     () => ({
       isAuthenticated: user !== null,
-      signIn: () => setUser(DEMO_USER),
-      signOut: () => setUser(null),
+      isRefreshing,
+      login,
+      logout,
+      refresh,
+      register,
       user,
     }),
-    [user],
+    [isRefreshing, login, logout, refresh, register, user],
   );
 
   return <AuthContext value={value}>{children}</AuthContext>;

--- a/frontend/src/app/providers/__tests__/AuthProvider.test.tsx
+++ b/frontend/src/app/providers/__tests__/AuthProvider.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearAuthToken, getAuthToken, setAuthToken } from '../../../lib/authToken';
+import { ApiError } from '../../../lib/apiError';
+import type { AuthApi, AuthUser } from '../../../features/auth';
+import { AuthProvider } from '../AuthProvider';
+import { useAuth } from '../useAuth';
+
+const JAKE: AuthUser = {
+  bio: null,
+  email: 'jake@example.com',
+  image: null,
+  username: 'jake',
+};
+
+const JANE: AuthUser = {
+  bio: 'Writer',
+  email: 'jane@example.com',
+  image: 'https://example.com/jane.png',
+  username: 'jane',
+};
+
+function createAuthApi(overrides: Partial<AuthApi> = {}): AuthApi {
+  return {
+    getCurrentUser: vi.fn().mockResolvedValue({
+      token: 'fresh-token',
+      user: JAKE,
+    }),
+    login: vi.fn().mockResolvedValue({
+      token: 'login-token',
+      user: JAKE,
+    }),
+    register: vi.fn().mockResolvedValue({
+      token: 'register-token',
+      user: JANE,
+    }),
+    ...overrides,
+  };
+}
+
+function AuthProbe(): ReactElement {
+  const auth = useAuth();
+
+  return (
+    <div>
+      <p>{auth.isAuthenticated ? 'authenticated' : 'guest'}</p>
+      <p>{auth.user?.username ?? 'no-user'}</p>
+      <button
+        type="button"
+        onClick={() => {
+          void auth.login({
+            email: 'jake@example.com',
+            password: 'secret',
+          });
+        }}
+      >
+        login
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void auth.register({
+            email: 'jane@example.com',
+            password: 'secret',
+            username: 'jane',
+          });
+        }}
+      >
+        register
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void auth.refresh();
+        }}
+      >
+        refresh
+      </button>
+      <button type="button" onClick={auth.logout}>
+        logout
+      </button>
+    </div>
+  );
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    clearAuthToken();
+  });
+
+  it('persists the token and updates current user after login', async () => {
+    const user = userEvent.setup();
+    const authApi = createAuthApi();
+
+    render(
+      <AuthProvider authApi={authApi}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'login' }));
+
+    expect(await screen.findByText('jake')).toBeInTheDocument();
+    expect(screen.getByText('authenticated')).toBeInTheDocument();
+    expect(getAuthToken()).toBe('login-token');
+  });
+
+  it('persists the token and updates current user after register', async () => {
+    const user = userEvent.setup();
+    const authApi = createAuthApi();
+
+    render(
+      <AuthProvider authApi={authApi}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'register' }));
+
+    expect(await screen.findByText('jane')).toBeInTheDocument();
+    expect(getAuthToken()).toBe('register-token');
+  });
+
+  it('refresh clears current user when no token exists', async () => {
+    const user = userEvent.setup();
+    const authApi = createAuthApi();
+
+    render(
+      <AuthProvider authApi={authApi} initialUser={JAKE}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByText('authenticated')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'refresh' }));
+
+    expect(await screen.findByText('guest')).toBeInTheDocument();
+    expect(screen.getByText('no-user')).toBeInTheDocument();
+    expect(authApi.getCurrentUser).not.toHaveBeenCalled();
+  });
+
+  it('refresh clears the token and current user when the API returns unauthorized', async () => {
+    const user = userEvent.setup();
+    const authApi = createAuthApi({
+      getCurrentUser: vi.fn().mockRejectedValue(
+        new ApiError('Unauthorized', {
+          bodyErrors: ['Unauthorized'],
+          kind: 'unauthorized',
+          status: 401,
+        }),
+      ),
+    });
+    setAuthToken('expired-token');
+
+    render(
+      <AuthProvider authApi={authApi} initialUser={JAKE}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'refresh' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('guest')).toBeInTheDocument();
+    });
+    expect(getAuthToken()).toBeNull();
+  });
+
+  it('logout clears token and current user', async () => {
+    const user = userEvent.setup();
+    const authApi = createAuthApi();
+    setAuthToken('active-token');
+
+    render(
+      <AuthProvider authApi={authApi} initialUser={JAKE}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'logout' }));
+
+    expect(screen.getByText('guest')).toBeInTheDocument();
+    expect(screen.getByText('no-user')).toBeInTheDocument();
+    expect(getAuthToken()).toBeNull();
+  });
+});

--- a/frontend/src/app/providers/__tests__/AuthProvider.test.tsx
+++ b/frontend/src/app/providers/__tests__/AuthProvider.test.tsx
@@ -2,9 +2,9 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { clearAuthToken, getAuthToken, setAuthToken } from '../../../lib/authToken';
-import { ApiError } from '../../../lib/apiError';
-import type { AuthApi, AuthUser } from '../../../features/auth';
+import type { AuthApi, AuthSession, AuthUser } from '@/features/auth';
+import { ApiError } from '@/lib/apiError';
+import { clearAuthToken, getAuthToken, setAuthToken } from '@/lib/authToken';
 import { AuthProvider } from '../AuthProvider';
 import { useAuth } from '../useAuth';
 
@@ -22,6 +22,9 @@ const JANE: AuthUser = {
   username: 'jane',
 };
 
+/**
+ * AuthProviderがAuthApiの結果をcontext状態とtoken storageへ反映することを検証するstubを作る。
+ */
 function createAuthApi(overrides: Partial<AuthApi> = {}): AuthApi {
   return {
     getCurrentUser: vi.fn().mockResolvedValue({
@@ -40,12 +43,16 @@ function createAuthApi(overrides: Partial<AuthApi> = {}): AuthApi {
   };
 }
 
+/**
+ * AuthContextの公開契約をユーザー操作から観測できるテスト用component。
+ */
 function AuthProbe(): ReactElement {
   const auth = useAuth();
 
   return (
     <div>
       <p>{auth.isAuthenticated ? 'authenticated' : 'guest'}</p>
+      <p>{auth.isRefreshing ? 'refreshing' : 'idle'}</p>
       <p>{auth.user?.username ?? 'no-user'}</p>
       <button
         type="button"
@@ -85,12 +92,12 @@ function AuthProbe(): ReactElement {
   );
 }
 
-describe('AuthProvider', () => {
+describe('認証Provider', () => {
   beforeEach(() => {
     clearAuthToken();
   });
 
-  it('persists the token and updates current user after login', async () => {
+  it('login後にtokenを保存してcurrent userを更新する', async () => {
     const user = userEvent.setup();
     const authApi = createAuthApi();
 
@@ -107,7 +114,7 @@ describe('AuthProvider', () => {
     expect(getAuthToken()).toBe('login-token');
   });
 
-  it('persists the token and updates current user after register', async () => {
+  it('register後にtokenを保存してcurrent userを更新する', async () => {
     const user = userEvent.setup();
     const authApi = createAuthApi();
 
@@ -123,7 +130,7 @@ describe('AuthProvider', () => {
     expect(getAuthToken()).toBe('register-token');
   });
 
-  it('refresh clears current user when no token exists', async () => {
+  it('tokenがないrefreshではcurrent userをクリアしてAPIを呼ばない', async () => {
     const user = userEvent.setup();
     const authApi = createAuthApi();
 
@@ -142,8 +149,25 @@ describe('AuthProvider', () => {
     expect(authApi.getCurrentUser).not.toHaveBeenCalled();
   });
 
-  it('refresh clears the token and current user when the API returns unauthorized', async () => {
-    const user = userEvent.setup();
+  it('保存済みtokenがある場合はmount時にcurrent userを復元する', async () => {
+    const authApi = createAuthApi();
+    setAuthToken('active-token');
+
+    render(
+      <AuthProvider authApi={authApi}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByText('refreshing')).toBeInTheDocument();
+    expect(await screen.findByText('jake')).toBeInTheDocument();
+    expect(screen.getByText('authenticated')).toBeInTheDocument();
+    expect(screen.getByText('idle')).toBeInTheDocument();
+    expect(getAuthToken()).toBe('fresh-token');
+    expect(authApi.getCurrentUser).toHaveBeenCalledOnce();
+  });
+
+  it('current user APIがunauthorizedを返した場合はtokenとcurrent userをクリアする', async () => {
     const authApi = createAuthApi({
       getCurrentUser: vi.fn().mockRejectedValue(
         new ApiError('Unauthorized', {
@@ -156,22 +180,27 @@ describe('AuthProvider', () => {
     setAuthToken('expired-token');
 
     render(
-      <AuthProvider authApi={authApi} initialUser={JAKE}>
+      <AuthProvider authApi={authApi}>
         <AuthProbe />
       </AuthProvider>,
     );
 
-    await user.click(screen.getByRole('button', { name: 'refresh' }));
-
     await waitFor(() => {
-      expect(screen.getByText('guest')).toBeInTheDocument();
+      expect(getAuthToken()).toBeNull();
+      expect(screen.getByText('idle')).toBeInTheDocument();
     });
-    expect(getAuthToken()).toBeNull();
+    expect(screen.getByText('guest')).toBeInTheDocument();
   });
 
-  it('logout clears token and current user', async () => {
-    const user = userEvent.setup();
-    const authApi = createAuthApi();
+  it('current user APIがunauthorized以外で失敗した場合は未認証扱いにして例外を漏らさない', async () => {
+    const authApi = createAuthApi({
+      getCurrentUser: vi.fn().mockRejectedValue(
+        new ApiError('Network request failed', {
+          bodyErrors: [],
+          kind: 'network',
+        }),
+      ),
+    });
     setAuthToken('active-token');
 
     render(
@@ -179,6 +208,58 @@ describe('AuthProvider', () => {
         <AuthProbe />
       </AuthProvider>,
     );
+
+    await waitFor(() => {
+      expect(screen.getByText('guest')).toBeInTheDocument();
+    });
+    expect(screen.getByText('idle')).toBeInTheDocument();
+    expect(getAuthToken()).toBe('active-token');
+  });
+
+  it('refresh中にlogoutした場合は古いcurrent userを再適用しない', async () => {
+    const user = userEvent.setup();
+    let resolveRefresh: (session: AuthSession) => void = () => {};
+    const refreshPromise = new Promise<AuthSession>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const authApi = createAuthApi({
+      getCurrentUser: vi.fn().mockReturnValue(refreshPromise),
+    });
+    setAuthToken('active-token');
+
+    render(
+      <AuthProvider authApi={authApi}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByText('refreshing')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'logout' }));
+    expect(getAuthToken()).toBeNull();
+
+    resolveRefresh({
+      token: 'fresh-token',
+      user: JAKE,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('idle')).toBeInTheDocument();
+    });
+    expect(screen.getByText('guest')).toBeInTheDocument();
+    expect(screen.getByText('no-user')).toBeInTheDocument();
+    expect(getAuthToken()).toBeNull();
+  });
+
+  it('logoutでtokenとcurrent userをクリアする', async () => {
+    const user = userEvent.setup();
+    const authApi = createAuthApi();
+
+    render(
+      <AuthProvider authApi={authApi} initialUser={JAKE}>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+    setAuthToken('active-token');
 
     await user.click(screen.getByRole('button', { name: 'logout' }));
 

--- a/frontend/src/app/providers/authContext.ts
+++ b/frontend/src/app/providers/authContext.ts
@@ -3,7 +3,7 @@ import type {
   AuthUser,
   LoginCredentials,
   RegisterCredentials,
-} from '../../features/auth';
+} from '@/features/auth';
 
 export interface AuthContextValue {
   isAuthenticated: boolean;

--- a/frontend/src/app/providers/authContext.ts
+++ b/frontend/src/app/providers/authContext.ts
@@ -1,14 +1,17 @@
 import { createContext } from 'react';
-
-export interface AuthUser {
-  image: string;
-  username: string;
-}
+import type {
+  AuthUser,
+  LoginCredentials,
+  RegisterCredentials,
+} from '../../features/auth';
 
 export interface AuthContextValue {
   isAuthenticated: boolean;
-  signIn: () => void;
-  signOut: () => void;
+  isRefreshing: boolean;
+  login: (credentials: LoginCredentials) => Promise<void>;
+  logout: () => void;
+  refresh: () => Promise<void>;
+  register: (credentials: RegisterCredentials) => Promise<void>;
   user: AuthUser | null;
 }
 

--- a/frontend/src/app/routes/__tests__/router.test.tsx
+++ b/frontend/src/app/routes/__tests__/router.test.tsx
@@ -2,8 +2,9 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactElement } from 'react';
 import { RouterProvider } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import type { AuthApi, AuthUser } from '../../../features/auth';
+import { clearAuthToken } from '../../../lib/authToken';
 import { AppProviders } from '../../providers/AppProviders';
 import { createAppRouter } from '../router';
 
@@ -46,6 +47,10 @@ function renderRoute(
 }
 
 describe('app router', () => {
+  beforeEach(() => {
+    clearAuthToken();
+  });
+
   it('redirects guests from required routes to login with return path', async () => {
     const { render } = await import('@testing-library/react');
 
@@ -67,7 +72,7 @@ describe('app router', () => {
     await user.click(screen.getByRole('button', { name: 'Sign in' }));
 
     expect(
-      screen.getByRole('heading', { name: 'New Article' }),
+      await screen.findByRole('heading', { name: 'New Article' }),
     ).toBeInTheDocument();
   });
 
@@ -84,7 +89,7 @@ describe('app router', () => {
     await user.click(screen.getByRole('button', { name: 'Sign in' }));
 
     expect(
-      screen.getByRole('heading', { name: 'Global Feed' }),
+      await screen.findByRole('heading', { name: 'Global Feed' }),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/app/routes/__tests__/router.test.tsx
+++ b/frontend/src/app/routes/__tests__/router.test.tsx
@@ -3,8 +3,33 @@ import userEvent from '@testing-library/user-event';
 import type { ReactElement } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
+import type { AuthApi, AuthUser } from '../../../features/auth';
 import { AppProviders } from '../../providers/AppProviders';
 import { createAppRouter } from '../router';
+
+const DEMO_USER: AuthUser = {
+  bio: null,
+  email: 'demo@example.com',
+  image: '',
+  username: 'demo-user',
+};
+
+function createAuthApi(): AuthApi {
+  return {
+    getCurrentUser: async () => ({
+      token: 'fresh-token',
+      user: DEMO_USER,
+    }),
+    login: async () => ({
+      token: 'login-token',
+      user: DEMO_USER,
+    }),
+    register: async () => ({
+      token: 'register-token',
+      user: DEMO_USER,
+    }),
+  };
+}
 
 function renderRoute(
   initialPath: string,
@@ -12,14 +37,8 @@ function renderRoute(
 ): ReactElement {
   return (
     <AppProviders
-      initialUser={
-        isAuthenticated
-          ? {
-              image: '',
-              username: 'demo-user',
-            }
-          : null
-      }
+      authApi={createAuthApi()}
+      initialUser={isAuthenticated ? DEMO_USER : null}
     >
       <RouterProvider router={createAppRouter([initialPath])} />
     </AppProviders>
@@ -43,6 +62,8 @@ describe('app router', () => {
     const { render } = await import('@testing-library/react');
 
     render(renderRoute('/login?returnTo=/editor'));
+    await user.type(screen.getByLabelText('Email'), 'demo@example.com');
+    await user.type(screen.getByLabelText('Password'), 'secret');
     await user.click(screen.getByRole('button', { name: 'Sign in' }));
 
     expect(
@@ -58,6 +79,8 @@ describe('app router', () => {
     const { render } = await import('@testing-library/react');
 
     render(renderRoute(`/login?returnTo=${encodeURIComponent(returnTo)}`));
+    await user.type(screen.getByLabelText('Email'), 'demo@example.com');
+    await user.type(screen.getByLabelText('Password'), 'secret');
     await user.click(screen.getByRole('button', { name: 'Sign in' }));
 
     expect(

--- a/frontend/src/app/routes/__tests__/router.test.tsx
+++ b/frontend/src/app/routes/__tests__/router.test.tsx
@@ -2,10 +2,10 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactElement } from 'react';
 import { RouterProvider } from 'react-router-dom';
-import { beforeEach, describe, expect, it } from 'vitest';
-import type { AuthApi, AuthUser } from '../../../features/auth';
-import { clearAuthToken } from '../../../lib/authToken';
-import { AppProviders } from '../../providers/AppProviders';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppProviders } from '@/app/providers/AppProviders';
+import type { AuthApi, AuthSession, AuthUser } from '@/features/auth';
+import { clearAuthToken, setAuthToken } from '@/lib/authToken';
 import { createAppRouter } from '../router';
 
 const DEMO_USER: AuthUser = {
@@ -15,7 +15,10 @@ const DEMO_USER: AuthUser = {
   username: 'demo-user',
 };
 
-function createAuthApi(): AuthApi {
+/**
+ * route integration testがfetchへ依存せず認証結果を制御するためのAPI stubを作る。
+ */
+function createAuthApi(overrides: Partial<AuthApi> = {}): AuthApi {
   return {
     getCurrentUser: async () => ({
       token: 'fresh-token',
@@ -29,32 +32,38 @@ function createAuthApi(): AuthApi {
       token: 'register-token',
       user: DEMO_USER,
     }),
+    ...overrides,
   };
 }
 
-function renderRoute(
-  initialPath: string,
-  isAuthenticated = false,
-): ReactElement {
+/**
+ * AppProvidersとmemory routerを組み合わせ、指定pathのルート挙動を検証可能にする。
+ */
+function renderRoute({
+  authApi = createAuthApi(),
+  initialPath,
+  initialUser = null,
+}: {
+  authApi?: AuthApi;
+  initialPath: string;
+  initialUser?: AuthUser | null;
+}): ReactElement {
   return (
-    <AppProviders
-      authApi={createAuthApi()}
-      initialUser={isAuthenticated ? DEMO_USER : null}
-    >
+    <AppProviders authApi={authApi} initialUser={initialUser}>
       <RouterProvider router={createAppRouter([initialPath])} />
     </AppProviders>
   );
 }
 
-describe('app router', () => {
+describe('アプリルーター', () => {
   beforeEach(() => {
     clearAuthToken();
   });
 
-  it('redirects guests from required routes to login with return path', async () => {
+  it('未認証ユーザーを必須ルートからreturn path付きログインへ遷移する', async () => {
     const { render } = await import('@testing-library/react');
 
-    render(renderRoute('/settings'));
+    render(renderRoute({ initialPath: '/settings' }));
 
     expect(
       screen.getByRole('heading', { name: 'Sign in' }),
@@ -62,11 +71,11 @@ describe('app router', () => {
     expect(screen.getByText('/settings')).toBeInTheDocument();
   });
 
-  it('restores the return path after signing in', async () => {
+  it('ログイン後にreturn pathへ復帰する', async () => {
     const user = userEvent.setup();
     const { render } = await import('@testing-library/react');
 
-    render(renderRoute('/login?returnTo=/editor'));
+    render(renderRoute({ initialPath: '/login?returnTo=/editor' }));
     await user.type(screen.getByLabelText('Email'), 'demo@example.com');
     await user.type(screen.getByLabelText('Password'), 'secret');
     await user.click(screen.getByRole('button', { name: 'Sign in' }));
@@ -77,13 +86,13 @@ describe('app router', () => {
   });
 
   it.each([
-    ['protocol-relative return path', '//evil.example'],
-    ['backslash return path', '/\\\\evil.example'],
-  ])('falls back to home for unsafe %s', async (_caseName, returnTo) => {
+    ['protocol-relativeなreturn path', '//evil.example'],
+    ['backslashを含むreturn path', '/\\\\evil.example'],
+  ])('危険な%sはホームへ戻す', async (_caseName, returnTo) => {
     const user = userEvent.setup();
     const { render } = await import('@testing-library/react');
 
-    render(renderRoute(`/login?returnTo=${encodeURIComponent(returnTo)}`));
+    render(renderRoute({ initialPath: `/login?returnTo=${encodeURIComponent(returnTo)}` }));
     await user.type(screen.getByLabelText('Email'), 'demo@example.com');
     await user.type(screen.getByLabelText('Password'), 'secret');
     await user.click(screen.getByRole('button', { name: 'Sign in' }));
@@ -93,23 +102,50 @@ describe('app router', () => {
     ).toBeInTheDocument();
   });
 
-  it('redirects authenticated users away from guest routes', async () => {
+  it('認証済みユーザーをゲスト専用ルートからリダイレクトする', async () => {
     const { render } = await import('@testing-library/react');
 
-    render(renderRoute('/login', true));
+    render(renderRoute({ initialPath: '/login', initialUser: DEMO_USER }));
 
     expect(
       screen.getByRole('heading', { name: 'Global Feed' }),
     ).toBeInTheDocument();
   });
 
-  it('renders not found for unknown routes', async () => {
+  it('未知のルートではnot foundを表示する', async () => {
     const { render } = await import('@testing-library/react');
 
-    render(renderRoute('/missing-page'));
+    render(renderRoute({ initialPath: '/missing-page' }));
 
     expect(
       screen.getByRole('heading', { name: 'Page not found' }),
+    ).toBeInTheDocument();
+  });
+
+  it('保存済みtokenの確認中は必須ルートからログインへ早期遷移しない', async () => {
+    const { render } = await import('@testing-library/react');
+    let resolveRefresh: (session: AuthSession) => void = () => {};
+    const refreshPromise = new Promise<AuthSession>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const authApi = createAuthApi({
+      getCurrentUser: vi.fn().mockReturnValue(refreshPromise),
+    });
+    setAuthToken('active-token');
+
+    render(renderRoute({ authApi, initialPath: '/settings' }));
+
+    expect(
+      screen.queryByRole('heading', { name: 'Sign in' }),
+    ).not.toBeInTheDocument();
+
+    resolveRefresh({
+      token: 'fresh-token',
+      user: DEMO_USER,
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Settings' }),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/routes/guards.tsx
+++ b/frontend/src/app/routes/guards.tsx
@@ -1,15 +1,22 @@
 import type { ReactElement, ReactNode } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
-import { useAuth } from '../providers/useAuth';
+import { useAuth } from '@/app/providers/useAuth';
 import { getSafeReturnTo } from './returnTo';
 
 interface GuardProps {
   children: ReactNode;
 }
 
-export function RequireAuth({ children }: GuardProps): ReactElement {
-  const { isAuthenticated } = useAuth();
+/**
+ * 認証必須ルートでcurrent User確認が終わるまでredirect判定を保留する。
+ */
+export function RequireAuth({ children }: GuardProps): ReactElement | null {
+  const { isAuthenticated, isRefreshing } = useAuth();
   const location = useLocation();
+
+  if (isRefreshing) {
+    return null;
+  }
 
   if (!isAuthenticated) {
     const returnTo = `${location.pathname}${location.search}`;
@@ -25,9 +32,16 @@ export function RequireAuth({ children }: GuardProps): ReactElement {
   return <>{children}</>;
 }
 
-export function GuestOnly({ children }: GuardProps): ReactElement {
-  const { isAuthenticated } = useAuth();
+/**
+ * ゲスト専用ルートでcurrent User確認が終わるまでredirect判定を保留する。
+ */
+export function GuestOnly({ children }: GuardProps): ReactElement | null {
+  const { isAuthenticated, isRefreshing } = useAuth();
   const location = useLocation();
+
+  if (isRefreshing) {
+    return null;
+  }
 
   if (isAuthenticated) {
     const searchParams = new URLSearchParams(location.search);

--- a/frontend/src/app/routes/pages.tsx
+++ b/frontend/src/app/routes/pages.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode } from 'react';
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { LoginForm, RegisterForm } from '../../features/auth';
-import { useAuth } from '../providers/useAuth';
+import { useAuth } from '@/app/providers/useAuth';
+import { LoginForm, RegisterForm } from '@/features/auth';
 import { getSafeReturnTo } from './returnTo';
 
 const SAMPLE_ARTICLES = [

--- a/frontend/src/app/routes/pages.tsx
+++ b/frontend/src/app/routes/pages.tsx
@@ -1,5 +1,6 @@
-import type { FormEvent, ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { LoginForm, RegisterForm } from '../../features/auth';
 import { useAuth } from '../providers/useAuth';
 import { getSafeReturnTo } from './returnTo';
 
@@ -102,14 +103,12 @@ export function HomePage(): ReactElement {
 }
 
 export function LoginPage(): ReactElement {
-  const { signIn } = useAuth();
+  const { login } = useAuth();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const returnTo = getSafeReturnTo(searchParams.get('returnTo'));
 
-  function handleSubmit(event: FormEvent<HTMLFormElement>): void {
-    event.preventDefault();
-    signIn();
+  function handleSuccess(): void {
     navigate(returnTo, { replace: true });
   }
 
@@ -119,19 +118,17 @@ export function LoginPage(): ReactElement {
       alternateText="Need an account?"
       heading="Sign in"
       returnTo={returnTo}
-      submitLabel="Sign in"
-      onSubmit={handleSubmit}
-    />
+    >
+      <LoginForm onSubmit={login} onSuccess={handleSuccess} />
+    </AuthPage>
   );
 }
 
 export function RegisterPage(): ReactElement {
-  const { signIn } = useAuth();
+  const { register } = useAuth();
   const navigate = useNavigate();
 
-  function handleSubmit(event: FormEvent<HTMLFormElement>): void {
-    event.preventDefault();
-    signIn();
+  function handleSuccess(): void {
     navigate('/', { replace: true });
   }
 
@@ -140,31 +137,26 @@ export function RegisterPage(): ReactElement {
       alternateHref="/login"
       alternateText="Have an account?"
       heading="Sign up"
-      submitLabel="Sign up"
-      variant="register"
-      onSubmit={handleSubmit}
-    />
+    >
+      <RegisterForm onSubmit={register} onSuccess={handleSuccess} />
+    </AuthPage>
   );
 }
 
 interface AuthPageProps {
   alternateHref: string;
   alternateText: string;
+  children: ReactNode;
   heading: string;
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   returnTo?: string;
-  submitLabel: string;
-  variant?: 'login' | 'register';
 }
 
 function AuthPage({
   alternateHref,
   alternateText,
+  children,
   heading,
-  onSubmit,
   returnTo,
-  submitLabel,
-  variant = 'login',
 }: AuthPageProps): ReactElement {
   return (
     <main className="page page--centered">
@@ -178,40 +170,18 @@ function AuthPage({
             Sign in to continue to <strong>{returnTo}</strong>
           </p>
         ) : null}
-        <form className="form-stack" onSubmit={onSubmit}>
-          {variant === 'register' ? (
-            <label>
-              <span>Username</span>
-              <input autoComplete="username" placeholder="Username" type="text" />
-            </label>
-          ) : null}
-          <label>
-            <span>Email</span>
-            <input autoComplete="email" placeholder="Email" type="email" />
-          </label>
-          <label>
-            <span>Password</span>
-            <input
-              autoComplete={variant === 'register' ? 'new-password' : 'current-password'}
-              placeholder="Password"
-              type="password"
-            />
-          </label>
-          <button className="primary-action" type="submit">
-            {submitLabel}
-          </button>
-        </form>
+        {children}
       </section>
     </main>
   );
 }
 
 export function SettingsPage(): ReactElement {
-  const { signOut, user } = useAuth();
+  const { logout, user } = useAuth();
   const navigate = useNavigate();
 
   function handleLogout(): void {
-    signOut();
+    logout();
     navigate('/', { replace: true });
   }
 

--- a/frontend/src/app/routes/router.tsx
+++ b/frontend/src/app/routes/router.tsx
@@ -5,7 +5,7 @@ import {
   type InitialEntry,
   type RouteObject,
 } from 'react-router-dom';
-import { AppShell } from '../layouts/AppShell';
+import { AppShell } from '@/app/layouts/AppShell';
 import { GuestOnly, RequireAuth } from './guards';
 import {
   ArticleDetailPage,

--- a/frontend/src/features/auth/__tests__/AuthForms.test.tsx
+++ b/frontend/src/features/auth/__tests__/AuthForms.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ApiError } from '../../../lib/apiError';
+import { LoginForm, RegisterForm } from '../index';
+
+describe('auth forms', () => {
+  it('submits login credentials and shows the pending state', async () => {
+    const user = userEvent.setup();
+    let resolveSubmit: (() => void) | undefined;
+    const submitPromise = new Promise<void>((resolve) => {
+      resolveSubmit = resolve;
+    });
+    const onSubmit = vi.fn().mockReturnValue(submitPromise);
+    const onSuccess = vi.fn();
+
+    render(<LoginForm onSubmit={onSubmit} onSuccess={onSuccess} />);
+
+    await user.type(screen.getByLabelText('Email'), 'jake@example.com');
+    await user.type(screen.getByLabelText('Password'), 'secret');
+    await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      email: 'jake@example.com',
+      password: 'secret',
+    });
+    expect(screen.getByRole('button', { name: 'Signing in...' })).toBeDisabled();
+
+    resolveSubmit?.();
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('keeps login input values when API validation fails', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockRejectedValue(
+      new ApiError('email is invalid', {
+        bodyErrors: ['email is invalid'],
+        kind: 'validation',
+        status: 422,
+      }),
+    );
+
+    render(<LoginForm onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText('Email'), 'invalid@example.com');
+    await user.type(screen.getByLabelText('Password'), 'secret');
+    await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    expect(await screen.findByText('email is invalid')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toHaveValue('invalid@example.com');
+    expect(screen.getByLabelText('Password')).toHaveValue('secret');
+  });
+
+  it('submits register credentials and keeps input values when the API rejects', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockRejectedValue(
+      new ApiError('username has already been taken', {
+        bodyErrors: ['username has already been taken'],
+        kind: 'validation',
+        status: 422,
+      }),
+    );
+
+    render(<RegisterForm onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText('Username'), 'jake');
+    await user.type(screen.getByLabelText('Email'), 'jake@example.com');
+    await user.type(screen.getByLabelText('Password'), 'secret');
+    await user.click(screen.getByRole('button', { name: 'Sign up' }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      email: 'jake@example.com',
+      password: 'secret',
+      username: 'jake',
+    });
+    expect(
+      await screen.findByText('username has already been taken'),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Username')).toHaveValue('jake');
+    expect(screen.getByLabelText('Email')).toHaveValue('jake@example.com');
+    expect(screen.getByLabelText('Password')).toHaveValue('secret');
+  });
+});

--- a/frontend/src/features/auth/__tests__/AuthForms.test.tsx
+++ b/frontend/src/features/auth/__tests__/AuthForms.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { ApiError } from '../../../lib/apiError';
+import { ApiError } from '@/lib/apiError';
 import { LoginForm, RegisterForm } from '../index';
 
-describe('auth forms', () => {
-  it('submits login credentials and shows the pending state', async () => {
+describe('認証フォーム', () => {
+  it('ログイン認証情報を送信し送信中状態を表示する', async () => {
     const user = userEvent.setup();
     let resolveSubmit: (() => void) | undefined;
     const submitPromise = new Promise<void>((resolve) => {
@@ -33,7 +33,7 @@ describe('auth forms', () => {
     });
   });
 
-  it('keeps login input values when API validation fails', async () => {
+  it('ログインAPI validationが失敗しても入力値を保持する', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn().mockRejectedValue(
       new ApiError('email is invalid', {
@@ -54,7 +54,7 @@ describe('auth forms', () => {
     expect(screen.getByLabelText('Password')).toHaveValue('secret');
   });
 
-  it('submits register credentials and keeps input values when the API rejects', async () => {
+  it('登録認証情報を送信しAPI拒否時も入力値を保持する', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn().mockRejectedValue(
       new ApiError('username has already been taken', {

--- a/frontend/src/features/auth/__tests__/authApi.test.ts
+++ b/frontend/src/features/auth/__tests__/authApi.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ApiClient } from '../../../lib/apiClient';
+import { getCurrentUser, loginUser, registerUser } from '../api/authApi';
+
+function createClient(): ApiClient {
+  return {
+    delete: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    request: vi.fn(),
+  };
+}
+
+describe('auth API', () => {
+  it('login sends RealWorld credentials and maps the returned session', async () => {
+    const client = createClient();
+    vi.mocked(client.post).mockResolvedValue({
+      user: {
+        bio: null,
+        email: 'jake@example.com',
+        image: null,
+        token: 'login-token',
+        username: 'jake',
+      },
+    });
+
+    const session = await loginUser(
+      {
+        email: 'jake@example.com',
+        password: 'secret',
+      },
+      client,
+    );
+
+    expect(client.post).toHaveBeenCalledWith('/api/users/login', {
+      user: {
+        email: 'jake@example.com',
+        password: 'secret',
+      },
+    });
+    expect(session).toEqual({
+      token: 'login-token',
+      user: {
+        bio: null,
+        email: 'jake@example.com',
+        image: null,
+        username: 'jake',
+      },
+    });
+  });
+
+  it('register sends RealWorld user payload and maps the returned session', async () => {
+    const client = createClient();
+    vi.mocked(client.post).mockResolvedValue({
+      user: {
+        bio: '',
+        email: 'jane@example.com',
+        image: '',
+        token: 'register-token',
+        username: 'jane',
+      },
+    });
+
+    const session = await registerUser(
+      {
+        email: 'jane@example.com',
+        password: 'secret',
+        username: 'jane',
+      },
+      client,
+    );
+
+    expect(client.post).toHaveBeenCalledWith('/api/users', {
+      user: {
+        email: 'jane@example.com',
+        password: 'secret',
+        username: 'jane',
+      },
+    });
+    expect(session.token).toBe('register-token');
+    expect(session.user.username).toBe('jane');
+  });
+
+  it('current user reads the authenticated RealWorld user endpoint', async () => {
+    const client = createClient();
+    vi.mocked(client.get).mockResolvedValue({
+      user: {
+        bio: 'API learner',
+        email: 'jake@example.com',
+        image: 'https://example.com/avatar.png',
+        token: 'fresh-token',
+        username: 'jake',
+      },
+    });
+
+    const session = await getCurrentUser(client);
+
+    expect(client.get).toHaveBeenCalledWith('/api/user');
+    expect(session).toEqual({
+      token: 'fresh-token',
+      user: {
+        bio: 'API learner',
+        email: 'jake@example.com',
+        image: 'https://example.com/avatar.png',
+        username: 'jake',
+      },
+    });
+  });
+});

--- a/frontend/src/features/auth/__tests__/authApi.test.ts
+++ b/frontend/src/features/auth/__tests__/authApi.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ApiClient } from '../../../lib/apiClient';
+import type { ApiClient } from '@/lib/apiClient';
 import { getCurrentUser, loginUser, registerUser } from '../api/authApi';
 
+/**
+ * auth API関数がHTTP clientへ渡すpath/body/optionsを検証するためのclient stubを作る。
+ */
 function createClient(): ApiClient {
   return {
     delete: vi.fn(),
@@ -12,8 +15,8 @@ function createClient(): ApiClient {
   };
 }
 
-describe('auth API', () => {
-  it('login sends RealWorld credentials and maps the returned session', async () => {
+describe('認証API', () => {
+  it('loginはRealWorld形式の認証情報を未認証リクエストとして送りsessionへ変換する', async () => {
     const client = createClient();
     vi.mocked(client.post).mockResolvedValue({
       user: {
@@ -33,12 +36,16 @@ describe('auth API', () => {
       client,
     );
 
-    expect(client.post).toHaveBeenCalledWith('/api/users/login', {
-      user: {
-        email: 'jake@example.com',
-        password: 'secret',
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/users/login',
+      {
+        user: {
+          email: 'jake@example.com',
+          password: 'secret',
+        },
       },
-    });
+      { auth: false },
+    );
     expect(session).toEqual({
       token: 'login-token',
       user: {
@@ -50,7 +57,7 @@ describe('auth API', () => {
     });
   });
 
-  it('register sends RealWorld user payload and maps the returned session', async () => {
+  it('registerはRealWorld形式のユーザー情報を未認証リクエストとして送りsessionへ変換する', async () => {
     const client = createClient();
     vi.mocked(client.post).mockResolvedValue({
       user: {
@@ -71,18 +78,22 @@ describe('auth API', () => {
       client,
     );
 
-    expect(client.post).toHaveBeenCalledWith('/api/users', {
-      user: {
-        email: 'jane@example.com',
-        password: 'secret',
-        username: 'jane',
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/users',
+      {
+        user: {
+          email: 'jane@example.com',
+          password: 'secret',
+          username: 'jane',
+        },
       },
-    });
+      { auth: false },
+    );
     expect(session.token).toBe('register-token');
     expect(session.user.username).toBe('jane');
   });
 
-  it('current user reads the authenticated RealWorld user endpoint', async () => {
+  it('current userは認証済みRealWorld user endpointを読みsessionへ変換する', async () => {
     const client = createClient();
     vi.mocked(client.get).mockResolvedValue({
       user: {

--- a/frontend/src/features/auth/api/authApi.ts
+++ b/frontend/src/features/auth/api/authApi.ts
@@ -1,4 +1,4 @@
-import { apiClient, type ApiClient } from '../../../lib/apiClient';
+import { apiClient, type ApiClient } from '@/lib/apiClient';
 import type {
   AuthApi,
   AuthSession,
@@ -24,9 +24,13 @@ export async function loginUser(
   credentials: LoginCredentials,
   client: ApiClient = apiClient,
 ): Promise<AuthSession> {
-  const response = await client.post<AuthUserResponse>('/api/users/login', {
-    user: credentials,
-  });
+  const response = await client.post<AuthUserResponse>(
+    '/api/users/login',
+    {
+      user: credentials,
+    },
+    { auth: false },
+  );
 
   return mapAuthSession(response);
 }
@@ -38,9 +42,13 @@ export async function registerUser(
   credentials: RegisterCredentials,
   client: ApiClient = apiClient,
 ): Promise<AuthSession> {
-  const response = await client.post<AuthUserResponse>('/api/users', {
-    user: credentials,
-  });
+  const response = await client.post<AuthUserResponse>(
+    '/api/users',
+    {
+      user: credentials,
+    },
+    { auth: false },
+  );
 
   return mapAuthSession(response);
 }

--- a/frontend/src/features/auth/api/authApi.ts
+++ b/frontend/src/features/auth/api/authApi.ts
@@ -1,0 +1,79 @@
+import { apiClient, type ApiClient } from '../../../lib/apiClient';
+import type {
+  AuthApi,
+  AuthSession,
+  AuthUser,
+  LoginCredentials,
+  RegisterCredentials,
+} from '../types/auth';
+
+interface AuthUserResponse {
+  user: {
+    bio: string | null;
+    email: string;
+    image: string | null;
+    token: string;
+    username: string;
+  };
+}
+
+/**
+ * RealWorld login endpointへ認証情報を送り、UI向けのAuthSessionへ変換する。
+ */
+export async function loginUser(
+  credentials: LoginCredentials,
+  client: ApiClient = apiClient,
+): Promise<AuthSession> {
+  const response = await client.post<AuthUserResponse>('/api/users/login', {
+    user: credentials,
+  });
+
+  return mapAuthSession(response);
+}
+
+/**
+ * RealWorld register endpointへ登録情報を送り、UI向けのAuthSessionへ変換する。
+ */
+export async function registerUser(
+  credentials: RegisterCredentials,
+  client: ApiClient = apiClient,
+): Promise<AuthSession> {
+  const response = await client.post<AuthUserResponse>('/api/users', {
+    user: credentials,
+  });
+
+  return mapAuthSession(response);
+}
+
+/**
+ * 保存済みtokenでcurrent Userを取得し、Providerが扱うAuthSessionへ変換する。
+ */
+export async function getCurrentUser(
+  client: ApiClient = apiClient,
+): Promise<AuthSession> {
+  const response = await client.get<AuthUserResponse>('/api/user');
+
+  return mapAuthSession(response);
+}
+
+export const authApi: AuthApi = {
+  getCurrentUser,
+  login: loginUser,
+  register: registerUser,
+};
+
+function mapAuthSession(response: AuthUserResponse): AuthSession {
+  return {
+    token: response.user.token,
+    user: mapAuthUser(response),
+  };
+}
+
+function mapAuthUser(response: AuthUserResponse): AuthUser {
+  return {
+    bio: response.user.bio,
+    email: response.user.email,
+    image: response.user.image,
+    username: response.user.username,
+  };
+}

--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -1,0 +1,107 @@
+import { type FormEvent, type ReactElement, useState } from 'react';
+import type { LoginCredentials } from '../types/auth';
+import { getFormErrors } from '../utils/formErrors';
+
+interface LoginFormProps {
+  onSubmit: (credentials: LoginCredentials) => Promise<void>;
+  onSuccess?: () => void;
+}
+
+/**
+ * Loginに必要な入力、送信中状態、API error表示を受け持つフォーム。
+ */
+export function LoginForm({
+  onSubmit,
+  onSuccess,
+}: LoginFormProps): ReactElement {
+  const [email, setEmail] = useState('');
+  const [errors, setErrors] = useState<string[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [password, setPassword] = useState('');
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+
+    const validationErrors = validateLogin({ email, password });
+
+    if (validationErrors.length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setErrors([]);
+    setIsSubmitting(true);
+
+    try {
+      await onSubmit({ email, password });
+      onSuccess?.();
+    } catch (error: unknown) {
+      setErrors(getFormErrors(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form className="form-stack" noValidate onSubmit={(event) => void handleSubmit(event)}>
+      <FormErrorList errors={errors} />
+      <label htmlFor="login-email">
+        <span>Email</span>
+        <input
+          autoComplete="email"
+          id="login-email"
+          onChange={(event) => setEmail(event.currentTarget.value)}
+          placeholder="Email"
+          type="email"
+          value={email}
+        />
+      </label>
+      <label htmlFor="login-password">
+        <span>Password</span>
+        <input
+          autoComplete="current-password"
+          id="login-password"
+          onChange={(event) => setPassword(event.currentTarget.value)}
+          placeholder="Password"
+          type="password"
+          value={password}
+        />
+      </label>
+      <button className="primary-action" disabled={isSubmitting} type="submit">
+        {isSubmitting ? 'Signing in...' : 'Sign in'}
+      </button>
+    </form>
+  );
+}
+
+function validateLogin(credentials: LoginCredentials): string[] {
+  const errors: string[] = [];
+
+  if (credentials.email.trim() === '') {
+    errors.push('email is required');
+  }
+
+  if (credentials.password === '') {
+    errors.push('password is required');
+  }
+
+  return errors;
+}
+
+interface FormErrorListProps {
+  errors: string[];
+}
+
+function FormErrorList({ errors }: FormErrorListProps): ReactElement | null {
+  if (errors.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className="form-errors" role="alert">
+      {errors.map((error) => (
+        <li key={error}>{error}</li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/features/auth/components/RegisterForm.tsx
+++ b/frontend/src/features/auth/components/RegisterForm.tsx
@@ -1,0 +1,123 @@
+import { type FormEvent, type ReactElement, useState } from 'react';
+import type { RegisterCredentials } from '../types/auth';
+import { getFormErrors } from '../utils/formErrors';
+
+interface RegisterFormProps {
+  onSubmit: (credentials: RegisterCredentials) => Promise<void>;
+  onSuccess?: () => void;
+}
+
+/**
+ * Registerに必要な入力、送信中状態、API error表示を受け持つフォーム。
+ */
+export function RegisterForm({
+  onSubmit,
+  onSuccess,
+}: RegisterFormProps): ReactElement {
+  const [email, setEmail] = useState('');
+  const [errors, setErrors] = useState<string[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [password, setPassword] = useState('');
+  const [username, setUsername] = useState('');
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+
+    const validationErrors = validateRegister({ email, password, username });
+
+    if (validationErrors.length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setErrors([]);
+    setIsSubmitting(true);
+
+    try {
+      await onSubmit({ email, password, username });
+      onSuccess?.();
+    } catch (error: unknown) {
+      setErrors(getFormErrors(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form className="form-stack" noValidate onSubmit={(event) => void handleSubmit(event)}>
+      <FormErrorList errors={errors} />
+      <label htmlFor="register-username">
+        <span>Username</span>
+        <input
+          autoComplete="username"
+          id="register-username"
+          onChange={(event) => setUsername(event.currentTarget.value)}
+          placeholder="Username"
+          type="text"
+          value={username}
+        />
+      </label>
+      <label htmlFor="register-email">
+        <span>Email</span>
+        <input
+          autoComplete="email"
+          id="register-email"
+          onChange={(event) => setEmail(event.currentTarget.value)}
+          placeholder="Email"
+          type="email"
+          value={email}
+        />
+      </label>
+      <label htmlFor="register-password">
+        <span>Password</span>
+        <input
+          autoComplete="new-password"
+          id="register-password"
+          onChange={(event) => setPassword(event.currentTarget.value)}
+          placeholder="Password"
+          type="password"
+          value={password}
+        />
+      </label>
+      <button className="primary-action" disabled={isSubmitting} type="submit">
+        {isSubmitting ? 'Signing up...' : 'Sign up'}
+      </button>
+    </form>
+  );
+}
+
+function validateRegister(credentials: RegisterCredentials): string[] {
+  const errors: string[] = [];
+
+  if (credentials.username.trim() === '') {
+    errors.push('username is required');
+  }
+
+  if (credentials.email.trim() === '') {
+    errors.push('email is required');
+  }
+
+  if (credentials.password === '') {
+    errors.push('password is required');
+  }
+
+  return errors;
+}
+
+interface FormErrorListProps {
+  errors: string[];
+}
+
+function FormErrorList({ errors }: FormErrorListProps): ReactElement | null {
+  if (errors.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className="form-errors" role="alert">
+      {errors.map((error) => (
+        <li key={error}>{error}</li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/features/auth/index.ts
+++ b/frontend/src/features/auth/index.ts
@@ -1,0 +1,10 @@
+export { authApi, getCurrentUser, loginUser, registerUser } from './api/authApi';
+export { LoginForm } from './components/LoginForm';
+export { RegisterForm } from './components/RegisterForm';
+export type {
+  AuthApi,
+  AuthSession,
+  AuthUser,
+  LoginCredentials,
+  RegisterCredentials,
+} from './types/auth';

--- a/frontend/src/features/auth/types/auth.ts
+++ b/frontend/src/features/auth/types/auth.ts
@@ -1,0 +1,26 @@
+export interface AuthUser {
+  bio: string | null;
+  email: string;
+  image: string | null;
+  username: string;
+}
+
+export interface AuthSession {
+  token: string;
+  user: AuthUser;
+}
+
+export interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+export interface RegisterCredentials extends LoginCredentials {
+  username: string;
+}
+
+export interface AuthApi {
+  getCurrentUser: () => Promise<AuthSession>;
+  login: (credentials: LoginCredentials) => Promise<AuthSession>;
+  register: (credentials: RegisterCredentials) => Promise<AuthSession>;
+}

--- a/frontend/src/features/auth/utils/formErrors.ts
+++ b/frontend/src/features/auth/utils/formErrors.ts
@@ -1,4 +1,4 @@
-import { isApiError } from '../../../lib/apiError';
+import { isApiError } from '@/lib/apiError';
 
 /**
  * form componentがunknown errorをユーザー表示用の文字列配列へ変換する。

--- a/frontend/src/features/auth/utils/formErrors.ts
+++ b/frontend/src/features/auth/utils/formErrors.ts
@@ -1,0 +1,16 @@
+import { isApiError } from '../../../lib/apiError';
+
+/**
+ * form componentがunknown errorをユーザー表示用の文字列配列へ変換する。
+ */
+export function getFormErrors(error: unknown): string[] {
+  if (isApiError(error)) {
+    return error.bodyErrors.length > 0 ? error.bodyErrors : [error.message];
+  }
+
+  if (error instanceof Error) {
+    return [error.message];
+  }
+
+  return ['Something went wrong. Please try again.'];
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -86,6 +86,11 @@ button {
   cursor: pointer;
 }
 
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
 button:focus-visible,
 a:focus-visible,
 input:focus-visible,
@@ -405,6 +410,19 @@ textarea:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 20px;
+}
+
+.form-errors {
+  margin: 0;
+  border-left: 3px solid var(--error);
+  color: var(--error);
+  padding: 0 0 0 16px;
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.form-errors li + li {
+  margin-top: 6px;
 }
 
 .form-stack label {

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -7,6 +7,11 @@
     "module": "ESNext",
     "types": ["vite/client"],
     "skipLibCheck": true,
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
+    "paths": {
+      "@/*": ["src/*"]
+    },
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+import { fileURLToPath, URL } from "node:url";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
   server: {
     port: 3005,
     host: true,


### PR DESCRIPTION
# 概要

- `features/auth` に RealWorld 互換の login / register / current user API と認証フォームを追加
- `AuthProvider` を demo state から token lifecycle / current User / refresh / logout を扱う実装へ更新
- 保存済み token からの current User 復元、401 clear、logout と refresh の race 対策を追加
- `@/` alias と `frontend/.env.example` を追加し、ローカルViteから backend API へ接続しやすくする
- login 後 return path 復帰、API validation error 表示、入力保持、logout、refresh中guard待機のテストを追加

# 関連Issue

Closes #67

Epic: #53

# 修正ファイルの説明

## Auth Feature

- `frontend/src/features/auth/api/authApi.ts`
  - RealWorld 互換の `/api/users/login`, `/api/users`, `/api/user` 呼び出しを追加
  - login / register は `{ auth: false }` を指定し、古い token を送らないようにするため
- `frontend/src/features/auth/components/LoginForm.tsx`
  - login 入力、submit、loading、error 表示を追加
  - API error 時に入力を保持するため
- `frontend/src/features/auth/components/RegisterForm.tsx`
  - register 入力、submit、loading、error 表示を追加
  - duplicate / validation error をフォーム上に表示するため
- `frontend/src/features/auth/types/auth.ts`
  - 認証API、認証入力、current User の型を追加
  - Provider / form / API の契約を明確にするため
- `frontend/src/features/auth/utils/formErrors.ts`
  - `ApiError` をフォーム表示用メッセージへ変換
  - raw error handling をフォームから分離するため
- `frontend/src/features/auth/index.ts`
  - feature の公開APIを定義
  - 外部から内部パスへ直接依存しないため

## App Provider / Routes

- `frontend/src/app/providers/AuthProvider.tsx`
  - login / register / refresh / logout と token persist / clear を実装
  - mount 時に保存済み token から current User を復元するため
  - unauthorized は token / current User を clear し、その他 refresh 失敗は未認証扱いにするため
  - refresh 中に logout した場合、古い current User 結果を再適用しないため
- `frontend/src/app/routes/guards.tsx`
  - `isRefreshing` 中は protected / guest route の redirect 判定を保留
  - 起動直後に保存済み token があるユーザーを login へ早期遷移させないため
- `frontend/src/app/providers/authContext.ts`
  - Auth context の contract を実セッション操作へ更新
  - route guard / pages / shell が同じ認証状態を参照するため
- `frontend/src/app/providers/AppProviders.tsx`
  - テスト用に `authApi` 注入を許可
  - fetch へ依存しない route integration test を書くため
- `frontend/src/app/routes/pages.tsx`
  - Login / Register page に auth form を組み込み
  - login 成功後に safe return path へ遷移するため
- `frontend/src/app/layouts/AppShell.tsx`
  - logout action 名を context に合わせて更新
  - token / current User を確実にクリアするため

## Frontend Config

- `frontend/tsconfig.app.json`
  - `@/*` path alias を追加
  - app / features / lib 間の import を安定させるため
- `frontend/vite.config.ts`
  - Vite の `@` alias を `src` へ設定
  - TypeScript と dev server の解決を揃えるため
- `frontend/.env.example`
  - `VITE_API_BASE_URL=http://localhost:8080` を追加
  - Vite単体起動時も backend API 接続先を共有できるようにするため

## Tests / Styles

- `frontend/src/features/auth/__tests__/authApi.test.ts`
  - API request shape、`auth: false`、response mapping を検証
- `frontend/src/features/auth/__tests__/AuthForms.test.tsx`
  - submit、loading、API error 表示、入力保持を検証
- `frontend/src/app/providers/__tests__/AuthProvider.test.tsx`
  - token persist / mount refresh / unauthorized clear / logout / refresh race を検証
- `frontend/src/app/routes/__tests__/router.test.tsx`
  - login 後 return path、unsafe return path、refresh中guard待機の回帰を検証
- `frontend/src/index.css`
  - auth form error と disabled button の表示を追加

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| フロントエンド変更あり | フロントエンドのテスト・lint・型チェック | `pnpm -C frontend exec vitest run` / `pnpm -C frontend exec eslint .` / `pnpm -C frontend exec tsc -b --noEmit` | すべて成功する | 成功 |
| バックエンド変更あり | バックエンドのテスト・format確認・静的解析 | 対象外 | バックエンド変更なし | 対象外 |
| ドキュメントのみ変更 | Markdown と参照確認 | `git diff --check` | 空白エラーがない | 成功 |
| 対象外の検証あり | ブラウザでの手動確認 | Browser実行ツールがこのセッションで未公開 | 自動テストで主要導線を確認 | 対象外 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: `frontend/.env.example` に `VITE_API_BASE_URL=http://localhost:8080` を追加。個人環境では `frontend/.env.local` にコピーして使用する
- レビュー時に重点確認してほしい点: AuthProvider の token lifecycle、mount refresh、return path、フォーム error 表示と入力保持、`@/` alias 設定
