### PR TITLE
[#72]: Home / Feed / Tag filteringを実装

### DIFF
--- a/frontend/src/app/routes/__tests__/HomePage.test.tsx
+++ b/frontend/src/app/routes/__tests__/HomePage.test.tsx
@@ -1,0 +1,308 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement } from 'react';
+import { RouterProvider } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AppProviders } from '@/app/providers/AppProviders';
+import type { AuthApi, AuthUser } from '@/features/auth';
+import { ApiError } from '@/lib/apiError';
+import { createAppRouter } from '../router';
+
+const DEMO_USER: AuthUser = {
+  bio: null,
+  email: 'demo@example.com',
+  image: null,
+  username: 'demo-user',
+};
+
+const GLOBAL_ARTICLES = {
+  articles: [
+    articleResponse({
+      description: 'A public article for everyone',
+      slug: 'global-article',
+      tagList: ['react'],
+      title: 'Global article',
+      username: 'global-author',
+    }),
+  ],
+  articlesCount: 21,
+};
+
+const YOUR_FEED_ARTICLES = {
+  articles: [
+    articleResponse({
+      description: 'From a followed author',
+      slug: 'your-feed-article',
+      tagList: ['feed'],
+      title: 'Your feed article',
+      username: 'followed-author',
+    }),
+  ],
+  articlesCount: 1,
+};
+
+const TAG_ARTICLES = {
+  articles: [
+    articleResponse({
+      description: 'Filtered by react',
+      slug: 'react-patterns',
+      tagList: ['react'],
+      title: 'React patterns',
+      username: 'tag-author',
+    }),
+  ],
+  articlesCount: 1,
+};
+
+function createAuthApi(overrides: Partial<AuthApi> = {}): AuthApi {
+  return {
+    getCurrentUser: vi.fn().mockRejectedValue(
+      new ApiError('Unauthorized', {
+        bodyErrors: ['Unauthorized'],
+        kind: 'unauthorized',
+        status: 401,
+      }),
+    ),
+    login: vi.fn().mockResolvedValue(DEMO_USER),
+    logout: vi.fn().mockResolvedValue(undefined),
+    register: vi.fn().mockResolvedValue(DEMO_USER),
+    updateCurrentUser: vi.fn().mockResolvedValue(DEMO_USER),
+    ...overrides,
+  };
+}
+
+function renderHome({
+  initialPath = '/',
+  initialUser = null,
+  routes,
+}: {
+  initialPath?: string;
+  initialUser?: AuthUser | null;
+  routes: Record<string, Response | unknown>;
+}): ReactElement {
+  vi.stubGlobal('fetch', createFetchMock(routes));
+
+  return (
+    <AppProviders authApi={createAuthApi()} initialUser={initialUser}>
+      <RouterProvider router={createAppRouter([initialPath])} />
+    </AppProviders>
+  );
+}
+
+describe('HomePage feed', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('guestはGlobal FeedとPopular Tagsを見られ、Your Feed tabは表示されない', async () => {
+    render(
+      renderHome({
+        routes: {
+          '/api/articles?limit=10&offset=0': GLOBAL_ARTICLES,
+          '/api/tags': { tags: ['react', 'laravel'] },
+        },
+      }),
+    );
+
+    expect(screen.queryByRole('button', { name: 'Your Feed' })).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { name: 'Global article' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'react' })).toBeInTheDocument();
+  });
+
+  it('authenticated userはYour Feed tabへ切り替えられる', async () => {
+    const user = userEvent.setup();
+
+    render(
+      renderHome({
+        initialUser: DEMO_USER,
+        routes: {
+          '/api/articles/feed?limit=10&offset=0': YOUR_FEED_ARTICLES,
+          '/api/articles?limit=10&offset=0': GLOBAL_ARTICLES,
+          '/api/tags': { tags: ['react'] },
+        },
+      }),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Your Feed' }));
+
+    expect(
+      await screen.findByRole('heading', { name: 'Your feed article' }),
+    ).toBeInTheDocument();
+  });
+
+  it('tag clickでselected tag tabとtag filtered articlesを表示する', async () => {
+    const user = userEvent.setup();
+
+    render(
+      renderHome({
+        routes: {
+          '/api/articles?limit=10&offset=0': GLOBAL_ARTICLES,
+          '/api/articles?tag=react&limit=10&offset=0': TAG_ARTICLES,
+          '/api/tags': { tags: ['react', 'laravel'] },
+        },
+      }),
+    );
+
+    await user.click(await screen.findByRole('button', { name: 'react' }));
+
+    expect(screen.getByRole('button', { name: '# react' })).toHaveClass('is-active');
+    expect(
+      await screen.findByRole('heading', { name: 'React patterns' }),
+    ).toBeInTheDocument();
+  });
+
+  it('Next pageでlimit/offset paginationの次ページへ切り替える', async () => {
+    const user = userEvent.setup();
+
+    render(
+      renderHome({
+        routes: {
+          '/api/articles?limit=10&offset=0': GLOBAL_ARTICLES,
+          '/api/articles?limit=10&offset=10': {
+            articles: [
+              articleResponse({
+                description: 'Second page article',
+                slug: 'page-two-article',
+                tagList: ['page'],
+                title: 'Page two article',
+                username: 'page-author',
+              }),
+            ],
+            articlesCount: 21,
+          },
+          '/api/tags': { tags: ['react'] },
+        },
+      }),
+    );
+
+    await screen.findByRole('heading', { name: 'Global article' });
+    await user.click(screen.getByRole('button', { name: 'Next page' }));
+
+    expect(
+      await screen.findByRole('heading', { name: 'Page two article' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Page 2 of 3')).toBeInTheDocument();
+  });
+
+  it('Article listのempty stateとerror stateを表示する', async () => {
+    const { unmount } = render(
+      renderHome({
+        routes: {
+          '/api/articles?limit=10&offset=0': {
+            articles: [],
+            articlesCount: 0,
+          },
+          '/api/tags': { tags: [] },
+        },
+      }),
+    );
+
+    expect(
+      await screen.findByText('No articles are here... yet.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('No tags yet.')).toBeInTheDocument();
+
+    unmount();
+    vi.unstubAllGlobals();
+
+    render(
+      renderHome({
+        routes: {
+          '/api/articles?limit=10&offset=0': jsonResponse(
+            {
+              errors: {
+                body: ['server error'],
+              },
+            },
+            500,
+          ),
+          '/api/tags': { tags: ['react'] },
+        },
+      }),
+    );
+
+    expect(
+      await screen.findByText('Articles could not be loaded.'),
+    ).toBeInTheDocument();
+  });
+});
+
+function articleResponse({
+  description,
+  slug,
+  tagList,
+  title,
+  username,
+}: {
+  description: string;
+  slug: string;
+  tagList: string[];
+  title: string;
+  username: string;
+}): unknown {
+  return {
+    author: {
+      bio: null,
+      following: false,
+      image: null,
+      username,
+    },
+    createdAt: '2026-05-06T00:00:00.000Z',
+    description,
+    favorited: false,
+    favoritesCount: 0,
+    slug,
+    tagList,
+    title,
+    updatedAt: '2026-05-06T00:00:00.000Z',
+  };
+}
+
+function createFetchMock(routes: Record<string, Response | unknown>): typeof fetch {
+  const fetcher: typeof fetch = async (input: RequestInfo | URL): Promise<Response> => {
+    const path = requestPath(input);
+    const response = routes[path];
+
+    if (response instanceof Response) {
+      return response;
+    }
+
+    if (response !== undefined) {
+      return jsonResponse(response);
+    }
+
+    return jsonResponse(
+      {
+        errors: {
+          body: [`Unhandled request: ${path}`],
+        },
+      },
+      500,
+    );
+  };
+
+  return vi.fn(fetcher);
+}
+
+function requestPath(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    const url = new URL(input, window.location.origin);
+
+    return `${url.pathname}${url.search}`;
+  }
+
+  const url = input instanceof URL ? input : new URL(input.url, window.location.origin);
+
+  return `${url.pathname}${url.search}`;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+}

--- a/frontend/src/app/routes/pages.tsx
+++ b/frontend/src/app/routes/pages.tsx
@@ -1,41 +1,75 @@
-import type { ReactElement, ReactNode } from 'react';
+import { type ReactElement, type ReactNode, useCallback } from 'react';
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useAuth } from '@/app/providers/useAuth';
+import {
+  ArticleList,
+  listArticles,
+  type ArticleListQuery,
+  type ArticleListResult,
+} from '@/features/article';
 import { LoginForm, RegisterForm, SettingsForm } from '@/features/auth';
+import { FeedTabs, getFeed, type ActiveFeed } from '@/features/feed';
+import { PopularTags } from '@/features/tag';
 import { getSafeReturnTo } from './returnTo';
-
-const SAMPLE_ARTICLES = [
-  {
-    author: 'Eric Simons',
-    description:
-      'This is the description for the post. It gives a brief overview without giving everything away.',
-    favoritesCount: 29,
-    slug: 'how-to-build-webapps',
-    tags: ['programming', 'webdev'],
-    title: 'How to build webapps that scale',
-  },
-  {
-    author: 'Jane Doe',
-    description:
-      'A concise field guide for building calm product interfaces around long-form writing.',
-    favoritesCount: 12,
-    slug: 'designing-for-reading',
-    tags: ['design', 'ux'],
-    title: 'Designing for the reading state',
-  },
-] as const;
-
-const POPULAR_TAGS = [
-  'programming',
-  'design',
-  'react',
-  'laravel',
-  'architecture',
-  'testing',
-] as const;
 
 export function HomePage(): ReactElement {
   const { isAuthenticated } = useAuth();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedTag = normalizeTag(searchParams.get('tag'));
+  const page = parsePage(searchParams.get('page'));
+  const activeFeed = getActiveFeed({
+    feedParam: searchParams.get('feed'),
+    isAuthenticated,
+    selectedTag,
+  });
+  const articleListKey = `${activeFeed}:${selectedTag ?? ''}:${page}`;
+  const heading = getFeedHeading(activeFeed, selectedTag);
+
+  const loadArticles = useCallback(
+    (query: ArticleListQuery): Promise<ArticleListResult> => {
+      if (activeFeed === 'your') {
+        return getFeed(query);
+      }
+
+      if (activeFeed === 'tag') {
+        return listArticles({
+          ...query,
+          tag: selectedTag ?? undefined,
+        });
+      }
+
+      return listArticles(query);
+    },
+    [activeFeed, selectedTag],
+  );
+
+  const selectGlobalFeed = useCallback((): void => {
+    setSearchParams(createHomeSearchParams({ activeFeed: 'global', page: 1 }));
+  }, [setSearchParams]);
+
+  const selectYourFeed = useCallback((): void => {
+    setSearchParams(createHomeSearchParams({ activeFeed: 'your', page: 1 }));
+  }, [setSearchParams]);
+
+  const selectTag = useCallback(
+    (tag: string): void => {
+      setSearchParams(createHomeSearchParams({ activeFeed: 'tag', page: 1, tag }));
+    },
+    [setSearchParams],
+  );
+
+  const selectPage = useCallback(
+    (nextPage: number): void => {
+      setSearchParams(
+        createHomeSearchParams({
+          activeFeed,
+          page: nextPage,
+          tag: selectedTag,
+        }),
+      );
+    },
+    [activeFeed, selectedTag, setSearchParams],
+  );
 
   return (
     <main className="page page--wide">
@@ -46,57 +80,23 @@ export function HomePage(): ReactElement {
 
       <div className="discovery-grid">
         <section className="feed-column" aria-labelledby="home-title">
-          <nav className="feed-tabs" aria-label="Feed filters">
-            {isAuthenticated ? <button type="button">Your Feed</button> : null}
-            <button className="is-active" type="button">
-              Global Feed
-            </button>
-          </nav>
-          <h1 id="home-title">Global Feed</h1>
-
-          <div className="article-list">
-            {SAMPLE_ARTICLES.map((article) => (
-              <article className="article-preview" key={article.slug}>
-                <div className="article-preview__meta">
-                  <Link to={`/profile/${article.author.toLowerCase().replaceAll(' ', '-')}`}>
-                    <span className="avatar" aria-hidden="true">
-                      {article.author.charAt(0)}
-                    </span>
-                    {article.author}
-                  </Link>
-                  <button className="favorite-button" type="button">
-                    {article.favoritesCount}
-                  </button>
-                </div>
-                <Link className="article-preview__body" to={`/article/${article.slug}`}>
-                  <h2>{article.title}</h2>
-                  <p>{article.description}</p>
-                  <div className="article-preview__footer">
-                    <span>Read more...</span>
-                    <span className="tag-row">
-                      {article.tags.map((tag) => (
-                        <span className="tag" key={tag}>
-                          {tag}
-                        </span>
-                      ))}
-                    </span>
-                  </div>
-                </Link>
-              </article>
-            ))}
-          </div>
+          <FeedTabs
+            activeFeed={activeFeed}
+            isAuthenticated={isAuthenticated}
+            onSelectGlobal={selectGlobalFeed}
+            onSelectYour={selectYourFeed}
+            selectedTag={selectedTag}
+          />
+          <h1 id="home-title">{heading}</h1>
+          <ArticleList
+            key={articleListKey}
+            loadArticles={loadArticles}
+            onPageChange={selectPage}
+            page={page}
+          />
         </section>
 
-        <aside className="tag-panel" aria-labelledby="popular-tags-title">
-          <h2 id="popular-tags-title">Popular Tags</h2>
-          <div className="tag-cloud">
-            {POPULAR_TAGS.map((tag) => (
-              <Link className="tag" key={tag} to={`/?tag=${tag}`}>
-                {tag}
-              </Link>
-            ))}
-          </div>
-        </aside>
+        <PopularTags onSelectTag={selectTag} selectedTag={selectedTag} />
       </div>
     </main>
   );
@@ -314,4 +314,86 @@ function readableSlug(slug: string): string {
     .filter((word) => word.length > 0)
     .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
     .join(' ');
+}
+
+function normalizeTag(tag: string | null): string | null {
+  const normalizedTag = tag?.trim();
+
+  if (normalizedTag === undefined || normalizedTag === '') {
+    return null;
+  }
+
+  return normalizedTag;
+}
+
+function parsePage(page: string | null): number {
+  if (page === null) {
+    return 1;
+  }
+
+  const parsedPage = Number.parseInt(page, 10);
+
+  if (!Number.isInteger(parsedPage) || parsedPage < 1) {
+    return 1;
+  }
+
+  return parsedPage;
+}
+
+function getActiveFeed({
+  feedParam,
+  isAuthenticated,
+  selectedTag,
+}: {
+  feedParam: string | null;
+  isAuthenticated: boolean;
+  selectedTag: string | null;
+}): ActiveFeed {
+  if (selectedTag !== null) {
+    return 'tag';
+  }
+
+  if (feedParam === 'your' && isAuthenticated) {
+    return 'your';
+  }
+
+  return 'global';
+}
+
+function getFeedHeading(activeFeed: ActiveFeed, selectedTag: string | null): string {
+  if (activeFeed === 'your') {
+    return 'Your Feed';
+  }
+
+  if (activeFeed === 'tag') {
+    return `# ${selectedTag ?? ''}`;
+  }
+
+  return 'Global Feed';
+}
+
+function createHomeSearchParams({
+  activeFeed,
+  page,
+  tag,
+}: {
+  activeFeed: ActiveFeed;
+  page: number;
+  tag?: string | null;
+}): URLSearchParams {
+  const searchParams = new URLSearchParams();
+
+  if (activeFeed === 'your') {
+    searchParams.set('feed', 'your');
+  }
+
+  if (activeFeed === 'tag' && tag !== undefined && tag !== null && tag.trim() !== '') {
+    searchParams.set('tag', tag);
+  }
+
+  if (page > 1) {
+    searchParams.set('page', String(page));
+  }
+
+  return searchParams;
 }

--- a/frontend/src/features/article/__tests__/articleApi.test.ts
+++ b/frontend/src/features/article/__tests__/articleApi.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ApiClient } from '@/lib/apiClient';
+import { ARTICLE_PAGE_SIZE, listArticles } from '../api/articleApi';
+
+function createClient(): ApiClient {
+  return {
+    delete: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    request: vi.fn(),
+  };
+}
+
+const ARTICLE_RESPONSE = {
+  articles: [
+    {
+      author: {
+        bio: 'API learner',
+        following: false,
+        image: 'https://example.com/jake.png',
+        username: 'jake',
+      },
+      createdAt: '2026-05-06T00:00:00.000Z',
+      description: 'Ever wonder how?',
+      favorited: false,
+      favoritesCount: 3,
+      slug: 'how-to-train-your-dragon',
+      tagList: ['dragons', 'training'],
+      title: 'How to train your dragon',
+      updatedAt: '2026-05-07T00:00:00.000Z',
+    },
+  ],
+  articlesCount: 1,
+};
+
+describe('Article API', () => {
+  it('Global Feed用のArticle listをlimit/offset付きで取得してfrontend modelへ変換する', async () => {
+    const client = createClient();
+    vi.mocked(client.get).mockResolvedValue(ARTICLE_RESPONSE);
+
+    const result = await listArticles(
+      {
+        limit: ARTICLE_PAGE_SIZE,
+        offset: 20,
+      },
+      client,
+    );
+
+    expect(client.get).toHaveBeenCalledWith('/api/articles?limit=10&offset=20');
+    expect(result).toEqual({
+      articles: [
+        {
+          author: {
+            bio: 'API learner',
+            following: false,
+            image: 'https://example.com/jake.png',
+            username: 'jake',
+          },
+          createdAt: '2026-05-06T00:00:00.000Z',
+          description: 'Ever wonder how?',
+          favorited: false,
+          favoritesCount: 3,
+          slug: 'how-to-train-your-dragon',
+          tags: ['dragons', 'training'],
+          title: 'How to train your dragon',
+          updatedAt: '2026-05-07T00:00:00.000Z',
+        },
+      ],
+      totalCount: 1,
+    });
+  });
+
+  it('tag filterをquery parameterとして送る', async () => {
+    const client = createClient();
+    vi.mocked(client.get).mockResolvedValue({
+      articles: [],
+      articlesCount: 0,
+    });
+
+    await listArticles(
+      {
+        limit: ARTICLE_PAGE_SIZE,
+        offset: 0,
+        tag: 'react patterns',
+      },
+      client,
+    );
+
+    expect(client.get).toHaveBeenCalledWith(
+      '/api/articles?tag=react+patterns&limit=10&offset=0',
+    );
+  });
+});

--- a/frontend/src/features/article/api/articleApi.ts
+++ b/frontend/src/features/article/api/articleApi.ts
@@ -1,0 +1,94 @@
+import { apiClient, type ApiClient } from '@/lib/apiClient';
+import type { ArticleListParams, ArticleListResult, ArticleSummary } from '../types/article';
+
+export const ARTICLE_PAGE_SIZE = 10;
+
+export interface ArticleListResponse {
+  articles: ArticleResponse[];
+  articlesCount: number;
+}
+
+interface ArticleResponse {
+  author: {
+    bio: string | null;
+    following: boolean;
+    image: string | null;
+    username: string;
+  };
+  createdAt: string;
+  description: string;
+  favorited: boolean;
+  favoritesCount: number;
+  slug: string;
+  tagList: string[];
+  title: string;
+  updatedAt: string;
+}
+
+/**
+ * Global Feedまたはtag filter付きArticle listをBFF経由で取得する。
+ */
+export async function listArticles(
+  params: ArticleListParams,
+  client: ApiClient = apiClient,
+): Promise<ArticleListResult> {
+  const response = await getArticleListResponse(
+    client,
+    buildArticleListPath('/api/articles', params),
+    params.signal,
+  );
+
+  return mapArticleListResponse(response);
+}
+
+export function mapArticleListResponse(response: ArticleListResponse): ArticleListResult {
+  return {
+    articles: response.articles.map(mapArticleResponse),
+    totalCount: response.articlesCount,
+  };
+}
+
+function mapArticleResponse(response: ArticleResponse): ArticleSummary {
+  return {
+    author: {
+      bio: response.author.bio,
+      following: response.author.following,
+      image: response.author.image,
+      username: response.author.username,
+    },
+    createdAt: response.createdAt,
+    description: response.description,
+    favorited: response.favorited,
+    favoritesCount: response.favoritesCount,
+    slug: response.slug,
+    tags: response.tagList,
+    title: response.title,
+    updatedAt: response.updatedAt,
+  };
+}
+
+export function buildArticleListPath(basePath: string, params: ArticleListParams): string {
+  const query = new URLSearchParams();
+  const tag = params.tag?.trim();
+
+  if (tag !== undefined && tag !== '') {
+    query.set('tag', tag);
+  }
+
+  query.set('limit', String(params.limit));
+  query.set('offset', String(params.offset));
+
+  return `${basePath}?${query.toString()}`;
+}
+
+async function getArticleListResponse(
+  client: ApiClient,
+  path: string,
+  signal?: AbortSignal,
+): Promise<ArticleListResponse> {
+  if (signal === undefined) {
+    return client.get<ArticleListResponse>(path);
+  }
+
+  return client.get<ArticleListResponse>(path, { signal });
+}

--- a/frontend/src/features/article/components/ArticleList.tsx
+++ b/frontend/src/features/article/components/ArticleList.tsx
@@ -1,0 +1,223 @@
+import { type ReactElement, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { isApiError } from '@/lib/apiError';
+import { ARTICLE_PAGE_SIZE } from '../api/articleApi';
+import type { ArticleSummary, LoadArticles } from '../types/article';
+
+interface ArticleListProps {
+  loadArticles: LoadArticles;
+  onPageChange: (page: number) => void;
+  page: number;
+}
+
+type ArticleListState =
+  | {
+      articles: ArticleSummary[];
+      error: null;
+      status: 'loading';
+      totalCount: number;
+    }
+  | {
+      articles: ArticleSummary[];
+      error: null;
+      status: 'success';
+      totalCount: number;
+    }
+  | {
+      articles: [];
+      error: string;
+      status: 'error';
+      totalCount: 0;
+    };
+
+/**
+ * Article listの取得状態、一覧表示、paginationをまとめて扱う。
+ */
+export function ArticleList({
+  loadArticles,
+  onPageChange,
+  page,
+}: ArticleListProps): ReactElement {
+  const [state, setState] = useState<ArticleListState>({
+    articles: [],
+    error: null,
+    status: 'loading',
+    totalCount: 0,
+  });
+  const offset = useMemo(() => (page - 1) * ARTICLE_PAGE_SIZE, [page]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let isCurrent = true;
+
+    async function load(): Promise<void> {
+      try {
+        const result = await loadArticles({
+          limit: ARTICLE_PAGE_SIZE,
+          offset,
+          signal: controller.signal,
+        });
+
+        if (!isCurrent) {
+          return;
+        }
+
+        setState({
+          articles: result.articles,
+          error: null,
+          status: 'success',
+          totalCount: result.totalCount,
+        });
+      } catch (error: unknown) {
+        if (!isCurrent || isAbortError(error)) {
+          return;
+        }
+
+        setState({
+          articles: [],
+          error: getArticleErrorMessage(error),
+          status: 'error',
+          totalCount: 0,
+        });
+      }
+    }
+
+    void load();
+
+    return () => {
+      isCurrent = false;
+      controller.abort();
+    };
+  }, [loadArticles, offset]);
+
+  if (state.status === 'loading') {
+    return (
+      <div className="article-list" aria-live="polite">
+        <p className="state-message">Loading articles...</p>
+      </div>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <div className="article-list" aria-live="polite">
+        <p className="state-message state-message--error">{state.error}</p>
+      </div>
+    );
+  }
+
+  if (state.articles.length === 0) {
+    return (
+      <div className="article-list" aria-live="polite">
+        <p className="state-message">No articles are here... yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="article-list">
+        {state.articles.map((article) => (
+          <ArticlePreview article={article} key={article.slug} />
+        ))}
+      </div>
+      <ArticlePagination
+        onPageChange={onPageChange}
+        page={page}
+        totalCount={state.totalCount}
+      />
+    </>
+  );
+}
+
+interface ArticlePreviewProps {
+  article: ArticleSummary;
+}
+
+function ArticlePreview({ article }: ArticlePreviewProps): ReactElement {
+  return (
+    <article className="article-preview">
+      <div className="article-preview__meta">
+        <Link to={`/profile/${encodeURIComponent(article.author.username)}`}>
+          <span className="avatar" aria-hidden="true">
+            {article.author.username.charAt(0).toUpperCase()}
+          </span>
+          {article.author.username}
+        </Link>
+        <button
+          aria-label={`${article.favoritesCount} favorites`}
+          className={article.favorited ? 'favorite-button is-active' : 'favorite-button'}
+          type="button"
+        >
+          {article.favoritesCount}
+        </button>
+      </div>
+      <Link className="article-preview__body" to={`/article/${article.slug}`}>
+        <h2>{article.title}</h2>
+        <p>{article.description}</p>
+        <div className="article-preview__footer">
+          <span>Read more...</span>
+          <span className="tag-row">
+            {article.tags.map((tag) => (
+              <span className="tag" key={tag}>
+                {tag}
+              </span>
+            ))}
+          </span>
+        </div>
+      </Link>
+    </article>
+  );
+}
+
+interface ArticlePaginationProps {
+  onPageChange: (page: number) => void;
+  page: number;
+  totalCount: number;
+}
+
+function ArticlePagination({
+  onPageChange,
+  page,
+  totalCount,
+}: ArticlePaginationProps): ReactElement | null {
+  const pageCount = Math.ceil(totalCount / ARTICLE_PAGE_SIZE);
+
+  if (pageCount <= 1) {
+    return null;
+  }
+
+  return (
+    <nav className="pagination" aria-label="Article pagination">
+      <button
+        disabled={page <= 1}
+        onClick={() => onPageChange(page - 1)}
+        type="button"
+      >
+        Previous page
+      </button>
+      <span>
+        Page {page} of {pageCount}
+      </span>
+      <button
+        disabled={page >= pageCount}
+        onClick={() => onPageChange(page + 1)}
+        type="button"
+      >
+        Next page
+      </button>
+    </nav>
+  );
+}
+
+function getArticleErrorMessage(error: unknown): string {
+  if (isApiError(error) && error.kind === 'unauthorized') {
+    return 'Sign in to view your feed.';
+  }
+
+  return 'Articles could not be loaded.';
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}

--- a/frontend/src/features/article/index.ts
+++ b/frontend/src/features/article/index.ts
@@ -1,0 +1,16 @@
+export {
+  ARTICLE_PAGE_SIZE,
+  buildArticleListPath,
+  listArticles,
+  mapArticleListResponse,
+  type ArticleListResponse,
+} from './api/articleApi';
+export { ArticleList } from './components/ArticleList';
+export type {
+  ArticleAuthor,
+  ArticleListParams,
+  ArticleListQuery,
+  ArticleListResult,
+  ArticleSummary,
+  LoadArticles,
+} from './types/article';

--- a/frontend/src/features/article/types/article.ts
+++ b/frontend/src/features/article/types/article.ts
@@ -1,0 +1,35 @@
+export interface ArticleAuthor {
+  bio: string | null;
+  following: boolean;
+  image: string | null;
+  username: string;
+}
+
+export interface ArticleSummary {
+  author: ArticleAuthor;
+  createdAt: string;
+  description: string;
+  favorited: boolean;
+  favoritesCount: number;
+  slug: string;
+  tags: string[];
+  title: string;
+  updatedAt: string;
+}
+
+export interface ArticleListResult {
+  articles: ArticleSummary[];
+  totalCount: number;
+}
+
+export interface ArticleListQuery {
+  limit: number;
+  offset: number;
+  signal?: AbortSignal;
+}
+
+export interface ArticleListParams extends ArticleListQuery {
+  tag?: string;
+}
+
+export type LoadArticles = (query: ArticleListQuery) => Promise<ArticleListResult>;

--- a/frontend/src/features/feed/__tests__/feedApi.test.ts
+++ b/frontend/src/features/feed/__tests__/feedApi.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ApiClient } from '@/lib/apiClient';
+import { getFeed } from '../api/feedApi';
+
+function createClient(): ApiClient {
+  return {
+    delete: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    request: vi.fn(),
+  };
+}
+
+describe('Feed API', () => {
+  it('Your Feedをlimit/offset付きで取得してArticle list resultへ変換する', async () => {
+    const client = createClient();
+    vi.mocked(client.get).mockResolvedValue({
+      articles: [
+        {
+          author: {
+            bio: null,
+            following: true,
+            image: null,
+            username: 'followed-user',
+          },
+          createdAt: '2026-05-06T00:00:00.000Z',
+          description: 'From someone you follow',
+          favorited: true,
+          favoritesCount: 9,
+          slug: 'your-feed-article',
+          tagList: ['feed'],
+          title: 'Your feed article',
+          updatedAt: '2026-05-06T00:00:00.000Z',
+        },
+      ],
+      articlesCount: 1,
+    });
+
+    const result = await getFeed(
+      {
+        limit: 10,
+        offset: 10,
+      },
+      client,
+    );
+
+    expect(client.get).toHaveBeenCalledWith('/api/articles/feed?limit=10&offset=10');
+    expect(result.articles[0]?.tags).toEqual(['feed']);
+    expect(result.totalCount).toBe(1);
+  });
+});

--- a/frontend/src/features/feed/api/feedApi.ts
+++ b/frontend/src/features/feed/api/feedApi.ts
@@ -1,0 +1,26 @@
+import { apiClient, type ApiClient } from '@/lib/apiClient';
+import {
+  buildArticleListPath,
+  mapArticleListResponse,
+  type ArticleListQuery,
+  type ArticleListResponse,
+  type ArticleListResult,
+} from '@/features/article';
+
+/**
+ * 認証済みユーザーのYour FeedをBFF経由で取得する。
+ */
+export async function getFeed(
+  params: ArticleListQuery,
+  client: ApiClient = apiClient,
+): Promise<ArticleListResult> {
+  const path = buildArticleListPath('/api/articles/feed', params);
+
+  if (params.signal === undefined) {
+    return mapArticleListResponse(await client.get<ArticleListResponse>(path));
+  }
+
+  return mapArticleListResponse(
+    await client.get<ArticleListResponse>(path, { signal: params.signal }),
+  );
+}

--- a/frontend/src/features/feed/components/FeedTabs.tsx
+++ b/frontend/src/features/feed/components/FeedTabs.tsx
@@ -1,0 +1,48 @@
+import type { ReactElement } from 'react';
+
+export type ActiveFeed = 'global' | 'tag' | 'your';
+
+interface FeedTabsProps {
+  activeFeed: ActiveFeed;
+  isAuthenticated: boolean;
+  onSelectGlobal: () => void;
+  onSelectYour: () => void;
+  selectedTag: string | null;
+}
+
+export function FeedTabs({
+  activeFeed,
+  isAuthenticated,
+  onSelectGlobal,
+  onSelectYour,
+  selectedTag,
+}: FeedTabsProps): ReactElement {
+  return (
+    <nav className="feed-tabs" aria-label="Feed filters">
+      {isAuthenticated ? (
+        <button
+          className={activeFeed === 'your' ? 'is-active' : undefined}
+          onClick={onSelectYour}
+          type="button"
+        >
+          Your Feed
+        </button>
+      ) : null}
+      <button
+        className={activeFeed === 'global' ? 'is-active' : undefined}
+        onClick={onSelectGlobal}
+        type="button"
+      >
+        Global Feed
+      </button>
+      {selectedTag !== null ? (
+        <button
+          className={activeFeed === 'tag' ? 'is-active' : undefined}
+          type="button"
+        >
+          # {selectedTag}
+        </button>
+      ) : null}
+    </nav>
+  );
+}

--- a/frontend/src/features/feed/index.ts
+++ b/frontend/src/features/feed/index.ts
@@ -1,0 +1,2 @@
+export { getFeed } from './api/feedApi';
+export { FeedTabs, type ActiveFeed } from './components/FeedTabs';

--- a/frontend/src/features/tag/__tests__/tagApi.test.ts
+++ b/frontend/src/features/tag/__tests__/tagApi.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ApiClient } from '@/lib/apiClient';
+import { getPopularTags } from '../api/tagApi';
+
+function createClient(): ApiClient {
+  return {
+    delete: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    request: vi.fn(),
+  };
+}
+
+describe('Tag API', () => {
+  it('Popular TagsをBFF経由で取得する', async () => {
+    const client = createClient();
+    vi.mocked(client.get).mockResolvedValue({
+      tags: ['react', 'laravel', 'testing'],
+    });
+
+    const tags = await getPopularTags(client);
+
+    expect(client.get).toHaveBeenCalledWith('/api/tags');
+    expect(tags).toEqual(['react', 'laravel', 'testing']);
+  });
+});

--- a/frontend/src/features/tag/api/tagApi.ts
+++ b/frontend/src/features/tag/api/tagApi.ts
@@ -1,0 +1,23 @@
+import { apiClient, type ApiClient } from '@/lib/apiClient';
+
+interface TagsResponse {
+  tags: string[];
+}
+
+interface TagApiOptions {
+  signal?: AbortSignal;
+}
+
+/**
+ * Popular TagsをBFF経由で取得する。
+ */
+export async function getPopularTags(
+  client: ApiClient = apiClient,
+  options: TagApiOptions = {},
+): Promise<string[]> {
+  if (options.signal === undefined) {
+    return (await client.get<TagsResponse>('/api/tags')).tags;
+  }
+
+  return (await client.get<TagsResponse>('/api/tags', { signal: options.signal })).tags;
+}

--- a/frontend/src/features/tag/components/PopularTags.tsx
+++ b/frontend/src/features/tag/components/PopularTags.tsx
@@ -1,0 +1,123 @@
+import { type ReactElement, useEffect, useState } from 'react';
+import { getPopularTags } from '../index';
+
+interface PopularTagsProps {
+  onSelectTag: (tag: string) => void;
+  selectedTag: string | null;
+}
+
+type PopularTagsState =
+  | {
+      error: null;
+      status: 'loading';
+      tags: [];
+    }
+  | {
+      error: null;
+      status: 'success';
+      tags: string[];
+    }
+  | {
+      error: string;
+      status: 'error';
+      tags: [];
+    };
+
+export function PopularTags({
+  onSelectTag,
+  selectedTag,
+}: PopularTagsProps): ReactElement {
+  const [state, setState] = useState<PopularTagsState>({
+    error: null,
+    status: 'loading',
+    tags: [],
+  });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let isCurrent = true;
+
+    async function load(): Promise<void> {
+      try {
+        const tags = await getPopularTags(undefined, {
+          signal: controller.signal,
+        });
+
+        if (!isCurrent) {
+          return;
+        }
+
+        setState({
+          error: null,
+          status: 'success',
+          tags,
+        });
+      } catch (error: unknown) {
+        if (!isCurrent || isAbortError(error)) {
+          return;
+        }
+
+        setState({
+          error: 'Tags could not be loaded.',
+          status: 'error',
+          tags: [],
+        });
+      }
+    }
+
+    void load();
+
+    return () => {
+      isCurrent = false;
+      controller.abort();
+    };
+  }, []);
+
+  return (
+    <aside className="tag-panel" aria-labelledby="popular-tags-title">
+      <h2 id="popular-tags-title">Popular Tags</h2>
+      {renderTagContent(state, selectedTag, onSelectTag)}
+    </aside>
+  );
+}
+
+function renderTagContent(
+  state: PopularTagsState,
+  selectedTag: string | null,
+  onSelectTag: (tag: string) => void,
+): ReactElement {
+  if (state.status === 'loading') {
+    return <p className="state-message state-message--compact">Loading tags...</p>;
+  }
+
+  if (state.status === 'error') {
+    return (
+      <p className="state-message state-message--compact state-message--error">
+        {state.error}
+      </p>
+    );
+  }
+
+  if (state.tags.length === 0) {
+    return <p className="state-message state-message--compact">No tags yet.</p>;
+  }
+
+  return (
+    <div className="tag-cloud">
+      {state.tags.map((tag) => (
+        <button
+          className={selectedTag === tag ? 'tag is-active' : 'tag'}
+          key={tag}
+          onClick={() => onSelectTag(tag)}
+          type="button"
+        >
+          {tag}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}

--- a/frontend/src/features/tag/index.ts
+++ b/frontend/src/features/tag/index.ts
@@ -1,0 +1,2 @@
+export { getPopularTags } from './api/tagApi';
+export { PopularTags } from './components/PopularTags';

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -345,6 +345,12 @@ textarea:focus-visible {
   font-weight: 700;
 }
 
+.favorite-button.is-active {
+  border-color: var(--primary);
+  background: var(--primary-soft);
+  color: var(--primary);
+}
+
 .tag-panel {
   border-left: 1px solid var(--surface-line);
   padding-left: 24px;
@@ -377,6 +383,58 @@ textarea:focus-visible {
   color: var(--text-muted);
   padding: 4px 10px;
   font-size: 0.78rem;
+}
+
+button.tag {
+  cursor: pointer;
+}
+
+.tag.is-active {
+  border-color: var(--primary);
+  background: var(--primary-soft);
+  color: var(--primary);
+}
+
+.state-message {
+  margin-block: 24px;
+  color: var(--text-muted);
+  font-size: 0.94rem;
+  font-weight: 700;
+}
+
+.state-message--compact {
+  margin-block: 16px 0;
+}
+
+.state-message--error {
+  color: var(--error);
+}
+
+.pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 28px;
+  color: var(--text-muted);
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.pagination button {
+  min-height: 34px;
+  border: 1px solid var(--surface-line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text-muted);
+  padding: 0 12px;
+  font-weight: 700;
+}
+
+.pagination button:not(:disabled):hover {
+  border-color: var(--primary);
+  color: var(--primary);
 }
 
 .auth-panel,


### PR DESCRIPTION
# 概要

- Home のモック記事/タグ表示を API-backed な Article list / Feed tabs / Popular Tags に置き換え
- Global Feed / Your Feed / selected tag tab と `limit` / `offset` pagination を実装
- Article / Feed / Tag API 変換と Home の guest/auth、tag click、pagination、empty/error state のテストを追加

# 関連Issue

Closes #72

Epic: #58

# 修正ファイルの説明

## App Route

- `frontend/src/app/routes/pages.tsx`
  - Home の static mock data を削除し、`ArticleList` / `FeedTabs` / `PopularTags` を組み合わせる構成へ変更
  - URL query の `feed`, `tag`, `page` から active feed と pagination state を導出するため

## Article Feature

- `frontend/src/features/article/api/articleApi.ts`
  - `/api/articles` の query path 生成と RealWorld article list response の frontend model 変換を追加
  - Global Feed と tag filtering の API contract を feature 境界に閉じるため
- `frontend/src/features/article/components/ArticleList.tsx`
  - Article list の loading / empty / error state、article preview、pagination を追加
  - Home から渡される loader により Global / Your / Tag の表示を同じ list UI で扱うため
- `frontend/src/features/article/types/article.ts`
  - Article summary、Article list result、loader query の型を追加
  - component と API の契約を明示するため

## Feed Feature

- `frontend/src/features/feed/api/feedApi.ts`
  - `/api/articles/feed` の取得 API を追加
  - authenticated user の Your Feed tab から BFF 経由で feed を取得するため
- `frontend/src/features/feed/components/FeedTabs.tsx`
  - Global / Your / selected tag tab の表示と切り替え UI を追加
  - Home の tab 表示差分を component に分離するため

## Tag Feature

- `frontend/src/features/tag/api/tagApi.ts`
  - `/api/tags` の取得 API を追加
  - Popular Tags を BFF 経由で取得するため
- `frontend/src/features/tag/components/PopularTags.tsx`
  - tag list の loading / empty / error state と tag 選択 UI を追加
  - Home の tag filtering 起点を feature component に分離するため

## Tests / Style

- `frontend/src/app/routes/__tests__/HomePage.test.tsx`
  - guest/auth tab 差分、Your Feed 切り替え、tag click、pagination、empty/error state を検証
  - Issue #72 の受け入れ条件をユーザー視点で固定するため
- `frontend/src/features/**/__tests__/*`
  - Article / Feed / Tag API の path と response mapping を検証
  - feature API の BFF contract を固定するため
- `frontend/src/index.css`
  - state message、active tag/favorite、pagination の最小スタイルを追加
  - 既存 Home layout に新しい状態表示を馴染ませるため

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| フロントエンド変更あり | 型チェック | `pnpm exec tsc -b --noEmit` | 成功する | 成功 |
| フロントエンド変更あり | Vitest | `pnpm vitest run` | すべて成功する | 9 files / 46 tests 成功 |
| フロントエンド変更あり | ESLint | `pnpm exec eslint .` | 成功する | 成功 |
| ドキュメント/空白確認 | diff check | `git diff --check` | 空白エラーなし | 成功 |
| バックエンド変更なし | Backend test / Pint / PHPStan | 対象外 | backend 差分がない | 未実施 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: Home の URL query state と feature 境界、BFF endpoint path の整合性
