### PR TITLE
[#148]: GitHub CLI運用を正本へ明記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,13 @@ React 19 + TypeScript / Laravel 13 のモノレポ。API、CRUD、新しい技�
 - `.worktree` は gitignored の非追跡作業領域として扱い、作業完了後にクリーンアップする。
 - 詳細な作成手順と命名は `docs/ai/harness.md` と該当 skill を正本とする。
 
+## Codex sandbox と GitHub CLI
+
+- Codex sandbox 内では macOS keyring や外部ネットワークにアクセスできず、`gh issue`、`gh pr`、`gh api` が失敗する場合がある。
+- GitHub API の読み取り・作成・編集が必要な場合は、必要に応じて sandbox 外実行を許可して行う。
+- `GH_TOKEN` / `GITHUB_TOKEN` を shell config に直書きせず、`gh auth login` の keyring 認証を使う。
+- sudo / root 権限で解決しようとしない。
+
 ## Skill の使い分け
 
 - `.agents/skills/code-review/` - コードレビュー、テスト妥当性、アーキテクチャ確認。

--- a/docs/ai/harness.md
+++ b/docs/ai/harness.md
@@ -39,6 +39,23 @@ session をまたいでも作業場所を再発見できるように、標準の
 - worktree には `node_modules/` や `vendor/` が含まれないため、対象レイヤーに応じて worktree 内で依存関係を入れる。
 - 作業完了後、PR 作成と必要な引き継ぎが済んだ worktree はクリーンアップする。
 
+## Codex Sandbox And GitHub CLI Policy
+
+Codex sandbox 内では、macOS keyring や外部ネットワークへ到達できないことがある。
+そのため `gh issue`、`gh pr`、`gh api` が認証済みのユーザー端末では成功しても、sandbox 内では失敗する場合がある。
+これは sudo / root 権限で解決する問題ではなく、sandbox 境界、keyring、network access の扱いとして切り分ける。
+
+- GitHub API の読み取り・作成・編集が必要な場合は、まず対象リポジトリ、Issue / PR 番号、操作内容を明確にする。
+- `gh` が keyring、network access、permission、host resolution などの理由で sandbox 内実行に失敗した場合は、必要性を説明して sandbox 外実行の許可を得てから再実行する。
+- `GH_TOKEN` / `GITHUB_TOKEN` を shell config、`.env`、git 管理ファイル、Issue / PR 本文、ログへ直書きしない。
+- 認証は `gh auth login` によるユーザーセッションの keyring 認証を使い、token 実値を AI agent に渡さない。
+- 認証状態の確認や API 操作で token 値、secret 値、cookie、credential helper の実体を出力しない。
+- sandbox 外実行でも、実行するコマンドは必要最小限にし、読み取り、作成、編集、push などの目的を分けて確認できるようにする。
+- sudo / root 権限、root の keyring、個人 token の一時 export で回避しない。
+
+この方針は GitHub Issue / PR / Project 操作全般に適用する。
+Issue、sub-issue、Project field の具体的な運用は `docs/rules/project.md` を正本とする。
+
 ## Skill Trigger Policy
 
 - Repository skill は `.agents/skills/<skill-name>/SKILL.md` に置く。

--- a/docs/rules/project.md
+++ b/docs/rules/project.md
@@ -10,6 +10,39 @@ GitHub Issue と GitHub Projects で、Epic、sub-issue、Project custom field �
 - GitHub Projects の custom field は一覧性、grouping、filtering、sprint 管理のために使う。
 - Epic 候補と実装順の正本は `docs/issue-breakdown.md` とする。
 
+## GitHub CLI 実行ルール
+
+Issue、PR、sub-issue、GitHub Projects の読み取り・作成・編集では、GitHub 上の状態を正として扱う。
+`gh issue`、`gh pr`、`gh api` を使う場合は、`docs/ai/harness.md` の Codex sandbox 方針に従う。
+
+### sandbox 内で失敗した場合
+
+Codex sandbox では macOS keyring や外部ネットワークへアクセスできず、認証済みのユーザー端末と同じ `gh` コマンドでも失敗することがある。
+次のような失敗は、権限不足の一般論ではなく sandbox 境界として切り分ける。
+
+- keyring にアクセスできず、`gh auth status` や `gh issue view` が未認証扱いになる。
+- host resolution、network access、TLS、API 到達性のエラーで `gh issue`、`gh pr`、`gh api` が失敗する。
+- `.git` や credential 周辺へのアクセスが sandbox 制約で拒否される。
+
+この場合は、実行したい操作、対象 Issue / PR / Project、必要な理由を明示し、sandbox 外実行の許可を得てから再実行する。
+sudo / root 権限、root ユーザーの keyring、個人 access token の shell export で回避しない。
+
+### 認証情報の扱い
+
+- `GH_TOKEN` / `GITHUB_TOKEN` を shell config、`.env`、git 管理ファイル、Issue / PR 本文、ログへ直書きしない。
+- `gh auth login` によるユーザーセッションの keyring 認証を使う。
+- token 値、secret 値、cookie、credential helper の実体を表示、転記、コミットしない。
+- 認証状態を確認するときも、成功 / 失敗と必要な scope の有無だけを扱う。
+
+### 操作前チェック
+
+GitHub API を作成・編集系で使う前に、次を確認する。
+
+- 対象 repository、Issue / PR 番号、Project が意図したものか。
+- labels、parent issue、Project field、milestone などの変更対象が `docs/labels.md` とこの文書に沿っているか。
+- 1 Issue = 1 PR の原則を崩していないか。
+- 失敗時のログや PR 本文に secret 値を含めていないか。
+
 ## Epic Issue
 
 Epic Issue は、複数 Issue に分割される機能単位の親 Issue として扱う。


### PR DESCRIPTION
# 概要

- Codex sandbox で `gh issue` / `gh pr` / `gh api` が失敗する場合の切り分け方針を `docs/ai/harness.md` に追加
- Issue / PR / Project 操作時の GitHub CLI 実行判断、認証情報の扱い、操作前チェックを `docs/rules/project.md` に追加
- root `AGENTS.md` に入口ルールとして最小限の GitHub CLI 運用方針を追加

# 関連Issue

Closes #148

Epic: #52

# 修正ファイルの説明

## AI Harness

- `AGENTS.md`
  - Codex sandbox と GitHub CLI の入口ルールを追加
  - 詳細は正本 docs に寄せるため、最小限の注意事項だけを記載
- `docs/ai/harness.md`
  - Codex sandbox、macOS keyring、network access、GitHub CLI の共通方針を追加
  - `GH_TOKEN` / `GITHUB_TOKEN` の shell config 直書き禁止と、sudo / root 権限で回避しない方針を明記

## Project Rules

- `docs/rules/project.md`
  - Issue / PR / sub-issue / Project 操作で `gh issue`、`gh pr`、`gh api` を使う場合の判断基準を追加
  - sandbox 内失敗時の切り分け、認証情報の扱い、操作前チェックを明記

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| ドキュメントのみ変更 | Markdown と空白確認 | `git diff --check HEAD~1..HEAD` | 空白エラーがない | 成功 |
| ドキュメントのみ変更 | 受け入れ条件の記述確認 | `rg "Codex sandbox|GH_TOKEN|GITHUB_TOKEN|keyring|sandbox 外|sudo / root"` | 必要な方針が docs に記載されている | 成功 |
| バックエンド変更なし | Pest / Pint / PHPStan | 対象外 | backend 変更がないため未実施であることを説明できる | 対象外 |
| フロントエンド変更なし | Vitest / ESLint / TypeScript | 対象外 | frontend 変更がないため未実施であることを説明できる | 対象外 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: `AGENTS.md` は入口、詳細は `docs/ai/harness.md` / `docs/rules/project.md` という役割分担が保たれているか
