### PR TITLE
[#68]: Settings画面を実装

### DIFF
--- a/frontend/src/app/routes/__tests__/router.test.tsx
+++ b/frontend/src/app/routes/__tests__/router.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactElement } from 'react';
 import { RouterProvider } from 'react-router-dom';
@@ -13,6 +13,13 @@ const DEMO_USER: AuthUser = {
   email: 'demo@example.com',
   image: '',
   username: 'demo-user',
+};
+
+const UPDATED_USER: AuthUser = {
+  bio: 'Updated bio',
+  email: 'updated@example.com',
+  image: 'https://example.com/updated.png',
+  username: 'updated-user',
 };
 
 /**
@@ -147,6 +154,64 @@ describe('アプリルーター', () => {
 
     expect(
       await screen.findByRole('heading', { name: 'Settings' }),
+    ).toBeInTheDocument();
+  });
+
+  it('Settings更新成功後にcurrent user由来の表示を更新する', async () => {
+    const user = userEvent.setup();
+    const { render } = await import('@testing-library/react');
+    const authApi = createAuthApi({
+      updateCurrentUser: vi.fn().mockResolvedValue(UPDATED_USER),
+    });
+
+    render(
+      renderRoute({
+        authApi,
+        initialPath: '/settings',
+        initialUser: DEMO_USER,
+      }),
+    );
+
+    await user.clear(screen.getByLabelText('Username'));
+    await user.type(screen.getByLabelText('Username'), 'updated-user');
+    await user.clear(screen.getByLabelText('Email'));
+    await user.type(screen.getByLabelText('Email'), 'updated@example.com');
+    await user.clear(screen.getByLabelText('Bio'));
+    await user.type(screen.getByLabelText('Bio'), 'Updated bio');
+    await user.click(screen.getByRole('button', { name: 'Update Settings' }));
+
+    expect(authApi.updateCurrentUser).toHaveBeenCalledWith({
+      bio: 'Updated bio',
+      email: 'updated@example.com',
+      image: null,
+      username: 'updated-user',
+    });
+    expect(screen.getByRole('link', { name: 'Profile' })).toHaveAttribute(
+      'href',
+      '/profile/updated-user',
+    );
+  });
+
+  it('Settings画面のlogoutでHomeへ遷移する', async () => {
+    const user = userEvent.setup();
+    const { render } = await import('@testing-library/react');
+    const authApi = createAuthApi();
+
+    render(
+      renderRoute({
+        authApi,
+        initialPath: '/settings',
+        initialUser: DEMO_USER,
+      }),
+    );
+
+    await user.click(
+      within(screen.getByRole('main')).getByRole('button', { name: 'Sign out' }),
+    );
+
+    expect(authApi.logout).toHaveBeenCalledOnce();
+    expect(
+      await screen.findByRole('heading', { name: 'Global Feed' }),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/routes/pages.tsx
+++ b/frontend/src/app/routes/pages.tsx
@@ -181,8 +181,8 @@ export function SettingsPage(): ReactElement {
   const navigate = useNavigate();
 
   async function handleLogout(): Promise<void> {
-    await logout();
     navigate('/', { replace: true });
+    await logout();
   }
 
   if (user === null) {

--- a/frontend/src/features/auth/__tests__/AuthForms.test.tsx
+++ b/frontend/src/features/auth/__tests__/AuthForms.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { ApiError } from '@/lib/apiError';
@@ -146,6 +146,76 @@ describe('認証フォーム', () => {
     await user.click(screen.getByRole('button', { name: 'Update Settings' }));
 
     expect(await screen.findByText('email is invalid')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toHaveAccessibleDescription(
+      'email is invalid',
+    );
     expect(screen.getByLabelText('Email')).toHaveValue('invalid@example.com');
+  });
+
+  it('settings formは必須validationをfield errorとして表示する', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <SettingsForm
+        onLogout={vi.fn().mockResolvedValue(undefined)}
+        onSubmit={onSubmit}
+        user={{
+          bio: null,
+          email: 'jake@example.com',
+          image: null,
+          username: 'jake',
+        }}
+      />,
+    );
+
+    await user.clear(screen.getByLabelText('Username'));
+    await user.click(screen.getByRole('button', { name: 'Update Settings' }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Username')).toHaveAccessibleDescription(
+      'username is required',
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('settings formは送信中の二重submitを防止する', async () => {
+    let resolveSubmit: (() => void) | undefined;
+    const submitPromise = new Promise<void>((resolve) => {
+      resolveSubmit = resolve;
+    });
+    const onSubmit = vi.fn().mockReturnValue(submitPromise);
+
+    render(
+      <SettingsForm
+        onLogout={vi.fn().mockResolvedValue(undefined)}
+        onSubmit={onSubmit}
+        user={{
+          bio: null,
+          email: 'jake@example.com',
+          image: null,
+          username: 'jake',
+        }}
+      />,
+    );
+
+    const form = screen
+      .getByRole('button', { name: 'Update Settings' })
+      .closest('form');
+
+    if (form === null) {
+      throw new Error('Settings form was not rendered');
+    }
+
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(screen.getByRole('button', { name: 'Updating...' })).toBeDisabled();
+
+    await act(async () => {
+      resolveSubmit?.();
+      await submitPromise;
+    });
   });
 });

--- a/frontend/src/features/auth/components/SettingsForm.tsx
+++ b/frontend/src/features/auth/components/SettingsForm.tsx
@@ -1,4 +1,10 @@
-import { type FormEvent, type ReactElement, useState } from 'react';
+import {
+  type FormEvent,
+  type ReactElement,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import type { AuthUser, UpdateUserInput } from '../types/auth';
 import { getFormErrors } from '../utils/formErrors';
 
@@ -6,6 +12,22 @@ interface SettingsFormProps {
   onLogout: () => Promise<void>;
   onSubmit: (input: UpdateUserInput) => Promise<void>;
   user: AuthUser;
+}
+
+const SETTINGS_FIELDS = [
+  'bio',
+  'email',
+  'image',
+  'password',
+  'username',
+] as const;
+
+type SettingsField = (typeof SETTINGS_FIELDS)[number];
+type SettingsFieldErrors = Partial<Record<SettingsField, string[]>>;
+
+interface SettingsFormErrors {
+  fields: SettingsFieldErrors;
+  global: string[];
 }
 
 /**
@@ -18,15 +40,29 @@ export function SettingsForm({
 }: SettingsFormProps): ReactElement {
   const [bio, setBio] = useState(user.bio ?? '');
   const [email, setEmail] = useState(user.email);
-  const [errors, setErrors] = useState<string[]>([]);
+  const [errors, setErrors] = useState<SettingsFormErrors>(
+    () => createEmptySettingsErrors(),
+  );
   const [image, setImage] = useState(user.image ?? '');
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [password, setPassword] = useState('');
   const [username, setUsername] = useState(user.username);
+  const isMountedRef = useRef(true);
+  const isSubmittingRef = useRef(false);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
+
+    if (isSubmittingRef.current) {
+      return;
+    }
 
     const input = createUpdateInput({
       bio,
@@ -37,20 +73,25 @@ export function SettingsForm({
     });
     const validationErrors = validateSettings(input);
 
-    if (validationErrors.length > 0) {
-      setErrors(validationErrors);
+    if (hasFieldErrors(validationErrors)) {
+      setErrors({
+        fields: validationErrors,
+        global: [],
+      });
       return;
     }
 
-    setErrors([]);
+    setErrors(createEmptySettingsErrors());
+    isSubmittingRef.current = true;
     setIsSubmitting(true);
 
     try {
       await onSubmit(input);
       setPassword('');
     } catch (error: unknown) {
-      setErrors(getFormErrors(error));
+      setErrors(createSettingsErrorsFromMessages(getFormErrors(error)));
     } finally {
+      isSubmittingRef.current = false;
       setIsSubmitting(false);
     }
   }
@@ -61,46 +102,65 @@ export function SettingsForm({
     try {
       await onLogout();
     } finally {
-      setIsLoggingOut(false);
+      if (isMountedRef.current) {
+        setIsLoggingOut(false);
+      }
     }
   }
 
   return (
     <form className="form-stack" noValidate onSubmit={(event) => void handleSubmit(event)}>
-      <FormErrorList errors={errors} />
-      <label htmlFor="settings-image">
-        <span>Profile image URL</span>
+      <FormErrorList errors={errors.global} />
+      <div className="form-field">
+        <label htmlFor="settings-image">Profile image URL</label>
         <input
+          aria-describedby={getFieldDescribedBy('image', errors.fields)}
+          aria-invalid={hasMessages(errors.fields.image) ? true : undefined}
           id="settings-image"
           onChange={(event) => setImage(event.currentTarget.value)}
           placeholder="URL of profile picture"
           type="url"
           value={image}
         />
-      </label>
-      <label htmlFor="settings-username">
-        <span>Username</span>
+        <FieldError
+          errors={errors.fields.image}
+          id={getFieldErrorId('image')}
+        />
+      </div>
+      <div className="form-field">
+        <label htmlFor="settings-username">Username</label>
         <input
+          aria-describedby={getFieldDescribedBy('username', errors.fields)}
+          aria-invalid={hasMessages(errors.fields.username) ? true : undefined}
           autoComplete="username"
           id="settings-username"
           onChange={(event) => setUsername(event.currentTarget.value)}
           type="text"
           value={username}
         />
-      </label>
-      <label htmlFor="settings-bio">
-        <span>Bio</span>
+        <FieldError
+          errors={errors.fields.username}
+          id={getFieldErrorId('username')}
+        />
+      </div>
+      <div className="form-field">
+        <label htmlFor="settings-bio">Bio</label>
         <textarea
+          aria-describedby={getFieldDescribedBy('bio', errors.fields)}
+          aria-invalid={hasMessages(errors.fields.bio) ? true : undefined}
           id="settings-bio"
           onChange={(event) => setBio(event.currentTarget.value)}
           placeholder="Short bio"
           rows={5}
           value={bio}
         />
-      </label>
-      <label htmlFor="settings-email">
-        <span>Email</span>
+        <FieldError errors={errors.fields.bio} id={getFieldErrorId('bio')} />
+      </div>
+      <div className="form-field">
+        <label htmlFor="settings-email">Email</label>
         <input
+          aria-describedby={getFieldDescribedBy('email', errors.fields)}
+          aria-invalid={hasMessages(errors.fields.email) ? true : undefined}
           autoComplete="email"
           id="settings-email"
           onChange={(event) => setEmail(event.currentTarget.value)}
@@ -108,10 +168,16 @@ export function SettingsForm({
           type="email"
           value={email}
         />
-      </label>
-      <label htmlFor="settings-password">
-        <span>Password</span>
+        <FieldError
+          errors={errors.fields.email}
+          id={getFieldErrorId('email')}
+        />
+      </div>
+      <div className="form-field">
+        <label htmlFor="settings-password">Password</label>
         <input
+          aria-describedby={getFieldDescribedBy('password', errors.fields)}
+          aria-invalid={hasMessages(errors.fields.password) ? true : undefined}
           autoComplete="new-password"
           id="settings-password"
           onChange={(event) => setPassword(event.currentTarget.value)}
@@ -119,7 +185,11 @@ export function SettingsForm({
           type="password"
           value={password}
         />
-      </label>
+        <FieldError
+          errors={errors.fields.password}
+          id={getFieldErrorId('password')}
+        />
+      </div>
       <div className="form-actions">
         <button className="primary-action" disabled={isSubmitting} type="submit">
           {isSubmitting ? 'Updating...' : 'Update Settings'}
@@ -160,18 +230,73 @@ function createUpdateInput(fields: SettingsFields): UpdateUserInput {
   return input;
 }
 
-function validateSettings(input: UpdateUserInput): string[] {
-  const errors: string[] = [];
+function validateSettings(input: UpdateUserInput): SettingsFieldErrors {
+  const errors: SettingsFieldErrors = {};
 
   if (input.username === undefined || input.username === '') {
-    errors.push('username is required');
+    errors.username = ['username is required'];
   }
 
   if (input.email === undefined || input.email === '') {
-    errors.push('email is required');
+    errors.email = ['email is required'];
   }
 
   return errors;
+}
+
+function createEmptySettingsErrors(): SettingsFormErrors {
+  return {
+    fields: {},
+    global: [],
+  };
+}
+
+function createSettingsErrorsFromMessages(messages: string[]): SettingsFormErrors {
+  const errors = createEmptySettingsErrors();
+
+  for (const message of messages) {
+    const field = findSettingsField(message);
+
+    if (field === null) {
+      errors.global.push(message);
+      continue;
+    }
+
+    errors.fields[field] = [...(errors.fields[field] ?? []), message];
+  }
+
+  return errors;
+}
+
+function findSettingsField(message: string): SettingsField | null {
+  const normalizedMessage = message.toLowerCase();
+
+  return (
+    SETTINGS_FIELDS.find(
+      (field) =>
+        normalizedMessage.startsWith(`${field} `) ||
+        normalizedMessage.startsWith(`user.${field} `),
+    ) ?? null
+  );
+}
+
+function hasFieldErrors(errors: SettingsFieldErrors): boolean {
+  return Object.values(errors).some((messages) => hasMessages(messages));
+}
+
+function hasMessages(messages: string[] | undefined): messages is string[] {
+  return messages !== undefined && messages.length > 0;
+}
+
+function getFieldErrorId(field: SettingsField): string {
+  return `settings-${field}-error`;
+}
+
+function getFieldDescribedBy(
+  field: SettingsField,
+  errors: SettingsFieldErrors,
+): string | undefined {
+  return hasMessages(errors[field]) ? getFieldErrorId(field) : undefined;
 }
 
 interface FormErrorListProps {
@@ -189,5 +314,22 @@ function FormErrorList({ errors }: FormErrorListProps): ReactElement | null {
         <li key={error}>{error}</li>
       ))}
     </ul>
+  );
+}
+
+interface FieldErrorProps {
+  errors?: string[];
+  id: string;
+}
+
+function FieldError({ errors, id }: FieldErrorProps): ReactElement | null {
+  if (!hasMessages(errors)) {
+    return null;
+  }
+
+  return (
+    <p className="field-error" id={id}>
+      {errors.join(' ')}
+    </p>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -425,13 +425,23 @@ textarea:focus-visible {
   margin-top: 6px;
 }
 
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-stack label,
+.form-field label {
+  color: var(--text-muted);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
 .form-stack label {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  color: var(--text-muted);
-  font-size: 0.84rem;
-  font-weight: 700;
 }
 
 .form-stack input,
@@ -450,6 +460,13 @@ textarea:focus-visible {
 .form-stack input:focus,
 .form-stack textarea:focus {
   border-color: var(--primary);
+}
+
+.field-error {
+  margin: 0;
+  color: var(--error);
+  font-size: 0.84rem;
+  font-weight: 700;
 }
 
 .form-actions {


### PR DESCRIPTION
# 概要

- Settings form の validation error を field-level / global error に分離して表示
- submit handler の再入を防ぎ、送信中の二重 submit を防止
- Settings 更新後の current User 表示反映と logout 後 Home 遷移をテストで固定

# 関連Issue

Closes #68

Epic: #53

# 修正ファイルの説明

## Frontend Tests

- `frontend/src/features/auth/__tests__/AuthForms.test.tsx`
  - Settings form の field error、API validation error、二重 submit 防止を追加
  - Issue #68 の form 受け入れ条件をユーザー視点で検証するため
- `frontend/src/app/routes/__tests__/router.test.tsx`
  - Settings 更新成功後の current User 表示反映と logout の Home 遷移を追加
  - route guard / AuthProvider / SettingsPage の連携を回帰検出するため

## Frontend Implementation

- `frontend/src/features/auth/components/SettingsForm.tsx`
  - Settings form の error state を global / field に分離し、field error を `aria-describedby` で input と関連付け
  - submit 中の再入を ref で防止し、logout 中に unmount された場合の state 更新を抑止
- `frontend/src/app/routes/pages.tsx`
  - Settings 画面の logout を Home 遷移後に BrowserSession 破棄する順序へ変更
  - required route guard に拾われて login へ戻る挙動を防ぐため
- `frontend/src/index.css`
  - Settings form の field wrapper と field error の表示スタイルを追加
  - field-level error を既存フォームの見た目に合わせるため

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| フロントエンド変更あり | 型チェック | `pnpm tsc -b --noEmit` | 成功する | 成功 |
| フロントエンド変更あり | Vitest | `pnpm vitest run` | すべて成功する | 成功: 5 files / 37 tests |
| フロントエンド変更あり | ESLint | `pnpm eslint .` | 成功する | 成功 |
| 差分確認 | 空白エラー確認 | `git diff --check` | 空白エラーなし | 成功 |
| バックエンド変更なし | Backend 検証 | 対象外 | 未実施理由を明示 | 対象外: frontend のみ |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: Settings form の field/global error 分離と logout の遷移順
