### PR TITLE
[#127]: JWTとBFF認証の統合QAを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ pnpm -C bff type-check
 pnpm -C bff test
 ```
 
+認証統合 QA（Docker 起動済み環境）:
+
+```bash
+pnpm qa:auth
+```
+
 バックエンド:
 
 ```bash

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -16,6 +16,9 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->statefulApi();
+        $middleware->redirectGuestsTo(
+            fn (Request $request): ?string => $request->is('api/*') ? null : route('login')
+        );
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->shouldRenderJsonWhen(

--- a/backend/tests/Feature/RealWorldApiErrorResponseTest.php
+++ b/backend/tests/Feature/RealWorldApiErrorResponseTest.php
@@ -51,6 +51,14 @@ describe('RealWorld API error response', function (): void {
         );
     });
 
+    it('Accept headerがない未認証APIリクエストも401とerrors.bodyを返す', function (): void {
+        assertRealWorldApiError(
+            $this->get('/api/user'),
+            401,
+            ['Unauthenticated.'],
+        );
+    });
+
     it('権限なしリクエストに403とerrors.bodyを返す', function (): void {
         assertRealWorldApiError(
             $this->getJson('/api/__test-forbidden'),

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "prepare": "husky"
+    "prepare": "husky",
+    "qa:auth": "node scripts/qa/auth-integration-qa.mjs"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.0",

--- a/scripts/qa/auth-integration-qa.mjs
+++ b/scripts/qa/auth-integration-qa.mjs
@@ -1,0 +1,484 @@
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+const DEFAULT_PUBLIC_API_BASE_URL = 'http://localhost:8080';
+const DEFAULT_FRONTEND_ORIGIN = 'http://localhost:3005';
+const SESSION_COOKIE_NAME = '__Host-conduit_session';
+const REQUEST_TIMEOUT_MS = 10_000;
+const SERVICE_READY_TIMEOUT_MS = 60_000;
+const SERVICE_READY_INTERVAL_MS = 1_000;
+
+const publicApiBaseUrl = trimTrailingSlash(
+  process.env.PUBLIC_API_BASE_URL ?? DEFAULT_PUBLIC_API_BASE_URL,
+);
+const frontendOrigin = trimTrailingSlash(
+  process.env.FRONTEND_ORIGIN ?? DEFAULT_FRONTEND_ORIGIN,
+);
+
+const runId = createRunId();
+const credential = createCredential(runId);
+
+async function main() {
+  console.log('auth integration QA');
+  console.log(`- Public API: ${publicApiBaseUrl}`);
+  console.log(`- Frontend origin: ${frontendOrigin}`);
+
+  await waitForService(
+    'Public API',
+    async () => {
+      const { response } = await requestJson(`${publicApiBaseUrl}/api/user`);
+      return response.status === 401;
+    },
+  );
+  await waitForService(
+    'frontend /api proxy',
+    async () => {
+      const jar = new CookieJar();
+      const { payload, response } = await requestJson(
+        `${frontendOrigin}/api/session/csrf`,
+        { jar },
+      );
+
+      return response.status === 200 && isRecord(payload) && typeof payload.csrfToken === 'string';
+    },
+  );
+
+  await verifyPublicJwtApi();
+  await verifyBffBrowserSessionViaFrontendOrigin();
+  await verifyFrontendProductionCodeDoesNotHandleJwt();
+
+  console.log('auth integration QA passed');
+}
+
+async function verifyPublicJwtApi() {
+  const user = {
+    email: `qa-public-${runId}@example.com`,
+    password: credential,
+    username: `qa-public-${runId}`,
+  };
+
+  const register = await requestJson(`${publicApiBaseUrl}/api/users`, {
+    body: { user },
+    method: 'POST',
+  });
+  assertStatus(register, 201, 'Public register returns 201');
+  const registerToken = extractUserToken(register.payload, 'Public register');
+  assertUserField(register.payload, 'email', user.email, 'Public register');
+
+  const login = await requestJson(`${publicApiBaseUrl}/api/users/login`, {
+    body: {
+      user: {
+        email: user.email,
+        password: user.password,
+      },
+    },
+    method: 'POST',
+  });
+  assertStatus(login, 200, 'Public login returns 200');
+  extractUserToken(login.payload, 'Public login');
+
+  const current = await requestJson(`${publicApiBaseUrl}/api/user`, {
+    headers: {
+      Authorization: `Token ${registerToken}`,
+    },
+  });
+  assertStatus(current, 200, 'Public current user accepts Token scheme JWT');
+  assertUserField(current.payload, 'email', user.email, 'Public current user');
+  extractUserToken(current.payload, 'Public current user');
+
+  console.log('- Public JWT API contract passed');
+}
+
+async function verifyBffBrowserSessionViaFrontendOrigin() {
+  const jar = new CookieJar();
+  const user = {
+    email: `qa-bff-${runId}@example.com`,
+    password: credential,
+    username: `qa-bff-${runId}`,
+  };
+
+  const csrf = await requestJson(`${frontendOrigin}/api/session/csrf`, { jar });
+  assertStatus(csrf, 200, 'BFF CSRF bootstrap returns 200');
+  const csrfToken = extractCsrfToken(csrf.payload);
+  const csrfSetCookie = firstSetCookie(csrf.response);
+  assertSessionCookieAttributes(csrfSetCookie, 'BFF CSRF bootstrap');
+  const preSessionCookie = jar.get(SESSION_COOKIE_NAME);
+  assert.ok(preSessionCookie, 'BFF CSRF bootstrap stores a pre-session cookie');
+
+  const missingCsrf = await requestJson(`${frontendOrigin}/api/session/login`, {
+    body: {
+      user: {
+        email: user.email,
+        password: user.password,
+      },
+    },
+    jar,
+    method: 'POST',
+  });
+  assertStatus(missingCsrf, 419, 'BFF login without CSRF proof is rejected');
+
+  const register = await requestJson(`${frontendOrigin}/api/session/register`, {
+    body: { user },
+    headers: {
+      'X-CSRF-TOKEN': csrfToken,
+    },
+    jar,
+    method: 'POST',
+  });
+  assertStatus(register, 201, 'BFF register via frontend origin returns 201');
+  assertUserField(register.payload, 'email', user.email, 'BFF register');
+  assertNoUserToken(register.payload, 'BFF register');
+  assert.equal(
+    jar.get(SESSION_COOKIE_NAME) === preSessionCookie,
+    false,
+    'BFF register regenerates the session identifier',
+  );
+
+  const current = await requestJson(`${frontendOrigin}/api/session`, { jar });
+  assertStatus(current, 200, 'BFF current session returns 200');
+  assertUserField(current.payload, 'email', user.email, 'BFF current session');
+  assertNoUserToken(current.payload, 'BFF current session');
+
+  const blockedDirectIdentity = await requestJson(`${frontendOrigin}/api/user`, { jar });
+  assertStatus(
+    blockedDirectIdentity,
+    404,
+    'BFF blocks browser-facing direct identity Public API path',
+  );
+
+  const update = await requestJson(`${frontendOrigin}/api/session/user`, {
+    body: {
+      user: {
+        bio: 'QA browser session',
+        image: null,
+      },
+    },
+    headers: {
+      'X-CSRF-TOKEN': csrfToken,
+    },
+    jar,
+    method: 'PUT',
+  });
+  assertStatus(update, 200, 'BFF settings update returns 200');
+  assertUserField(update.payload, 'bio', 'QA browser session', 'BFF settings update');
+  assertNoUserToken(update.payload, 'BFF settings update');
+
+  const logout = await requestJson(`${frontendOrigin}/api/session`, {
+    headers: {
+      'X-CSRF-TOKEN': csrfToken,
+    },
+    jar,
+    method: 'DELETE',
+  });
+  assertStatus(logout, 204, 'BFF logout returns 204');
+  assert.match(firstSetCookie(logout.response), /Max-Age=0/, 'BFF logout expires session cookie');
+
+  const loggedOutCurrent = await requestJson(`${frontendOrigin}/api/session`, { jar });
+  assertStatus(loggedOutCurrent, 401, 'BFF current session is unauthorized after logout');
+
+  const loginCsrf = await requestJson(`${frontendOrigin}/api/session/csrf`, { jar });
+  assertStatus(loginCsrf, 200, 'BFF CSRF bootstrap after logout returns 200');
+  const loginCsrfToken = extractCsrfToken(loginCsrf.payload);
+
+  const login = await requestJson(`${frontendOrigin}/api/session/login`, {
+    body: {
+      user: {
+        email: user.email,
+        password: user.password,
+      },
+    },
+    headers: {
+      'X-CSRF-TOKEN': loginCsrfToken,
+    },
+    jar,
+    method: 'POST',
+  });
+  assertStatus(login, 200, 'BFF login via frontend origin returns 200');
+  assertUserField(login.payload, 'email', user.email, 'BFF login');
+  assertNoUserToken(login.payload, 'BFF login');
+
+  console.log('- BFF BrowserSession Docker path passed');
+}
+
+async function verifyFrontendProductionCodeDoesNotHandleJwt() {
+  const files = await listSourceFiles('frontend/src');
+  const forbidden = [
+    { label: 'localStorage', pattern: /\blocalStorage\b/ },
+    { label: 'sessionStorage', pattern: /\bsessionStorage\b/ },
+    { label: 'Authorization header', pattern: /\bAuthorization\b/ },
+    { label: 'RealWorld Token scheme', pattern: /(['"`])Token\s/ },
+    { label: 'auth token helper', pattern: /authToken/ },
+    { label: 'direct localhost Public API', pattern: /localhost:8080/ },
+  ];
+  const violations = [];
+
+  for (const file of files) {
+    const contents = await readFile(file, 'utf8');
+
+    for (const rule of forbidden) {
+      if (rule.pattern.test(contents)) {
+        violations.push(`${relative(process.cwd(), file)}: ${rule.label}`);
+      }
+    }
+  }
+
+  assert.deepEqual(
+    violations,
+    [],
+    `Frontend production code must not handle browser-readable JWT credentials:\n${violations.join('\n')}`,
+  );
+
+  console.log('- Frontend JWT boundary static scan passed');
+}
+
+async function requestJson(url, options = {}) {
+  const headers = new Headers(options.headers);
+  const init = {
+    headers,
+    method: options.method ?? 'GET',
+    redirect: 'manual',
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  };
+
+  if (options.jar instanceof CookieJar) {
+    const cookieHeader = options.jar.header();
+
+    if (cookieHeader !== '') {
+      headers.set('Cookie', cookieHeader);
+    }
+  }
+
+  if (options.body !== undefined) {
+    headers.set('Content-Type', 'application/json');
+    init.body = JSON.stringify(options.body);
+  }
+
+  const response = await fetch(url, init);
+
+  if (options.jar instanceof CookieJar) {
+    options.jar.store(response);
+  }
+
+  const text = await response.text();
+  const payload = text === '' ? null : parseJson(text, url);
+
+  return {
+    payload,
+    response,
+    text,
+  };
+}
+
+async function waitForService(label, probe) {
+  const startedAt = Date.now();
+  let lastError = null;
+
+  while (Date.now() - startedAt < SERVICE_READY_TIMEOUT_MS) {
+    try {
+      if (await probe()) {
+        console.log(`- ${label} is ready`);
+        return;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    await delay(SERVICE_READY_INTERVAL_MS);
+  }
+
+  if (lastError instanceof Error) {
+    throw new Error(`${label} did not become ready: ${lastError.message}`);
+  }
+
+  throw new Error(`${label} did not become ready`);
+}
+
+class CookieJar {
+  #cookies = new Map();
+
+  get(name) {
+    return this.#cookies.get(name) ?? null;
+  }
+
+  header() {
+    return Array.from(this.#cookies.entries())
+      .map(([name, value]) => `${name}=${value}`)
+      .join('; ');
+  }
+
+  store(response) {
+    for (const setCookie of getSetCookies(response)) {
+      const [pair] = setCookie.split(';');
+
+      if (pair === undefined || pair === '') {
+        continue;
+      }
+
+      const separatorIndex = pair.indexOf('=');
+
+      if (separatorIndex === -1) {
+        continue;
+      }
+
+      const name = pair.slice(0, separatorIndex);
+      const value = pair.slice(separatorIndex + 1);
+
+      if (value === '' || /;\s*Max-Age=0\b/i.test(setCookie)) {
+        this.#cookies.delete(name);
+        continue;
+      }
+
+      this.#cookies.set(name, value);
+    }
+  }
+}
+
+async function listSourceFiles(root) {
+  const entries = await readdir(root, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const absolutePath = join(root, entry.name);
+    const normalizedPath = absolutePath.split('/').join('/');
+
+    if (
+      normalizedPath.includes('/__tests__/') ||
+      normalizedPath.includes('/test/') ||
+      normalizedPath.endsWith('.test.ts') ||
+      normalizedPath.endsWith('.test.tsx')
+    ) {
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      files.push(...await listSourceFiles(absolutePath));
+      continue;
+    }
+
+    if (entry.isFile() && /\.(ts|tsx)$/.test(entry.name)) {
+      files.push(absolutePath);
+    }
+  }
+
+  return files;
+}
+
+function assertStatus(result, expected, label) {
+  assert.equal(
+    result.response.status,
+    expected,
+    `${label}: expected ${expected}, got ${result.response.status} ${JSON.stringify(redact(result.payload))}`,
+  );
+}
+
+function assertUserField(payload, field, expected, label) {
+  assert.ok(isRecord(payload), `${label}: response must be an object`);
+  assert.ok(isRecord(payload.user), `${label}: response.user must be an object`);
+  assert.equal(payload.user[field], expected, `${label}: user.${field} mismatch`);
+}
+
+function assertNoUserToken(payload, label) {
+  assert.ok(isRecord(payload), `${label}: response must be an object`);
+  assert.ok(isRecord(payload.user), `${label}: response.user must be an object`);
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(payload.user, 'token'),
+    false,
+    `${label}: browser-facing user response must not include token`,
+  );
+}
+
+function extractUserToken(payload, label) {
+  assert.ok(isRecord(payload), `${label}: response must be an object`);
+  assert.ok(isRecord(payload.user), `${label}: response.user must be an object`);
+  assert.equal(typeof payload.user.token, 'string', `${label}: user.token must be a string`);
+  assert.notEqual(payload.user.token, '', `${label}: user.token must not be empty`);
+
+  return payload.user.token;
+}
+
+function extractCsrfToken(payload) {
+  assert.ok(isRecord(payload), 'CSRF response must be an object');
+  assert.equal(typeof payload.csrfToken, 'string', 'CSRF token must be a string');
+  assert.ok(payload.csrfToken.length >= 32, 'CSRF token should be opaque');
+
+  return payload.csrfToken;
+}
+
+function assertSessionCookieAttributes(setCookie, label) {
+  assert.match(setCookie, /^__Host-conduit_session=[^;]+;/, `${label}: session cookie name`);
+  assert.match(setCookie, /;\s*Path=\//, `${label}: session cookie Path=/`);
+  assert.match(setCookie, /;\s*HttpOnly\b/i, `${label}: session cookie HttpOnly`);
+  assert.match(setCookie, /;\s*Secure\b/i, `${label}: session cookie Secure`);
+  assert.match(setCookie, /;\s*SameSite=Lax\b/i, `${label}: session cookie SameSite=Lax`);
+  assert.doesNotMatch(setCookie, /;\s*Domain=/i, `${label}: session cookie must not set Domain`);
+}
+
+function firstSetCookie(response) {
+  return getSetCookies(response)[0] ?? '';
+}
+
+function getSetCookies(response) {
+  if (typeof response.headers.getSetCookie === 'function') {
+    return response.headers.getSetCookie();
+  }
+
+  const setCookie = response.headers.get('set-cookie');
+
+  return setCookie === null ? [] : [setCookie];
+}
+
+function parseJson(text, url) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`Expected JSON response from ${url}, got: ${text.slice(0, 120)}`, {
+      cause: error,
+    });
+  }
+}
+
+function redact(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => redact(item));
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const redacted = {};
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    redacted[key] = key.toLowerCase().includes('token') ? '[redacted]' : redact(nestedValue);
+  }
+
+  return redacted;
+}
+
+function createRunId() {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function createCredential(value) {
+  return `qa-pass-${value}`;
+}
+
+function trimTrailingSlash(value) {
+  return value.replace(/\/+$/, '');
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/scripts/qa/auth-integration-qa.mjs
+++ b/scripts/qa/auth-integration-qa.mjs
@@ -2,6 +2,12 @@ import assert from 'node:assert/strict';
 import { readdir, readFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 
+/**
+ * ローカル Docker の認証トポロジを、JWT をログに出さずに smoke test する。
+ *
+ * 想定経路:
+ * Browser 相当 request -> frontend origin /api/* -> BFF -> backend-nginx.
+ */
 const DEFAULT_PUBLIC_API_BASE_URL = 'http://localhost:8080';
 const DEFAULT_FRONTEND_ORIGIN = 'http://localhost:3005';
 const SESSION_COOKIE_NAME = '__Host-conduit_session';
@@ -19,6 +25,9 @@ const frontendOrigin = trimTrailingSlash(
 const runId = createRunId();
 const credential = createCredential(runId);
 
+/**
+ * service 未起動と認証契約の破綻を切り分けるため、先に readiness を確認する。
+ */
 async function main() {
   console.log('auth integration QA');
   console.log(`- Public API: ${publicApiBaseUrl}`);
@@ -51,6 +60,9 @@ async function main() {
   console.log('auth integration QA passed');
 }
 
+/**
+ * Laravel Public API が外部へ公開する RealWorld JWT contract を検証する。
+ */
 async function verifyPublicJwtApi() {
   const user = {
     email: `qa-public-${runId}@example.com`,
@@ -90,6 +102,9 @@ async function verifyPublicJwtApi() {
   console.log('- Public JWT API contract passed');
 }
 
+/**
+ * React app と同じ origin 経由で BrowserSession lifecycle を検証する。
+ */
 async function verifyBffBrowserSessionViaFrontendOrigin() {
   const jar = new CookieJar();
   const user = {
@@ -201,6 +216,9 @@ async function verifyBffBrowserSessionViaFrontendOrigin() {
   console.log('- BFF BrowserSession Docker path passed');
 }
 
+/**
+ * frontend production code が browser-readable credential を扱い始める退行を検出する。
+ */
 async function verifyFrontendProductionCodeDoesNotHandleJwt() {
   const files = await listSourceFiles('frontend/src');
   const forbidden = [
@@ -232,6 +250,9 @@ async function verifyFrontendProductionCodeDoesNotHandleJwt() {
   console.log('- Frontend JWT boundary static scan passed');
 }
 
+/**
+ * session 検証用の小さな in-memory jar に cookie を保持しながら JSON request を送る。
+ */
 async function requestJson(url, options = {}) {
   const headers = new Headers(options.headers);
   const init = {
@@ -270,6 +291,9 @@ async function requestJson(url, options = {}) {
   };
 }
 
+/**
+ * container status だけに依存せず、service contract を polling する。
+ */
 async function waitForService(label, probe) {
   const startedAt = Date.now();
   let lastError = null;
@@ -294,6 +318,9 @@ async function waitForService(label, probe) {
   throw new Error(`${label} did not become ready`);
 }
 
+/**
+ * Node fetch 用の最小 cookie jar。QA に必要な name/value pair だけを保持する。
+ */
 class CookieJar {
   #cookies = new Map();
 
@@ -334,6 +361,9 @@ class CookieJar {
   }
 }
 
+/**
+ * test と test setup を除外し、production TypeScript source だけを列挙する。
+ */
 async function listSourceFiles(root) {
   const entries = await readdir(root, { withFileTypes: true });
   const files = [];
@@ -364,6 +394,9 @@ async function listSourceFiles(root) {
   return files;
 }
 
+/**
+ * 失敗内容を PR comment に貼れるよう、token を redact して status を検証する。
+ */
 function assertStatus(result, expected, label) {
   assert.equal(
     result.response.status,


### PR DESCRIPTION
# 概要

- Public JWT API と same-origin BFF / BrowserSession の認証フローを Docker 環境で統合検証する QA コマンドを追加しました。
- `pnpm qa:auth` で `frontend origin (:3005) /api/* -> bff -> backend-nginx` の経路を通し、Public register / login / current user、BFF CSRF bootstrap、register / login / current session / settings update / logout を検証します。
- Browser-facing response に `user.token` が含まれないこと、`__Host-conduit_session` cookie attributes、missing CSRF `419`、direct identity path block、frontend production code の JWT storage / `Authorization` header 非使用を確認します。
- 統合 QA で、`Accept: application/json` がない API 未認証 request が Laravel の `login` route redirect に落ちて 500 になる問題を検出したため、API route の guest redirect を無効化して RealWorld JSON `401` に統一しました。

# 関連Issue

Closes #127

Epic: #123

# JWT Auth Migration の確認範囲

```mermaid
flowchart LR
  I124["#124 / PR #130<br/>認証境界と Docker topology の方針確定"]
  I126["#126 / PR #133<br/>Public API JWT 発行・検証"]
  I131["#131 / PR #134<br/>Hono + TypeScript BFF / BrowserSession / CSRF / Docker"]
  I125["#125 / PR #136<br/>Frontend を BFF client へ移行"]
  I127["#127 / 本 PR<br/>統合 QA"]
  I124 --> I126
  I124 --> I131
  I126 --> I125
  I131 --> I125
  I125 --> I127
```

| 順序 | Issue / PR | 内容 | 状態 |
| ---- | ---------- | ---- | ---- |
| 1 | [#124](https://github.com/takeshi-arihori/real-world/issues/124) / PR #130 | Public JWT API と same-origin BFF / BrowserSession / Docker topology の契約を確定する | マージ済み |
| 2-a | [#126](https://github.com/takeshi-arihori/real-world/issues/126) / PR #133 | Laravel Public API の JWT 発行・検証を実装する | マージ済み |
| 2-b | [#131](https://github.com/takeshi-arihori/real-world/issues/131) / PR #134 | Hono + TypeScript BFF、BrowserSession、CSRF、Public API forwarding、Docker service / proxy / env example を実装する | マージ済み |
| 3 | [#125](https://github.com/takeshi-arihori/real-world/issues/125) / PR #136 | Frontend を JWT 保存 / header 注入から BFF client へ移行する | マージ済み |
| 4 | [#127](https://github.com/takeshi-arihori/real-world/issues/127) / 本 PR | Public JWT と BFF BrowserSession の統合 QA を実施する | 本 PR |

# 修正ファイルの説明

## Integration QA

- `scripts/qa/auth-integration-qa.mjs`
  - Docker 起動済み環境へ HTTP request を投げる認証統合 QA を追加しました。
  - Public API の RealWorld JWT contract と、frontend origin 経由の BFF BrowserSession / CSRF / token stripping / logout invalidation を一度に検証するためです。
- `package.json`
  - `pnpm qa:auth` script を追加しました。
  - PR 前やレビュー時に統合 QA を再実行しやすくするためです。
- `README.md`
  - 認証統合 QA コマンドをテスト・リント一覧へ追記しました。
  - Docker 起動済み環境が前提であることを明示するためです。

## Backend Error Handling

- `backend/tests/Feature/RealWorldApiErrorResponseTest.php`
  - `Accept` header がない未認証 API request でも `401` + `errors.body` を返す Feature test を追加しました。
  - BFF からの server-to-server request や通常の `fetch` が `Accept: application/json` に依存せず API JSON contract を満たすことを固定するためです。
- `backend/bootstrap/app.php`
  - API route の guest redirect 先を `null` にし、`AuthenticationException` を RealWorld JSON renderer に渡すようにしました。
  - 未認証 API request が存在しない `login` route へ redirect しようとして `500` になる問題を防ぐためです。

# テスト

| 条件 | 実施した検証 | コマンド・確認内容 | 結果 |
| ---- | ------------ | ------------------ | ---- |
| Red / QA command | QA command 先行追加 | `pnpm qa:auth` | 期待通り失敗（`scripts/qa/auth-integration-qa.mjs` 未実装） |
| Red / backend contract | Accept header なし未認証 API のテスト追加 | `docker compose exec backend-php sh -lc 'php artisan test --filter="Accept headerがない未認証APIリクエスト"'` | 期待通り失敗（`500 Route [login] not defined`） |
| Docker 統合 QA | Public JWT + frontend origin BFF BrowserSession 経路 | `pnpm qa:auth` | 成功 |
| Backend 変更あり | Pest 全体 | `docker compose exec backend-php sh -lc 'php artisan test'` | 成功（45 tests / 204 assertions） |
| Backend 変更あり | Pint format check | `docker compose exec backend-php sh -lc './vendor/bin/pint --test'` | 成功（72 files） |
| Backend 変更あり | PHPStan / Larastan | `docker compose exec backend-php sh -lc './vendor/bin/phpstan analyse --no-progress --memory-limit=512M'` | 成功 |
| BFF 関連 QA | TypeScript 型チェック | `pnpm -C bff type-check` | 成功 |
| BFF 関連 QA | Contract test | `pnpm -C bff test` | 成功（9 tests） |
| Frontend 境界確認 | TypeScript 型チェック | `pnpm -C frontend exec tsc -b --noEmit` | 成功 |
| Frontend 境界確認 | Vitest 全体 | `pnpm -C frontend exec vitest run` | 成功（5 files / 33 tests） |
| Frontend 境界確認 | ESLint | `pnpm -C frontend exec eslint .` | 成功 |
| QA script | 構文確認 | `node --check scripts/qa/auth-integration-qa.mjs` | 成功 |
| 差分確認 | 空白エラー確認 | `git diff --check HEAD` | 成功 |

# マージもしくはレビュー時の注意点

- build が必要: なし。
- migrate が必要: なし。
- 環境変数・設定変更: なし。`pnpm qa:auth` は既定で `http://localhost:8080` と `http://localhost:3005` を使い、必要な場合は `PUBLIC_API_BASE_URL` / `FRONTEND_ORIGIN` で上書きできます。
- Docker が必要: あり。`pnpm qa:auth` は `docker compose up -d` 済みで、backend DB migration が完了している環境を前提にします。
- レビュー時に重点確認してほしい点: QA が browser-facing response に JWT を出していないこと、frontend origin `/api/*` 経由で BFF を通していること、API 未認証時の JSON `401` が `Accept` header に依存しないこと。
