### PR TITLE
[#69]: Article CRUD APIを実装

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
         "eamodio.gitlens",
-        "xdebug.php-debug"
+        "xdebug.php-debug",
+        "bmewburn.vscode-intelephense-client"
       ],
       "settings": {
         "editor.formatOnSave": true,

--- a/backend/app/Application/Publishing/Commands/CreateArticleCommand.php
+++ b/backend/app/Application/Publishing/Commands/CreateArticleCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\Commands;
+
+use App\Application\Publishing\DTOs\CreateArticleDto;
+use App\Domain\Publishing\Entities\Article;
+use App\Domain\Publishing\Repositories\ArticleRepositoryInterface;
+use App\Domain\Publishing\Services\UniqueSlugGenerator;
+use App\Domain\Publishing\ValueObjects\ArticleBody;
+use App\Domain\Publishing\ValueObjects\ArticleDescription;
+use App\Domain\Publishing\ValueObjects\ArticleTitle;
+use App\Domain\Publishing\ValueObjects\TagName;
+use Illuminate\Support\Facades\DB;
+
+final readonly class CreateArticleCommand
+{
+    public function __construct(
+        private ArticleRepositoryInterface $articles,
+        private UniqueSlugGenerator $slugs,
+    ) {}
+
+    /**
+     * Article を作成する。
+     */
+    public function execute(int $authorUserId, CreateArticleDto $dto): Article
+    {
+        $title = new ArticleTitle($dto->title);
+        $article = Article::create(
+            authorUserId: $authorUserId,
+            slug: $this->slugs->generate($title),
+            title: $title,
+            description: new ArticleDescription($dto->description),
+            body: new ArticleBody($dto->body),
+            tags: array_map(
+                fn (string $tagName): TagName => new TagName($tagName),
+                $dto->tagList,
+            ),
+        );
+
+        return DB::transaction(fn (): Article => $this->articles->save($article));
+    }
+}

--- a/backend/app/Application/Publishing/Commands/DeleteArticleCommand.php
+++ b/backend/app/Application/Publishing/Commands/DeleteArticleCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\Commands;
+
+use App\Domain\Publishing\Entities\Article;
+use App\Domain\Publishing\Repositories\ArticleRepositoryInterface;
+use Illuminate\Support\Facades\DB;
+
+final readonly class DeleteArticleCommand
+{
+    public function __construct(private ArticleRepositoryInterface $articles) {}
+
+    /**
+     * Article を削除する。
+     */
+    public function execute(Article $article): void
+    {
+        DB::transaction(function () use ($article): void {
+            $this->articles->delete($article);
+        });
+    }
+}

--- a/backend/app/Application/Publishing/Commands/UpdateArticleCommand.php
+++ b/backend/app/Application/Publishing/Commands/UpdateArticleCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\Commands;
+
+use App\Application\Publishing\DTOs\UpdateArticleDto;
+use App\Domain\Publishing\Entities\Article;
+use App\Domain\Publishing\Repositories\ArticleRepositoryInterface;
+use App\Domain\Publishing\Services\UniqueSlugGenerator;
+use App\Domain\Publishing\ValueObjects\ArticleBody;
+use App\Domain\Publishing\ValueObjects\ArticleDescription;
+use App\Domain\Publishing\ValueObjects\ArticleTitle;
+use Illuminate\Support\Facades\DB;
+
+final readonly class UpdateArticleCommand
+{
+    public function __construct(
+        private ArticleRepositoryInterface $articles,
+        private UniqueSlugGenerator $slugs,
+    ) {}
+
+    /**
+     * Article author が更新する本文情報を反映する。
+     */
+    public function execute(Article $article, UpdateArticleDto $dto): Article
+    {
+        $title = new ArticleTitle($dto->title ?? $article->title()->value);
+        $description = new ArticleDescription($dto->description ?? $article->description()->value);
+        $body = new ArticleBody($dto->body ?? $article->body()->value);
+        $id = $article->id();
+
+        $slug = $article->slug();
+
+        if ($id !== null && $title->value !== $article->title()->value) {
+            $slug = $this->slugs->generate($title, $id);
+        }
+
+        $updated = $article->withUpdatedContent(
+            slug: $slug,
+            title: $title,
+            description: $description,
+            body: $body,
+        );
+
+        return DB::transaction(fn (): Article => $this->articles->update($updated));
+    }
+}

--- a/backend/app/Application/Publishing/DTOs/ArticleAuthorDto.php
+++ b/backend/app/Application/Publishing/DTOs/ArticleAuthorDto.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\DTOs;
+
+final readonly class ArticleAuthorDto
+{
+    public function __construct(
+        public string $username,
+        public ?string $bio,
+        public ?string $image,
+        public bool $following,
+    ) {}
+}

--- a/backend/app/Application/Publishing/DTOs/ArticleListDto.php
+++ b/backend/app/Application/Publishing/DTOs/ArticleListDto.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\DTOs;
+
+final readonly class ArticleListDto
+{
+    /**
+     * @param  list<ArticleViewDto>  $articles
+     */
+    public function __construct(
+        public array $articles,
+        public int $articlesCount,
+    ) {}
+}

--- a/backend/app/Application/Publishing/DTOs/ArticleViewDto.php
+++ b/backend/app/Application/Publishing/DTOs/ArticleViewDto.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\DTOs;
+
+final readonly class ArticleViewDto
+{
+    /**
+     * @param  list<string>  $tagList
+     */
+    public function __construct(
+        public string $slug,
+        public string $title,
+        public string $description,
+        public string $body,
+        public array $tagList,
+        public string $createdAt,
+        public string $updatedAt,
+        public bool $favorited,
+        public int $favoritesCount,
+        public ArticleAuthorDto $author,
+    ) {}
+}

--- a/backend/app/Application/Publishing/DTOs/CreateArticleDto.php
+++ b/backend/app/Application/Publishing/DTOs/CreateArticleDto.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\DTOs;
+
+final readonly class CreateArticleDto
+{
+    /**
+     * @param  list<string>  $tagList
+     */
+    public function __construct(
+        public string $title,
+        public string $description,
+        public string $body,
+        public array $tagList,
+    ) {}
+}

--- a/backend/app/Application/Publishing/DTOs/ListArticlesDto.php
+++ b/backend/app/Application/Publishing/DTOs/ListArticlesDto.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\DTOs;
+
+final readonly class ListArticlesDto
+{
+    public function __construct(
+        public ?string $tag,
+        public ?string $author,
+        public ?string $favorited,
+        public int $limit,
+        public int $offset,
+    ) {}
+}

--- a/backend/app/Application/Publishing/DTOs/UpdateArticleDto.php
+++ b/backend/app/Application/Publishing/DTOs/UpdateArticleDto.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\DTOs;
+
+final readonly class UpdateArticleDto
+{
+    public function __construct(
+        public ?string $title,
+        public ?string $description,
+        public ?string $body,
+    ) {}
+}

--- a/backend/app/Application/Publishing/Queries/ArticleViewFactory.php
+++ b/backend/app/Application/Publishing/Queries/ArticleViewFactory.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\Queries;
+
+use App\Application\Publishing\DTOs\ArticleAuthorDto;
+use App\Application\Publishing\DTOs\ArticleViewDto;
+use App\Infrastructure\Persistence\Models\Article as ArticleModel;
+use App\Infrastructure\Persistence\Models\Tag as TagModel;
+use App\Infrastructure\Persistence\Models\User as UserModel;
+use DateTimeInterface;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+final class ArticleViewFactory
+{
+    /**
+     * Article Eloquent model 群を RealWorld response 用 DTO へ変換する。
+     *
+     * @param  Collection<int, ArticleModel>  $models
+     * @return list<ArticleViewDto>
+     */
+    public function fromModels(Collection $models, ?int $currentUserId): array
+    {
+        if ($models->isEmpty()) {
+            return [];
+        }
+
+        $models->each(fn (ArticleModel $model): ArticleModel => $model->loadMissing(['author', 'tags']));
+        $articleIds = $models->map(fn (ArticleModel $model): int => (int) $model->getKey())->all();
+        $authorUserIds = $models->map(fn (ArticleModel $model): int => $model->author_user_id)->unique()->all();
+        $favoritesCounts = $this->favoritesCounts($articleIds);
+        $favoritedArticleIds = $this->favoritedArticleIds($articleIds, $currentUserId);
+        $followingUserIds = $this->followingUserIds($authorUserIds, $currentUserId);
+
+        return $models
+            ->map(fn (ArticleModel $model): ArticleViewDto => $this->buildDto(
+                model: $model,
+                favoritesCounts: $favoritesCounts,
+                favoritedArticleIds: $favoritedArticleIds,
+                followingUserIds: $followingUserIds,
+            ))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * 1件の Article Eloquent model を RealWorld response 用 DTO へ変換する。
+     */
+    public function fromModel(ArticleModel $model, ?int $currentUserId): ArticleViewDto
+    {
+        return $this->fromModels(collect([$model]), $currentUserId)[0];
+    }
+
+    /**
+     * @param  array<int, int>  $favoritesCounts
+     * @param  list<int>  $favoritedArticleIds
+     * @param  list<int>  $followingUserIds
+     */
+    private function buildDto(
+        ArticleModel $model,
+        array $favoritesCounts,
+        array $favoritedArticleIds,
+        array $followingUserIds,
+    ): ArticleViewDto {
+        /** @var UserModel $author */
+        $author = $model->author;
+
+        return new ArticleViewDto(
+            slug: $model->slug,
+            title: $model->title,
+            description: $model->description,
+            body: $model->body,
+            tagList: $model->tags
+                ->map(fn (TagModel $tag): string => $tag->name)
+                ->values()
+                ->all(),
+            createdAt: $this->formatTimestamp($model->created_at),
+            updatedAt: $this->formatTimestamp($model->updated_at),
+            favorited: in_array((int) $model->getKey(), $favoritedArticleIds, true),
+            favoritesCount: $favoritesCounts[(int) $model->getKey()] ?? 0,
+            author: new ArticleAuthorDto(
+                username: $author->username,
+                bio: $author->bio,
+                image: $author->image,
+                following: in_array($model->author_user_id, $followingUserIds, true),
+            ),
+        );
+    }
+
+    /**
+     * @param  list<int>  $articleIds
+     * @return array<int, int>
+     */
+    private function favoritesCounts(array $articleIds): array
+    {
+        /** @var array<int, int> $counts */
+        $counts = DB::table('favorites')
+            ->select('article_id', DB::raw('count(*) as aggregate'))
+            ->whereIn('article_id', $articleIds)
+            ->groupBy('article_id')
+            ->pluck('aggregate', 'article_id')
+            ->map(fn (mixed $count): int => (int) $count)
+            ->all();
+
+        return $counts;
+    }
+
+    /**
+     * @param  list<int>  $articleIds
+     * @return list<int>
+     */
+    private function favoritedArticleIds(array $articleIds, ?int $currentUserId): array
+    {
+        if ($currentUserId === null) {
+            return [];
+        }
+
+        return DB::table('favorites')
+            ->where('user_id', $currentUserId)
+            ->whereIn('article_id', $articleIds)
+            ->pluck('article_id')
+            ->map(fn (mixed $articleId): int => (int) $articleId)
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  list<int>  $authorUserIds
+     * @return list<int>
+     */
+    private function followingUserIds(array $authorUserIds, ?int $currentUserId): array
+    {
+        if ($currentUserId === null) {
+            return [];
+        }
+
+        return DB::table('follows')
+            ->where('follower_user_id', $currentUserId)
+            ->whereIn('followee_user_id', $authorUserIds)
+            ->pluck('followee_user_id')
+            ->map(fn (mixed $userId): int => (int) $userId)
+            ->values()
+            ->all();
+    }
+
+    /**
+     * RealWorld API の timestamp 形式へ変換する。
+     */
+    private function formatTimestamp(DateTimeInterface|string|null $value): string
+    {
+        return Carbon::parse($value)->utc()->format('Y-m-d\TH:i:s.v\Z');
+    }
+}

--- a/backend/app/Application/Publishing/Queries/GetArticleForAuthorizationQuery.php
+++ b/backend/app/Application/Publishing/Queries/GetArticleForAuthorizationQuery.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\Queries;
+
+use App\Domain\Publishing\Entities\Article;
+use App\Domain\Publishing\Exceptions\ArticleNotFoundException;
+use App\Domain\Publishing\Repositories\ArticleRepositoryInterface;
+use App\Domain\Publishing\ValueObjects\Slug;
+
+final readonly class GetArticleForAuthorizationQuery
+{
+    public function __construct(private ArticleRepositoryInterface $articles) {}
+
+    /**
+     * 認可判定用に slug に一致する Article Entity を取得する。
+     */
+    public function execute(string $slug): Article
+    {
+        $article = $this->articles->findBySlug(new Slug($slug));
+
+        if ($article === null) {
+            throw ArticleNotFoundException::forSlug($slug);
+        }
+
+        return $article;
+    }
+}

--- a/backend/app/Application/Publishing/Queries/GetArticleQuery.php
+++ b/backend/app/Application/Publishing/Queries/GetArticleQuery.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\Queries;
+
+use App\Application\Publishing\DTOs\ArticleViewDto;
+use App\Domain\Publishing\Exceptions\ArticleNotFoundException;
+use App\Infrastructure\Persistence\Models\Article as ArticleModel;
+
+final readonly class GetArticleQuery
+{
+    public function __construct(private ArticleViewFactory $articles) {}
+
+    /**
+     * slug に一致する Article を response DTO として取得する。
+     */
+    public function execute(string $slug, ?int $currentUserId): ArticleViewDto
+    {
+        $model = ArticleModel::query()
+            ->with(['author', 'tags'])
+            ->where('slug', $slug)
+            ->first();
+
+        if (! $model instanceof ArticleModel) {
+            throw ArticleNotFoundException::forSlug($slug);
+        }
+
+        return $this->articles->fromModel($model, $currentUserId);
+    }
+}

--- a/backend/app/Application/Publishing/Queries/ListArticlesQuery.php
+++ b/backend/app/Application/Publishing/Queries/ListArticlesQuery.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\Queries;
+
+use App\Application\Publishing\DTOs\ArticleListDto;
+use App\Application\Publishing\DTOs\ListArticlesDto;
+use App\Infrastructure\Persistence\Models\Article as ArticleModel;
+use Illuminate\Database\Eloquent\Builder;
+
+final readonly class ListArticlesQuery
+{
+    public function __construct(private ArticleViewFactory $articles) {}
+
+    /**
+     * Article 一覧を filter / pagination つきで取得する。
+     */
+    public function execute(ListArticlesDto $dto, ?int $currentUserId): ArticleListDto
+    {
+        $query = ArticleModel::query()
+            ->with(['author', 'tags']);
+
+        if ($dto->tag !== null) {
+            $query->whereHas('tags', function (Builder $query) use ($dto): void {
+                $query->where('name', $dto->tag);
+            });
+        }
+
+        if ($dto->author !== null) {
+            $query->whereHas('author', function (Builder $query) use ($dto): void {
+                $query->where('username', $dto->author);
+            });
+        }
+
+        if ($dto->favorited !== null) {
+            $query->whereHas('favoritedBy', function (Builder $query) use ($dto): void {
+                $query->where('username', $dto->favorited);
+            });
+        }
+
+        $articlesCount = (clone $query)->count();
+        $models = $query
+            ->orderByDesc('created_at')
+            ->offset($dto->offset)
+            ->limit($dto->limit)
+            ->get();
+
+        return new ArticleListDto(
+            articles: $this->articles->fromModels($models, $currentUserId),
+            articlesCount: $articlesCount,
+        );
+    }
+}

--- a/backend/app/Domain/Publishing/Entities/Article.php
+++ b/backend/app/Domain/Publishing/Entities/Article.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Publishing\Entities;
+
+use App\Domain\Publishing\ValueObjects\ArticleBody;
+use App\Domain\Publishing\ValueObjects\ArticleDescription;
+use App\Domain\Publishing\ValueObjects\ArticleId;
+use App\Domain\Publishing\ValueObjects\ArticleTitle;
+use App\Domain\Publishing\ValueObjects\Slug;
+use App\Domain\Publishing\ValueObjects\TagName;
+use InvalidArgumentException;
+
+final readonly class Article
+{
+    /**
+     * @param  list<TagName>  $tags
+     */
+    public function __construct(
+        private ?ArticleId $id,
+        private int $authorUserId,
+        private Slug $slug,
+        private ArticleTitle $title,
+        private ArticleDescription $description,
+        private ArticleBody $body,
+        private array $tags,
+    ) {
+        if ($authorUserId < 1) {
+            throw new InvalidArgumentException('Article author user id must be positive.');
+        }
+    }
+
+    /**
+     * 新規 Article を生成する。
+     *
+     * @param  list<TagName>  $tags
+     */
+    public static function create(
+        int $authorUserId,
+        Slug $slug,
+        ArticleTitle $title,
+        ArticleDescription $description,
+        ArticleBody $body,
+        array $tags,
+    ): self {
+        return new self(
+            id: null,
+            authorUserId: $authorUserId,
+            slug: $slug,
+            title: $title,
+            description: $description,
+            body: $body,
+            tags: $tags,
+        );
+    }
+
+    /**
+     * 永続化後の ID を持つ Article として複製する。
+     */
+    public function withId(ArticleId $id): self
+    {
+        return new self(
+            id: $id,
+            authorUserId: $this->authorUserId,
+            slug: $this->slug,
+            title: $this->title,
+            description: $this->description,
+            body: $this->body,
+            tags: $this->tags,
+        );
+    }
+
+    /**
+     * 更新後の本文情報を持つ Article として複製する。
+     */
+    public function withUpdatedContent(
+        Slug $slug,
+        ArticleTitle $title,
+        ArticleDescription $description,
+        ArticleBody $body,
+    ): self {
+        return new self(
+            id: $this->id,
+            authorUserId: $this->authorUserId,
+            slug: $slug,
+            title: $title,
+            description: $description,
+            body: $body,
+            tags: $this->tags,
+        );
+    }
+
+    public function id(): ?ArticleId
+    {
+        return $this->id;
+    }
+
+    public function authorUserId(): int
+    {
+        return $this->authorUserId;
+    }
+
+    public function slug(): Slug
+    {
+        return $this->slug;
+    }
+
+    public function title(): ArticleTitle
+    {
+        return $this->title;
+    }
+
+    public function description(): ArticleDescription
+    {
+        return $this->description;
+    }
+
+    public function body(): ArticleBody
+    {
+        return $this->body;
+    }
+
+    /**
+     * @return list<TagName>
+     */
+    public function tags(): array
+    {
+        return $this->tags;
+    }
+}

--- a/backend/app/Domain/Publishing/Exceptions/ArticleNotFoundException.php
+++ b/backend/app/Domain/Publishing/Exceptions/ArticleNotFoundException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Publishing\Exceptions;
+
+use DomainException;
+
+final class ArticleNotFoundException extends DomainException
+{
+    /**
+     * slug に一致する Article が存在しないことを表す。
+     */
+    public static function forSlug(string $slug): self
+    {
+        return new self("article not found: {$slug}");
+    }
+}

--- a/backend/app/Domain/Publishing/Repositories/ArticleRepositoryInterface.php
+++ b/backend/app/Domain/Publishing/Repositories/ArticleRepositoryInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Publishing\Repositories;
+
+use App\Domain\Publishing\Entities\Article;
+use App\Domain\Publishing\ValueObjects\ArticleId;
+use App\Domain\Publishing\ValueObjects\Slug;
+
+interface ArticleRepositoryInterface
+{
+    /**
+     * slug に一致する Article を取得する。
+     */
+    public function findBySlug(Slug $slug): ?Article;
+
+    /**
+     * slug が既存 Article で使用済みか確認する。
+     */
+    public function slugExists(Slug $slug): bool;
+
+    /**
+     * 指定 Article を除き、slug が既存 Article で使用済みか確認する。
+     */
+    public function slugExistsExceptArticle(Slug $slug, ArticleId $exceptArticleId): bool;
+
+    /**
+     * Article を永続化し、採番済み ID を含む Entity を返す。
+     */
+    public function save(Article $article): Article;
+
+    /**
+     * 既存 Article を更新し、更新後の Entity を返す。
+     */
+    public function update(Article $article): Article;
+
+    /**
+     * Article を削除する。
+     */
+    public function delete(Article $article): void;
+}

--- a/backend/app/Domain/Publishing/Services/UniqueSlugGenerator.php
+++ b/backend/app/Domain/Publishing/Services/UniqueSlugGenerator.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Publishing\Services;
+
+use App\Domain\Publishing\Repositories\ArticleRepositoryInterface;
+use App\Domain\Publishing\ValueObjects\ArticleId;
+use App\Domain\Publishing\ValueObjects\ArticleTitle;
+use App\Domain\Publishing\ValueObjects\Slug;
+
+final readonly class UniqueSlugGenerator
+{
+    public function __construct(private ArticleRepositoryInterface $articles) {}
+
+    /**
+     * title から一意な Article slug を生成する。
+     */
+    public function generate(ArticleTitle $title, ?ArticleId $exceptArticleId = null): Slug
+    {
+        $base = $this->baseSlug($title->value);
+        $candidate = new Slug($base);
+        $suffix = 2;
+
+        while ($this->exists($candidate, $exceptArticleId)) {
+            $candidate = new Slug($base.'-'.$suffix);
+            $suffix++;
+        }
+
+        return $candidate;
+    }
+
+    /**
+     * slug 候補が衝突しているか確認する。
+     */
+    private function exists(Slug $slug, ?ArticleId $exceptArticleId): bool
+    {
+        if ($exceptArticleId === null) {
+            return $this->articles->slugExists($slug);
+        }
+
+        return $this->articles->slugExistsExceptArticle($slug, $exceptArticleId);
+    }
+
+    /**
+     * title を URL safe な slug base へ変換する。
+     */
+    private function baseSlug(string $title): string
+    {
+        $slug = strtolower(trim($title));
+        $slug = preg_replace('/[^a-z0-9]+/', '-', $slug) ?? '';
+        $slug = trim($slug, '-');
+
+        return $slug === '' ? 'article' : $slug;
+    }
+}

--- a/backend/app/Domain/Publishing/ValueObjects/ArticleBody.php
+++ b/backend/app/Domain/Publishing/ValueObjects/ArticleBody.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Publishing\ValueObjects;
+
+use InvalidArgumentException;
+
+final readonly class ArticleBody
+{
+    public string $value;
+
+    /**
+     * Article の本文を表す。
+     */
+    public function __construct(string $value)
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException('Article body is invalid.');
+        }
+
+        $this->value = $value;
+    }
+}

--- a/backend/app/Domain/Publishing/ValueObjects/ArticleDescription.php
+++ b/backend/app/Domain/Publishing/ValueObjects/ArticleDescription.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Publishing\ValueObjects;
+
+use InvalidArgumentException;
+
+final readonly class ArticleDescription
+{
+    public string $value;
+
+    /**
+     * Article の description を表す。
+     */
+    public function __construct(string $value)
+    {
+        $normalized = trim($value);
+
+        if ($normalized === '' || strlen($normalized) > 255) {
+            throw new InvalidArgumentException('Article description is invalid.');
+        }
+
+        $this->value = $normalized;
+    }
+}

--- a/backend/app/Domain/Publishing/ValueObjects/ArticleId.php
+++ b/backend/app/Domain/Publishing/ValueObjects/ArticleId.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Publishing\ValueObjects;
+
+use InvalidArgumentException;
+
+final readonly class ArticleId
+{
+    /**
+     * 正の整数 ID として Article を識別する。
+     */
+    public function __construct(public int $value)
+    {
+        if ($value < 1) {
+            throw new InvalidArgumentException('Article id must be positive.');
+        }
+    }
+}

--- a/backend/app/Domain/Publishing/ValueObjects/ArticleTitle.php
+++ b/backend/app/Domain/Publishing/ValueObjects/ArticleTitle.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Publishing\ValueObjects;
+
+use InvalidArgumentException;
+
+final readonly class ArticleTitle
+{
+    public string $value;
+
+    /**
+     * Article の title を表す。
+     */
+    public function __construct(string $value)
+    {
+        $normalized = trim($value);
+
+        if ($normalized === '' || strlen($normalized) > 255) {
+            throw new InvalidArgumentException('Article title is invalid.');
+        }
+
+        $this->value = $normalized;
+    }
+}

--- a/backend/app/Domain/Publishing/ValueObjects/Slug.php
+++ b/backend/app/Domain/Publishing/ValueObjects/Slug.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Publishing\ValueObjects;
+
+use InvalidArgumentException;
+
+final readonly class Slug
+{
+    public string $value;
+
+    /**
+     * URL path segment として使う Article slug を表す。
+     */
+    public function __construct(string $value)
+    {
+        $normalized = trim($value);
+
+        if ($normalized === '' || strlen($normalized) > 255) {
+            throw new InvalidArgumentException('Slug is invalid.');
+        }
+
+        $this->value = $normalized;
+    }
+}

--- a/backend/app/Domain/Publishing/ValueObjects/TagName.php
+++ b/backend/app/Domain/Publishing/ValueObjects/TagName.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Publishing\ValueObjects;
+
+use InvalidArgumentException;
+
+final readonly class TagName
+{
+    public string $value;
+
+    /**
+     * Article に付与する Tag の名前を表す。
+     */
+    public function __construct(string $value)
+    {
+        $normalized = trim($value);
+
+        if ($normalized === '' || strlen($normalized) > 50) {
+            throw new InvalidArgumentException('Tag name is invalid.');
+        }
+
+        $this->value = $normalized;
+    }
+}

--- a/backend/app/Infrastructure/Persistence/Models/Article.php
+++ b/backend/app/Infrastructure/Persistence/Models/Article.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+/**
+ * @property int $id
+ * @property int $author_user_id
+ * @property string $slug
+ * @property string $title
+ * @property string $description
+ * @property string $body
+ */
+class Article extends Model
+{
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'author_user_id',
+        'slug',
+        'title',
+        'description',
+        'body',
+    ];
+
+    /**
+     * Article author の User を返す。
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'author_user_id');
+    }
+
+    /**
+     * Article に付与された Tag を返す。
+     *
+     * @return BelongsToMany<Tag, $this>
+     */
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class, 'article_tag')
+            ->withTimestamps()
+            ->orderBy('article_tag.id');
+    }
+
+    /**
+     * Article を favorite した User を返す。
+     *
+     * @return BelongsToMany<User, $this>
+     */
+    public function favoritedBy(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'favorites', 'article_id', 'user_id')
+            ->withTimestamps();
+    }
+}

--- a/backend/app/Infrastructure/Persistence/Models/Tag.php
+++ b/backend/app/Infrastructure/Persistence/Models/Tag.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+/**
+ * @property int $id
+ * @property string $name
+ */
+class Tag extends Model
+{
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * Tag が付与された Article を返す。
+     *
+     * @return BelongsToMany<Article, $this>
+     */
+    public function articles(): BelongsToMany
+    {
+        return $this->belongsToMany(Article::class, 'article_tag')
+            ->withTimestamps();
+    }
+}

--- a/backend/app/Infrastructure/Persistence/Repositories/EloquentArticleRepository.php
+++ b/backend/app/Infrastructure/Persistence/Repositories/EloquentArticleRepository.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Repositories;
+
+use App\Domain\Publishing\Entities\Article;
+use App\Domain\Publishing\Repositories\ArticleRepositoryInterface;
+use App\Domain\Publishing\ValueObjects\ArticleBody;
+use App\Domain\Publishing\ValueObjects\ArticleDescription;
+use App\Domain\Publishing\ValueObjects\ArticleId;
+use App\Domain\Publishing\ValueObjects\ArticleTitle;
+use App\Domain\Publishing\ValueObjects\Slug;
+use App\Domain\Publishing\ValueObjects\TagName;
+use App\Infrastructure\Persistence\Models\Article as ArticleModel;
+use App\Infrastructure\Persistence\Models\Tag as TagModel;
+use InvalidArgumentException;
+
+final class EloquentArticleRepository implements ArticleRepositoryInterface
+{
+    /**
+     * slug に一致する Article を取得する。
+     */
+    public function findBySlug(Slug $slug): ?Article
+    {
+        $model = ArticleModel::query()
+            ->with('tags')
+            ->where('slug', $slug->value)
+            ->first();
+
+        return $model instanceof ArticleModel ? $this->toEntity($model) : null;
+    }
+
+    /**
+     * slug が既存 Article で使用済みか確認する。
+     */
+    public function slugExists(Slug $slug): bool
+    {
+        return ArticleModel::query()
+            ->where('slug', $slug->value)
+            ->exists();
+    }
+
+    /**
+     * 指定 Article を除き、slug が既存 Article で使用済みか確認する。
+     */
+    public function slugExistsExceptArticle(Slug $slug, ArticleId $exceptArticleId): bool
+    {
+        return ArticleModel::query()
+            ->where('slug', $slug->value)
+            ->whereKeyNot($exceptArticleId->value)
+            ->exists();
+    }
+
+    /**
+     * Article を永続化し、採番済み ID を含む Entity を返す。
+     */
+    public function save(Article $article): Article
+    {
+        $model = new ArticleModel;
+        $this->fillModel($model, $article);
+        $model->save();
+        $this->syncTags($model, $article->tags());
+
+        return $this->toEntity($model->load('tags'));
+    }
+
+    /**
+     * 既存 Article を更新し、更新後の Entity を返す。
+     */
+    public function update(Article $article): Article
+    {
+        $id = $article->id();
+
+        if ($id === null) {
+            throw new InvalidArgumentException('Cannot update an unsaved article.');
+        }
+
+        $model = ArticleModel::query()->findOrFail($id->value);
+        $this->fillModel($model, $article);
+        $model->save();
+        $this->syncTags($model, $article->tags());
+
+        return $this->toEntity($model->load('tags'));
+    }
+
+    /**
+     * Article を削除する。
+     */
+    public function delete(Article $article): void
+    {
+        $id = $article->id();
+
+        if ($id === null) {
+            throw new InvalidArgumentException('Cannot delete an unsaved article.');
+        }
+
+        ArticleModel::query()->whereKey($id->value)->delete();
+    }
+
+    /**
+     * Domain Entity の値を Eloquent model へ反映する。
+     */
+    private function fillModel(ArticleModel $model, Article $article): void
+    {
+        $model->fill([
+            'author_user_id' => $article->authorUserId(),
+            'slug' => $article->slug()->value,
+            'title' => $article->title()->value,
+            'description' => $article->description()->value,
+            'body' => $article->body()->value,
+        ]);
+    }
+
+    /**
+     * Article に紐付く Tag を同期する。
+     *
+     * @param  list<TagName>  $tags
+     */
+    private function syncTags(ArticleModel $model, array $tags): void
+    {
+        $tagIds = [];
+
+        foreach ($tags as $tag) {
+            $tagIds[] = TagModel::query()->firstOrCreate(['name' => $tag->value])->getKey();
+        }
+
+        $model->tags()->sync($tagIds);
+    }
+
+    /**
+     * 永続化モデルを Domain Entity へ変換する。
+     */
+    private function toEntity(ArticleModel $model): Article
+    {
+        $model->loadMissing('tags');
+
+        return new Article(
+            id: new ArticleId((int) $model->getKey()),
+            authorUserId: $model->author_user_id,
+            slug: new Slug($model->slug),
+            title: new ArticleTitle($model->title),
+            description: new ArticleDescription($model->description),
+            body: new ArticleBody($model->body),
+            tags: $model->tags
+                ->map(fn (TagModel $tag): TagName => new TagName($tag->name))
+                ->values()
+                ->all(),
+        );
+    }
+}

--- a/backend/app/Infrastructure/Providers/RepositoryServiceProvider.php
+++ b/backend/app/Infrastructure/Providers/RepositoryServiceProvider.php
@@ -7,8 +7,10 @@ namespace App\Infrastructure\Providers;
 use App\Application\Identity\Services\AuthTokenIssuerInterface;
 use App\Application\Identity\Services\PasswordHasherInterface;
 use App\Domain\Identity\Repositories\UserRepositoryInterface;
+use App\Domain\Publishing\Repositories\ArticleRepositoryInterface;
 use App\Infrastructure\Identity\HashPasswordHasher;
 use App\Infrastructure\Identity\JwtAuthTokenIssuer;
+use App\Infrastructure\Persistence\Repositories\EloquentArticleRepository;
 use App\Infrastructure\Persistence\Repositories\EloquentUserRepository;
 use Illuminate\Support\ServiceProvider;
 
@@ -17,6 +19,7 @@ final class RepositoryServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->bind(UserRepositoryInterface::class, EloquentUserRepository::class);
+        $this->app->bind(ArticleRepositoryInterface::class, EloquentArticleRepository::class);
         $this->app->bind(PasswordHasherInterface::class, HashPasswordHasher::class);
         $this->app->bind(AuthTokenIssuerInterface::class, JwtAuthTokenIssuer::class);
     }

--- a/backend/app/Policies/ArticlePolicy.php
+++ b/backend/app/Policies/ArticlePolicy.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Domain\Publishing\Entities\Article;
+use App\Infrastructure\Persistence\Models\User;
+
+final class ArticlePolicy
+{
+    /**
+     * Article author のみ更新を許可する。
+     */
+    public function update(User $user, Article $article): bool
+    {
+        return (int) $user->getKey() === $article->authorUserId();
+    }
+
+    /**
+     * Article author のみ削除を許可する。
+     */
+    public function delete(User $user, Article $article): bool
+    {
+        return (int) $user->getKey() === $article->authorUserId();
+    }
+}

--- a/backend/app/Presentation/Http/Controllers/Publishing/ArticleController.php
+++ b/backend/app/Presentation/Http/Controllers/Publishing/ArticleController.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Controllers\Publishing;
+
+use App\Application\Publishing\Commands\CreateArticleCommand;
+use App\Application\Publishing\Commands\DeleteArticleCommand;
+use App\Application\Publishing\Commands\UpdateArticleCommand;
+use App\Application\Publishing\Queries\GetArticleForAuthorizationQuery;
+use App\Application\Publishing\Queries\GetArticleQuery;
+use App\Application\Publishing\Queries\ListArticlesQuery;
+use App\Presentation\Http\Controllers\Controller;
+use App\Presentation\Http\Requests\Publishing\CreateArticleRequest;
+use App\Presentation\Http\Requests\Publishing\ListArticlesRequest;
+use App\Presentation\Http\Requests\Publishing\UpdateArticleRequest;
+use App\Presentation\Http\Resources\Publishing\ArticleListResource;
+use App\Presentation\Http\Resources\Publishing\SingleArticleResource;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ArticleController extends Controller
+{
+    /**
+     * Article 一覧を RealWorld multiple articles wrapper で返す。
+     */
+    public function index(ListArticlesRequest $request, ListArticlesQuery $query): JsonResponse
+    {
+        return (new ArticleListResource($query->execute(
+            dto: $request->toDto(),
+            currentUserId: $this->optionalAuthenticatedUserId($request),
+        )))
+            ->response()
+            ->setStatusCode(Response::HTTP_OK);
+    }
+
+    /**
+     * Article を作成し、RealWorld single article wrapper で返す。
+     */
+    public function store(
+        CreateArticleRequest $request,
+        CreateArticleCommand $command,
+        GetArticleQuery $query,
+    ): JsonResponse {
+        $article = $command->execute(
+            authorUserId: $this->authenticatedUserId($request),
+            dto: $request->toDto(),
+        );
+
+        return (new SingleArticleResource($query->execute(
+            slug: $article->slug()->value,
+            currentUserId: $this->authenticatedUserId($request),
+        )))
+            ->response()
+            ->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    /**
+     * Article 詳細を RealWorld single article wrapper で返す。
+     */
+    public function show(Request $request, string $slug, GetArticleQuery $query): JsonResponse
+    {
+        return (new SingleArticleResource($query->execute(
+            slug: $slug,
+            currentUserId: $this->optionalAuthenticatedUserId($request),
+        )))
+            ->response()
+            ->setStatusCode(Response::HTTP_OK);
+    }
+
+    /**
+     * Article author が Article を更新する。
+     */
+    public function update(
+        UpdateArticleRequest $request,
+        string $slug,
+        GetArticleForAuthorizationQuery $articleForAuthorization,
+        UpdateArticleCommand $command,
+        GetArticleQuery $query,
+    ): JsonResponse {
+        $article = $articleForAuthorization->execute($slug);
+        Gate::forUser($request->user('api'))->authorize('update', $article);
+
+        $updated = $command->execute($article, $request->toDto());
+
+        return (new SingleArticleResource($query->execute(
+            slug: $updated->slug()->value,
+            currentUserId: $this->authenticatedUserId($request),
+        )))
+            ->response()
+            ->setStatusCode(Response::HTTP_OK);
+    }
+
+    /**
+     * Article author が Article を削除する。
+     */
+    public function destroy(
+        Request $request,
+        string $slug,
+        GetArticleForAuthorizationQuery $articleForAuthorization,
+        DeleteArticleCommand $command,
+    ): JsonResponse {
+        $article = $articleForAuthorization->execute($slug);
+        Gate::forUser($request->user('api'))->authorize('delete', $article);
+
+        $command->execute($article);
+
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * 認証必須 endpoint の認証済み User ID を取得する。
+     */
+    private function authenticatedUserId(Request $request): int
+    {
+        $userId = $request->user()?->getAuthIdentifier();
+
+        if (! is_numeric($userId)) {
+            throw new AuthenticationException;
+        }
+
+        return (int) $userId;
+    }
+
+    /**
+     * Optional auth endpoint で JWT があれば認証済み User ID を取得する。
+     */
+    private function optionalAuthenticatedUserId(Request $request): ?int
+    {
+        if ($request->headers->get('Authorization') === null) {
+            return null;
+        }
+
+        $user = Auth::guard('api')->user();
+        $userId = $user?->getAuthIdentifier();
+
+        if (! is_numeric($userId)) {
+            throw new AuthenticationException;
+        }
+
+        return (int) $userId;
+    }
+}

--- a/backend/app/Presentation/Http/Requests/Publishing/CreateArticleRequest.php
+++ b/backend/app/Presentation/Http/Requests/Publishing/CreateArticleRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Requests\Publishing;
+
+use App\Application\Publishing\DTOs\CreateArticleDto;
+use Illuminate\Foundation\Http\FormRequest;
+
+final class CreateArticleRequest extends FormRequest
+{
+    /**
+     * 認証済み User の Article 作成リクエストとして許可する。
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * RealWorld create article request の nested article payload を検証する。
+     *
+     * @return array<string, list<mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'article' => ['required', 'array'],
+            'article.title' => ['required', 'string', 'max:255'],
+            'article.description' => ['required', 'string', 'max:255'],
+            'article.body' => ['required', 'string'],
+            'article.tagList' => ['sometimes', 'array'],
+            'article.tagList.*' => ['filled', 'string', 'max:50', 'distinct'],
+        ];
+    }
+
+    /**
+     * 検証済み payload を Application DTO へ変換する。
+     */
+    public function toDto(): CreateArticleDto
+    {
+        /** @var array{article: array{title: string, description: string, body: string, tagList?: list<string>}} $payload */
+        $payload = $this->validated();
+
+        return new CreateArticleDto(
+            title: $payload['article']['title'],
+            description: $payload['article']['description'],
+            body: $payload['article']['body'],
+            tagList: $payload['article']['tagList'] ?? [],
+        );
+    }
+}

--- a/backend/app/Presentation/Http/Requests/Publishing/ListArticlesRequest.php
+++ b/backend/app/Presentation/Http/Requests/Publishing/ListArticlesRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Requests\Publishing;
+
+use App\Application\Publishing\DTOs\ListArticlesDto;
+use Illuminate\Foundation\Http\FormRequest;
+
+final class ListArticlesRequest extends FormRequest
+{
+    /**
+     * Article 一覧はゲストにも公開する。
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Article list query parameters を検証する。
+     *
+     * @return array<string, list<mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'tag' => ['sometimes', 'string'],
+            'author' => ['sometimes', 'string'],
+            'favorited' => ['sometimes', 'string'],
+            'limit' => ['sometimes', 'integer', 'min:1'],
+            'offset' => ['sometimes', 'integer', 'min:0'],
+        ];
+    }
+
+    /**
+     * 検証済み query parameters を Application DTO へ変換する。
+     */
+    public function toDto(): ListArticlesDto
+    {
+        /** @var array{tag?: string, author?: string, favorited?: string, limit?: int|string, offset?: int|string} $payload */
+        $payload = $this->validated();
+
+        return new ListArticlesDto(
+            tag: $payload['tag'] ?? null,
+            author: $payload['author'] ?? null,
+            favorited: $payload['favorited'] ?? null,
+            limit: isset($payload['limit']) ? (int) $payload['limit'] : 20,
+            offset: isset($payload['offset']) ? (int) $payload['offset'] : 0,
+        );
+    }
+}

--- a/backend/app/Presentation/Http/Requests/Publishing/UpdateArticleRequest.php
+++ b/backend/app/Presentation/Http/Requests/Publishing/UpdateArticleRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Requests\Publishing;
+
+use App\Application\Publishing\DTOs\UpdateArticleDto;
+use Illuminate\Foundation\Http\FormRequest;
+
+final class UpdateArticleRequest extends FormRequest
+{
+    /**
+     * 認可は Controller から ArticlePolicy へ委譲する。
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * RealWorld update article request の nested article payload を検証する。
+     *
+     * @return array<string, list<mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'article' => ['required', 'array'],
+            'article.title' => ['sometimes', 'filled', 'string', 'max:255'],
+            'article.description' => ['sometimes', 'filled', 'string', 'max:255'],
+            'article.body' => ['sometimes', 'filled', 'string'],
+        ];
+    }
+
+    /**
+     * 検証済み payload を Application DTO へ変換する。
+     */
+    public function toDto(): UpdateArticleDto
+    {
+        /** @var array{article: array{title?: string, description?: string, body?: string}} $payload */
+        $payload = $this->validated();
+
+        return new UpdateArticleDto(
+            title: $payload['article']['title'] ?? null,
+            description: $payload['article']['description'] ?? null,
+            body: $payload['article']['body'] ?? null,
+        );
+    }
+}

--- a/backend/app/Presentation/Http/Resources/Publishing/ArticleListResource.php
+++ b/backend/app/Presentation/Http/Resources/Publishing/ArticleListResource.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Resources\Publishing;
+
+use App\Application\Publishing\DTOs\ArticleListDto;
+use App\Application\Publishing\DTOs\ArticleViewDto;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin ArticleListDto
+ */
+final class ArticleListResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * RealWorld multiple articles wrapper へ変換する。
+     *
+     * @return array{articles: list<array<string, mixed>>, articlesCount: int}
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var ArticleListDto $articleList */
+        $articleList = $this->resource;
+
+        return [
+            'articles' => array_map(
+                fn (ArticleViewDto $article): array => (new ArticleResource($article, includeBody: false))->toArray($request),
+                $articleList->articles,
+            ),
+            'articlesCount' => $articleList->articlesCount,
+        ];
+    }
+}

--- a/backend/app/Presentation/Http/Resources/Publishing/ArticleResource.php
+++ b/backend/app/Presentation/Http/Resources/Publishing/ArticleResource.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Resources\Publishing;
+
+use App\Application\Publishing\DTOs\ArticleViewDto;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin ArticleViewDto
+ */
+final class ArticleResource extends JsonResource
+{
+    public static $wrap = null;
+
+    public function __construct(mixed $resource, private readonly bool $includeBody = true)
+    {
+        parent::__construct($resource);
+    }
+
+    /**
+     * RealWorld article object へ変換する。
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var ArticleViewDto $article */
+        $article = $this->resource;
+        $payload = [
+            'slug' => $article->slug,
+            'title' => $article->title,
+            'description' => $article->description,
+            'tagList' => $article->tagList,
+            'createdAt' => $article->createdAt,
+            'updatedAt' => $article->updatedAt,
+            'favorited' => $article->favorited,
+            'favoritesCount' => $article->favoritesCount,
+            'author' => [
+                'username' => $article->author->username,
+                'bio' => $article->author->bio,
+                'image' => $article->author->image,
+                'following' => $article->author->following,
+            ],
+        ];
+
+        if ($this->includeBody) {
+            $payload = [
+                ...array_slice($payload, 0, 3, true),
+                'body' => $article->body,
+                ...array_slice($payload, 3, null, true),
+            ];
+        }
+
+        return $payload;
+    }
+}

--- a/backend/app/Presentation/Http/Resources/Publishing/SingleArticleResource.php
+++ b/backend/app/Presentation/Http/Resources/Publishing/SingleArticleResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Resources\Publishing;
+
+use App\Application\Publishing\DTOs\ArticleViewDto;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin ArticleViewDto
+ */
+final class SingleArticleResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * RealWorld single article wrapper へ変換する。
+     *
+     * @return array{article: array<string, mixed>}
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'article' => (new ArticleResource($this->resource))->toArray($request),
+        ];
+    }
+}

--- a/backend/app/Presentation/Http/Responses/RealWorldErrorResponse.php
+++ b/backend/app/Presentation/Http/Responses/RealWorldErrorResponse.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Presentation\Http\Responses;
 
+use App\Domain\Publishing\Exceptions\ArticleNotFoundException;
 use DomainException;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
@@ -53,6 +54,10 @@ final class RealWorldErrorResponse
 
         if ($exception instanceof ValidationException) {
             return [Response::HTTP_UNPROCESSABLE_ENTITY, self::validationMessages($exception)];
+        }
+
+        if ($exception instanceof ArticleNotFoundException) {
+            return [Response::HTTP_NOT_FOUND, ['Resource not found.']];
         }
 
         if ($exception instanceof DomainException) {

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -1,7 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Providers;
 
+use App\Domain\Publishing\Entities\Article;
+use App\Policies\ArticlePolicy;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +24,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Gate::policy(Article::class, ArticlePolicy::class);
     }
 }

--- a/backend/database/migrations/2026_06_01_000000_create_publishing_article_tables.php
+++ b/backend/database/migrations/2026_06_01_000000_create_publishing_article_tables.php
@@ -1,0 +1,114 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('articles', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('author_user_id')
+                ->constrained('users')
+                ->restrictOnDelete()
+                ->cascadeOnUpdate();
+            $table->string('slug')->unique('articles_slug_unique');
+            $table->string('title');
+            $table->string('description');
+            $table->text('body');
+            $table->timestamps();
+
+            $table->index(['author_user_id', 'created_at'], 'articles_author_user_id_created_at_index');
+            $table->index('created_at', 'articles_created_at_index');
+        });
+
+        Schema::create('comments', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('article_id')
+                ->constrained('articles')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+            $table->foreignId('author_user_id')
+                ->constrained('users')
+                ->restrictOnDelete()
+                ->cascadeOnUpdate();
+            $table->text('body');
+            $table->timestamps();
+
+            $table->index(['article_id', 'created_at'], 'comments_article_id_created_at_index');
+            $table->index('author_user_id', 'comments_author_user_id_index');
+        });
+
+        Schema::create('tags', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name', 50)->unique('tags_name_unique');
+            $table->timestamps();
+        });
+
+        Schema::create('article_tag', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('article_id')
+                ->constrained('articles')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+            $table->foreignId('tag_id')
+                ->constrained('tags')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+            $table->timestamps();
+
+            $table->unique(['article_id', 'tag_id'], 'article_tag_article_id_tag_id_unique');
+            $table->index('tag_id', 'article_tag_tag_id_index');
+        });
+
+        Schema::create('follows', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('follower_user_id')
+                ->constrained('users')
+                ->restrictOnDelete()
+                ->cascadeOnUpdate();
+            $table->foreignId('followee_user_id')
+                ->constrained('users')
+                ->restrictOnDelete()
+                ->cascadeOnUpdate();
+            $table->timestamps();
+
+            $table->unique(['follower_user_id', 'followee_user_id'], 'follows_follower_followee_unique');
+            $table->index('followee_user_id', 'follows_followee_user_id_index');
+        });
+
+        Schema::create('favorites', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('user_id')
+                ->constrained('users')
+                ->restrictOnDelete()
+                ->cascadeOnUpdate();
+            $table->foreignId('article_id')
+                ->constrained('articles')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+            $table->timestamps();
+
+            $table->unique(['user_id', 'article_id'], 'favorites_user_id_article_id_unique');
+            $table->index('article_id', 'favorites_article_id_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('favorites');
+        Schema::dropIfExists('follows');
+        Schema::dropIfExists('article_tag');
+        Schema::dropIfExists('tags');
+        Schema::dropIfExists('comments');
+        Schema::dropIfExists('articles');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -2,12 +2,18 @@
 
 use App\Presentation\Http\Controllers\Identity\AuthController;
 use App\Presentation\Http\Controllers\Identity\CurrentUserController;
+use App\Presentation\Http\Controllers\Publishing\ArticleController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/users', [AuthController::class, 'register']);
 Route::post('/users/login', [AuthController::class, 'login']);
+Route::get('/articles', [ArticleController::class, 'index'])->name('articles.index');
+Route::get('/articles/{slug}', [ArticleController::class, 'show'])->name('articles.show');
 
 Route::middleware('auth:api')->group(function (): void {
     Route::get('/user', [CurrentUserController::class, 'show']);
     Route::put('/user', [CurrentUserController::class, 'update']);
+    Route::post('/articles', [ArticleController::class, 'store'])->name('articles.store');
+    Route::put('/articles/{slug}', [ArticleController::class, 'update'])->name('articles.update');
+    Route::delete('/articles/{slug}', [ArticleController::class, 'destroy'])->name('articles.destroy');
 });

--- a/backend/tests/Feature/Infrastructure/RepositoryServiceProviderTest.php
+++ b/backend/tests/Feature/Infrastructure/RepositoryServiceProviderTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 use App\Application\Identity\Services\AuthTokenIssuerInterface;
 use App\Domain\Identity\Repositories\UserRepositoryInterface;
+use App\Domain\Publishing\Repositories\ArticleRepositoryInterface;
 use App\Infrastructure\Identity\JwtAuthTokenIssuer;
+use App\Infrastructure\Persistence\Repositories\EloquentArticleRepository;
 use App\Infrastructure\Persistence\Repositories\EloquentUserRepository;
 use Tests\TestCase;
 
@@ -15,6 +17,12 @@ describe('Repository service provider', function (): void {
         $repository = $this->app->make(UserRepositoryInterface::class);
 
         expect($repository)->toBeInstanceOf(EloquentUserRepository::class);
+    });
+
+    it('ArticleRepositoryInterfaceをEloquent実装として解決する', function (): void {
+        $repository = $this->app->make(ArticleRepositoryInterface::class);
+
+        expect($repository)->toBeInstanceOf(EloquentArticleRepository::class);
     });
 
     it('AuthTokenIssuerInterfaceをJWT実装として解決する', function (): void {

--- a/backend/tests/Feature/Publishing/ArticleCrudApiTest.php
+++ b/backend/tests/Feature/Publishing/ArticleCrudApiTest.php
@@ -1,0 +1,320 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Infrastructure\Persistence\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+describe('Article CRUD API', function (): void {
+    it('認証済みUserがArticleを作成してRealWorld article wrapperを返す', function (): void {
+        $author = User::factory()->create([
+            'username' => 'jake',
+            'bio' => 'I like APIs',
+            'image' => 'https://example.com/avatar.png',
+        ]);
+
+        $response = $this->withRealWorldToken($this->issueRealWorldTokenFor($author))
+            ->postJson('/api/articles', [
+                'article' => [
+                    'title' => 'How to train your dragon',
+                    'description' => 'Ever wonder how?',
+                    'body' => 'You have to believe',
+                    'tagList' => ['dragons', 'training'],
+                ],
+            ]);
+
+        $response
+            ->assertCreated()
+            ->assertJsonPath('article.slug', 'how-to-train-your-dragon')
+            ->assertJsonPath('article.title', 'How to train your dragon')
+            ->assertJsonPath('article.description', 'Ever wonder how?')
+            ->assertJsonPath('article.body', 'You have to believe')
+            ->assertJsonPath('article.tagList', ['dragons', 'training'])
+            ->assertJsonPath('article.favorited', false)
+            ->assertJsonPath('article.favoritesCount', 0)
+            ->assertJsonPath('article.author.username', 'jake')
+            ->assertJsonPath('article.author.bio', 'I like APIs')
+            ->assertJsonPath('article.author.image', 'https://example.com/avatar.png')
+            ->assertJsonPath('article.author.following', false);
+
+        expect(DB::table('articles')->where('slug', 'how-to-train-your-dragon')->exists())->toBeTrue()
+            ->and(DB::table('tags')->pluck('name')->all())
+            ->toContain('dragons')
+            ->toContain('training');
+    });
+
+    it('slugが重複する場合はsuffix付きで一意なslugを生成する', function (): void {
+        $author = User::factory()->create(['username' => 'jake']);
+        articleApiCreateArticle($author, [
+            'slug' => 'how-to-train-your-dragon',
+            'title' => 'How to train your dragon',
+        ]);
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($author))
+            ->postJson('/api/articles', [
+                'article' => [
+                    'title' => 'How to train your dragon',
+                    'description' => 'Ever wonder how?',
+                    'body' => 'You have to believe',
+                    'tagList' => [],
+                ],
+            ])
+            ->assertCreated()
+            ->assertJsonPath('article.slug', 'how-to-train-your-dragon-2');
+    });
+
+    it('未認証作成とvalidation failureを拒否する', function (): void {
+        $this->postJson('/api/articles', [
+            'article' => [
+                'title' => 'How to train your dragon',
+                'description' => 'Ever wonder how?',
+                'body' => 'You have to believe',
+            ],
+        ])
+            ->assertUnauthorized()
+            ->assertJsonStructure(['errors' => ['body']]);
+
+        $author = User::factory()->create();
+
+        $response = $this->withRealWorldToken($this->issueRealWorldTokenFor($author))
+            ->postJson('/api/articles', [
+                'article' => [
+                    'title' => '',
+                    'description' => '',
+                    'body' => '',
+                    'tagList' => ['', 'dup', 'dup'],
+                ],
+            ]);
+
+        $response
+            ->assertUnprocessable()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+
+    it('Article一覧をfilterとpaginationつきで返しbodyを含めない', function (): void {
+        $jake = User::factory()->create(['username' => 'jake']);
+        $jane = User::factory()->create(['username' => 'jane']);
+        $bob = User::factory()->create(['username' => 'bob']);
+        articleApiCreateArticle($jake, [
+            'slug' => 'old-dragon',
+            'title' => 'Old Dragon',
+            'created_at' => Carbon::parse('2026-05-01 00:00:00'),
+            'updated_at' => Carbon::parse('2026-05-01 00:00:00'),
+        ], ['dragons']);
+        $newDragonId = articleApiCreateArticle($jane, [
+            'slug' => 'new-dragon',
+            'title' => 'New Dragon',
+            'created_at' => Carbon::parse('2026-05-03 00:00:00'),
+            'updated_at' => Carbon::parse('2026-05-03 00:00:00'),
+        ], ['dragons', 'training']);
+        articleApiCreateArticle($jake, [
+            'slug' => 'laravel-api',
+            'title' => 'Laravel API',
+            'created_at' => Carbon::parse('2026-05-02 00:00:00'),
+            'updated_at' => Carbon::parse('2026-05-02 00:00:00'),
+        ], ['php']);
+        articleApiFavorite($bob, $newDragonId);
+
+        $tagResponse = $this->getJson('/api/articles?tag=dragons&limit=1&offset=0')
+            ->assertOk()
+            ->assertJsonPath('articlesCount', 2)
+            ->assertJsonCount(1, 'articles')
+            ->assertJsonPath('articles.0.slug', 'new-dragon');
+
+        expect($tagResponse->json('articles.0'))->not->toHaveKey('body');
+
+        $this->getJson('/api/articles?author=jake')
+            ->assertOk()
+            ->assertJsonPath('articlesCount', 2)
+            ->assertJsonPath('articles.0.slug', 'laravel-api')
+            ->assertJsonPath('articles.1.slug', 'old-dragon');
+
+        $this->getJson('/api/articles?favorited=bob')
+            ->assertOk()
+            ->assertJsonPath('articlesCount', 1)
+            ->assertJsonPath('articles.0.slug', 'new-dragon');
+    });
+
+    it('Article詳細のfavoritedとfollowingをoptional authで算出する', function (): void {
+        $author = User::factory()->create(['username' => 'jake']);
+        $viewer = User::factory()->create(['username' => 'bob']);
+        $articleId = articleApiCreateArticle($author, [
+            'slug' => 'how-to-train-your-dragon',
+            'title' => 'How to train your dragon',
+        ], ['dragons']);
+        articleApiFavorite($viewer, $articleId);
+        articleApiFollow($viewer, $author);
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($viewer))
+            ->getJson('/api/articles/how-to-train-your-dragon')
+            ->assertOk()
+            ->assertJsonPath('article.slug', 'how-to-train-your-dragon')
+            ->assertJsonPath('article.favorited', true)
+            ->assertJsonPath('article.favoritesCount', 1)
+            ->assertJsonPath('article.author.following', true);
+
+        $this->getJson('/api/articles/how-to-train-your-dragon')
+            ->assertOk()
+            ->assertJsonPath('article.favorited', false)
+            ->assertJsonPath('article.favoritesCount', 1)
+            ->assertJsonPath('article.author.following', false);
+    });
+
+    it('optional auth endpointでも無効JWTは401を返す', function (): void {
+        $author = User::factory()->create();
+        articleApiCreateArticle($author, ['slug' => 'how-to-train-your-dragon']);
+
+        $this->withRealWorldToken('not-a-jwt')
+            ->getJson('/api/articles/how-to-train-your-dragon')
+            ->assertUnauthorized()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+
+    it('authorのみArticleを更新できtitle変更時にslugを再生成する', function (): void {
+        $author = User::factory()->create(['username' => 'jake']);
+        $other = User::factory()->create(['username' => 'other']);
+        articleApiCreateArticle($author, ['slug' => 'did-you-train-your-dragon']);
+        articleApiCreateArticle($author, [
+            'slug' => 'how-to-train-your-dragon',
+            'title' => 'How to train your dragon',
+        ]);
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($other))
+            ->putJson('/api/articles/how-to-train-your-dragon', [
+                'article' => ['title' => 'Hacked'],
+            ])
+            ->assertForbidden()
+            ->assertJsonStructure(['errors' => ['body']]);
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($author))
+            ->putJson('/api/articles/how-to-train-your-dragon', [
+                'article' => [
+                    'title' => 'Did you train your dragon',
+                    'description' => 'Updated summary',
+                    'body' => 'Updated body',
+                ],
+            ])
+            ->assertOk()
+            ->assertJsonPath('article.slug', 'did-you-train-your-dragon-2')
+            ->assertJsonPath('article.title', 'Did you train your dragon')
+            ->assertJsonPath('article.description', 'Updated summary')
+            ->assertJsonPath('article.body', 'Updated body');
+
+        expect(DB::table('articles')->where('slug', 'how-to-train-your-dragon')->exists())->toBeFalse()
+            ->and(DB::table('articles')->where('slug', 'did-you-train-your-dragon-2')->exists())->toBeTrue();
+    });
+
+    it('存在しないslugの更新は404を返す', function (): void {
+        $author = User::factory()->create();
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($author))
+            ->putJson('/api/articles/missing-article', [
+                'article' => ['title' => 'Missing'],
+            ])
+            ->assertNotFound()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+
+    it('authorのみArticleを削除できる', function (): void {
+        $author = User::factory()->create(['username' => 'jake']);
+        $other = User::factory()->create(['username' => 'other']);
+        $articleId = articleApiCreateArticle($author, ['slug' => 'how-to-train-your-dragon']);
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($other))
+            ->deleteJson('/api/articles/how-to-train-your-dragon')
+            ->assertForbidden()
+            ->assertJsonStructure(['errors' => ['body']]);
+
+        expect(DB::table('articles')->where('id', $articleId)->exists())->toBeTrue();
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($author))
+            ->deleteJson('/api/articles/how-to-train-your-dragon')
+            ->assertNoContent();
+
+        expect(DB::table('articles')->where('id', $articleId)->exists())->toBeFalse();
+    });
+
+    it('存在しないslugの詳細と削除は404を返す', function (): void {
+        $author = User::factory()->create();
+
+        $this->getJson('/api/articles/missing-article')
+            ->assertNotFound()
+            ->assertJsonStructure(['errors' => ['body']]);
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($author))
+            ->deleteJson('/api/articles/missing-article')
+            ->assertNotFound()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+});
+
+/**
+ * @param  array<string, mixed>  $attributes
+ * @param  list<string>  $tagNames
+ */
+function articleApiCreateArticle(User $author, array $attributes = [], array $tagNames = []): int
+{
+    $createdAt = $attributes['created_at'] ?? Carbon::parse('2026-05-01 00:00:00');
+    $updatedAt = $attributes['updated_at'] ?? $createdAt;
+
+    $articleId = DB::table('articles')->insertGetId([
+        'author_user_id' => $author->getKey(),
+        'slug' => $attributes['slug'] ?? 'how-to-train-your-dragon',
+        'title' => $attributes['title'] ?? 'How to train your dragon',
+        'description' => $attributes['description'] ?? 'Ever wonder how?',
+        'body' => $attributes['body'] ?? 'You have to believe',
+        'created_at' => $createdAt,
+        'updated_at' => $updatedAt,
+    ]);
+
+    foreach ($tagNames as $tagName) {
+        articleApiAttachTag((int) $articleId, $tagName, $createdAt);
+    }
+
+    return (int) $articleId;
+}
+
+function articleApiAttachTag(int $articleId, string $tagName, Carbon $createdAt): void
+{
+    $tagId = DB::table('tags')->where('name', $tagName)->value('id');
+
+    if (! is_numeric($tagId)) {
+        $tagId = DB::table('tags')->insertGetId([
+            'name' => $tagName,
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ]);
+    }
+
+    DB::table('article_tag')->insert([
+        'article_id' => $articleId,
+        'tag_id' => (int) $tagId,
+        'created_at' => $createdAt,
+        'updated_at' => $createdAt,
+    ]);
+}
+
+function articleApiFavorite(User $user, int $articleId): void
+{
+    DB::table('favorites')->insert([
+        'user_id' => $user->getKey(),
+        'article_id' => $articleId,
+        'created_at' => Carbon::parse('2026-05-04 00:00:00'),
+        'updated_at' => Carbon::parse('2026-05-04 00:00:00'),
+    ]);
+}
+
+function articleApiFollow(User $follower, User $followee): void
+{
+    DB::table('follows')->insert([
+        'follower_user_id' => $follower->getKey(),
+        'followee_user_id' => $followee->getKey(),
+        'created_at' => Carbon::parse('2026-05-04 00:00:00'),
+        'updated_at' => Carbon::parse('2026-05-04 00:00:00'),
+    ]);
+}

--- a/backend/tests/Feature/Publishing/ArticleCrudApiTest.php
+++ b/backend/tests/Feature/Publishing/ArticleCrudApiTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Infrastructure\Persistence\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
@@ -158,7 +159,8 @@ describe('Article CRUD API', function (): void {
             ->assertJsonPath('article.favoritesCount', 1)
             ->assertJsonPath('article.author.following', true);
 
-        $this->getJson('/api/articles/how-to-train-your-dragon')
+        $this->flushHeaders()
+            ->getJson('/api/articles/how-to-train-your-dragon')
             ->assertOk()
             ->assertJsonPath('article.favorited', false)
             ->assertJsonPath('article.favoritesCount', 1)
@@ -190,6 +192,8 @@ describe('Article CRUD API', function (): void {
             ])
             ->assertForbidden()
             ->assertJsonStructure(['errors' => ['body']]);
+
+        Auth::forgetGuards();
 
         $this->withRealWorldToken($this->issueRealWorldTokenFor($author))
             ->putJson('/api/articles/how-to-train-your-dragon', [
@@ -229,6 +233,8 @@ describe('Article CRUD API', function (): void {
             ->deleteJson('/api/articles/how-to-train-your-dragon')
             ->assertForbidden()
             ->assertJsonStructure(['errors' => ['body']]);
+
+        Auth::forgetGuards();
 
         expect(DB::table('articles')->where('id', $articleId)->exists())->toBeTrue();
 


### PR DESCRIPTION
# 概要

- RealWorld 互換の Article CRUD API を追加
- Publishing Context の Article Domain / Application / Infrastructure / Presentation 層を追加
- Article response 用に `favorites` / `follows` の read state を算出
- devcontainer に Intelephense 拡張を追加

# 関連Issue

Closes #69

Epic: #58

# 修正ファイルの説明

## Backend / Publishing Domain

- `backend/app/Domain/Publishing/**`
  - Article Entity、ValueObject、Repository Interface、slug 一意化 Domain Service を追加
  - Article CRUD のビジネスルールを Domain 層で表現するため

## Backend / Application

- `backend/app/Application/Publishing/**`
  - Create / Update / Delete Command と List / Detail Query、response DTO を追加
  - 書き込み処理と読み取り整形を分離するため

## Backend / Infrastructure

- `backend/app/Infrastructure/Persistence/Models/Article.php`
- `backend/app/Infrastructure/Persistence/Models/Tag.php`
- `backend/app/Infrastructure/Persistence/Repositories/EloquentArticleRepository.php`
  - Article / Tag の Eloquent model と Repository 実装を追加
  - Domain Entity と永続化 model を分離するため

## Backend / Presentation

- `backend/app/Presentation/Http/Controllers/Publishing/ArticleController.php`
- `backend/app/Presentation/Http/Requests/Publishing/*`
- `backend/app/Presentation/Http/Resources/Publishing/*`
- `backend/app/Policies/ArticlePolicy.php`
- `backend/routes/api.php`
  - Article CRUD route、FormRequest、Resource、author-only Policy を追加
  - RealWorld API contract、validation、authorization を HTTP 層に集約するため

## Database

- `backend/database/migrations/2026_06_01_000000_create_publishing_article_tables.php`
  - `articles`, `comments`, `tags`, `article_tag`, `follows`, `favorites` を追加
  - Article CRUD と response/filter に必要な schema を用意するため

## Test / Tooling

- `backend/tests/Feature/Publishing/ArticleCrudApiTest.php`
- `backend/tests/Feature/Infrastructure/RepositoryServiceProviderTest.php`
  - CRUD、validation、authorization、optional auth、filter、pagination、slug uniqueness を検証
- `.devcontainer/devcontainer.json`
  - `bmewburn.vscode-intelephense-client` を追加

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| バックエンド変更あり | Feature / Unit 全テスト | Docker コンテナ内で `php artisan test` | すべて成功する | 成功 |
| バックエンド変更あり | format確認 | Docker コンテナ内で `./vendor/bin/pint --test` | すべて成功する | 成功 |
| バックエンド変更あり | 静的解析 | Docker コンテナ内で `./vendor/bin/phpstan analyse` | すべて成功する | 成功 |
| DB・マイグレーション変更あり | migrate / rollback 確認 | Docker コンテナ内で `php artisan migrate:fresh --env=testing --force && php artisan migrate:rollback --env=testing --step=1 --force && php artisan migrate --env=testing --force` | migrate / rollback が成功する | 成功 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: あり。Publishing / Social read state 用の新規テーブルを作成します
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: ArticleResource の RealWorld contract、optional auth の無効 JWT 401、author-only Policy、filter / pagination の Query
