### PR TITLE
[#147]: FrontendのBFF接続設定を修正

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,13 @@ React 19 + TypeScript / Laravel 13 のモノレポ。API、CRUD、新しい技�
 - `.worktree` は gitignored の非追跡作業領域として扱い、作業完了後にクリーンアップする。
 - 詳細な作成手順と命名は `docs/ai/harness.md` と該当 skill を正本とする。
 
+## Shell command と RTK
+
+- Shell command は原則として必ず `rtk` 経由で実行する。
+- 通常は `rtk <command>`、raw output や引数互換性が必要な場合は `rtk proxy <command>` を使う。
+- `rtk` 経由で実行できない場合は、commentary または approval justification に理由を明記してから最小範囲の bare command を使う。
+- 詳細は `docs/ai/harness.md` の Shell Command Policy を正本とする。
+
 ## Skill の使い分け
 
 - `.agents/skills/code-review/` - コードレビュー、テスト妥当性、アーキテクチャ確認。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,13 @@ React 19 + TypeScript / Laravel 13 のモノレポ。API、CRUD、新しい技�
 - `.worktree` は gitignored の非追跡作業領域として扱い、作業完了後にクリーンアップする。
 - 詳細な作成手順と命名は `docs/ai/harness.md` と該当 skill を正本とする。
 
+## Codex sandbox と GitHub CLI
+
+- Codex sandbox 内では macOS keyring や外部ネットワークにアクセスできず、`gh issue`、`gh pr`、`gh api` が失敗する場合がある。
+- GitHub API の読み取り・作成・編集が必要な場合は、必要に応じて sandbox 外実行を許可して行う。
+- `GH_TOKEN` / `GITHUB_TOKEN` を shell config に直書きせず、`gh auth login` の keyring 認証を使う。
+- sudo / root 権限で解決しようとしない。
+
 ## Shell command と RTK
 
 - Shell command は原則として必ず `rtk` 経由で実行する。

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ docker compose exec frontend sh
 pnpm install
 ```
 
+Frontend は browser から same-origin の `/api/*` だけを呼び、Vite dev server が BFF (`BFF_PROXY_TARGET`, 既定 `http://localhost:3006`) へ proxy します。
+既存の `frontend/.env.local` に `VITE_API_BASE_URL=http://localhost:8080` が残っている場合は、Public API/backend-nginx 直送になるため削除してください。
+
 停止:
 
 ```bash

--- a/docs/ai/harness.md
+++ b/docs/ai/harness.md
@@ -27,6 +27,16 @@ ADR は廃止方向とし、判断は要件・ルール・ドメイン設計・�
 - https://openai.com/ja-JP/index/harness-engineering/
 - https://developers.openai.com/codex/skills
 
+## Shell Command Policy
+
+このプロジェクトで AI agent が shell command を実行するときは、セッションをまたいでも必ず RTK を経由する。
+
+- 通常の shell command は `rtk <command>` で実行する。
+- `git diff` や `git status` のように raw output を読みたい場合、または RTK のフィルタリングや引数解釈が command の挙動に影響する場合は `rtk proxy <command>` を使う。
+- GitHub CLI、Docker、curl、git の sandbox 外実行や approval 付き実行でも、原則として `rtk proxy gh ...`、`rtk proxy docker ...`、`rtk proxy curl ...`、`rtk proxy git ...` のように RTK 経由を維持する。
+- `rtk` 経由では command が壊れる、承認 prefix と衝突する、または tool/runtime の制約で実行できない場合に限り bare command を使ってよい。その場合は、commentary または approval justification に「なぜ bare command にしたか」を具体的に残す。
+- bare command fallback は必要最小限の 1 command に留め、以後の command は RTK 経由へ戻す。
+
 ## Worktree Policy
 
 AI agent が Issue 対応で worktree を使う場合、作業用 checkout は repo root 配下の `.worktree/<task-name>` に作成する。

--- a/docs/frontend-features.md
+++ b/docs/frontend-features.md
@@ -292,5 +292,6 @@ Test examples:
 - Do not use `innerHTML` or `dangerouslySetInnerHTML` for Article body in MVP.
 - Do not store JWT, session identifiers, or refresh tokens in `localStorage`, `sessionStorage`, or React state.
 - Browser authentication uses BFF-managed `HttpOnly` session cookies; `lib/` sends same-origin credentialed requests and CSRF proof without reading the auth cookie.
-- `VITE_API_BASE_URL` targets the frontend/BFF origin or uses relative `/api`; it does not target the Public API origin for authenticated browser operations.
+- The default API client uses relative `/api/*` so the browser reaches the same-origin BFF through the frontend dev proxy.
+- `VITE_API_BASE_URL` must not target the Public API origin such as `http://localhost:8080`; if a local `.env.local` still has that value, remove it and use `BFF_PROXY_TARGET` to configure the Vite proxy target instead.
 - Backend authorization remains required even when frontend hides buttons.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,3 @@
-VITE_API_BASE_URL=http://localhost:8080
+# Frontend は same-origin の /api/* を呼び、Vite dev server が BFF へ proxy します。
+# VITE_API_BASE_URL に http://localhost:8080 など Public API/backend-nginx を指定しないでください。
 BFF_PROXY_TARGET=http://localhost:3006

--- a/frontend/src/lib/__tests__/apiClient.test.ts
+++ b/frontend/src/lib/__tests__/apiClient.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createApiClient } from '../apiClient';
+import { createApiClient, resolveDefaultApiBaseUrl } from '../apiClient';
 import { isApiError } from '../apiError';
 
 /**
@@ -66,6 +66,38 @@ describe('共通API client', () => {
     expect(requestOptions.credentials).toBe('same-origin');
     expect(headers.get('Authorization')).toBeNull();
     expect(window.localStorage.getItem('realworld.authToken')).toBeNull();
+  });
+
+  it('base URL未設定時はrelativeなBFF pathへrequestする', async () => {
+    const fetchMock = createFetchMock(jsonResponse({ tags: ['react'] }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createApiClient();
+
+    await client.get('/api/tags');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/tags',
+      expect.objectContaining({
+        credentials: 'same-origin',
+        method: 'GET',
+      }),
+    );
+  });
+
+  it('VITE_API_BASE_URLが現在originと異なる場合はdefault base URLに採用しない', () => {
+    expect(
+      resolveDefaultApiBaseUrl('http://localhost:8080', 'http://localhost:3005'),
+    ).toBe('');
+    expect(
+      resolveDefaultApiBaseUrl('http://backend-nginx', 'http://localhost:3005'),
+    ).toBe('');
+  });
+
+  it('VITE_API_BASE_URLが現在originと一致する場合だけdefault base URLに採用する', () => {
+    expect(
+      resolveDefaultApiBaseUrl('http://localhost:3005', 'http://localhost:3005'),
+    ).toBe('http://localhost:3005');
   });
 
   it('mutating request前にCSRF proofを取得してX-CSRF-TOKEN headerを付与する', async () => {

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -8,7 +8,9 @@ import {
   type ApiRequestOptionsWithMethod,
 } from './apiRequest';
 
-const DEFAULT_API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
+const DEFAULT_API_BASE_URL = resolveDefaultApiBaseUrl(
+  import.meta.env.VITE_API_BASE_URL,
+);
 const CSRF_PATH = '/api/session/csrf';
 const MUTATING_METHODS = new Set(['DELETE', 'PATCH', 'POST', 'PUT']);
 
@@ -175,6 +177,53 @@ export function createApiClient(config: ApiClientConfig = {}): ApiClient {
 
 export const apiClient = createApiClient();
 
+/**
+ * Browserの既定API接続先はsame-origin BFFだけに限定し、Public API直指定を採用しない。
+ */
+export function resolveDefaultApiBaseUrl(
+  configuredBaseUrl: string | undefined,
+  currentOrigin: string | undefined = getCurrentOrigin(),
+): string {
+  const baseUrl = configuredBaseUrl?.trim();
+
+  if (baseUrl === undefined || baseUrl === '') {
+    return '';
+  }
+
+  const configuredUrl = parseAbsoluteUrl(baseUrl);
+
+  if (configuredUrl === null || currentOrigin === undefined) {
+    return '';
+  }
+
+  const currentUrl = parseAbsoluteUrl(currentOrigin);
+
+  if (currentUrl === null) {
+    return '';
+  }
+
+  return configuredUrl.origin === currentUrl.origin ? configuredUrl.origin : '';
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function getCurrentOrigin(): string | undefined {
+  if (
+    typeof globalThis.location === 'object' &&
+    typeof globalThis.location.origin === 'string'
+  ) {
+    return globalThis.location.origin;
+  }
+
+  return undefined;
+}
+
+function parseAbsoluteUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
# 概要

- API client の既定接続先を same-origin BFF に限定し、`VITE_API_BASE_URL=http://localhost:8080` があっても backend-nginx 直送にならないように修正
- `frontend/.env.example` から backend 直指定を削除し、BFF proxy target のみ案内
- README / frontend docs に既存 `.env.local` の注意と same-origin `/api/*` proxy 前提を追記
- AI harness / AGENTS に RTK 経由の shell command policy と Codex sandbox / GitHub CLI 運用メモを追記

# 関連Issue

Closes #147

Epic: #123

# 修正ファイルの説明

## Frontend lib

- `frontend/src/lib/apiClient.ts`
  - 既定の API base URL を現在 origin と一致する場合だけ採用する判定を追加
  - Public API/backend-nginx の直指定を既定値に採用しないため
- `frontend/src/lib/__tests__/apiClient.test.ts`
  - 未設定時の relative `/api/*` request と、異なる origin の `VITE_API_BASE_URL` を採用しない仕様を追加
  - signup/session 系 request が BFF proxy を通る契約を固定するため

## Config / Docs

- `frontend/.env.example`
  - `VITE_API_BASE_URL=http://localhost:8080` を削除
  - `BFF_PROXY_TARGET` で Vite proxy target を設定する前提に合わせるため
- `README.md`
  - frontend local setup に same-origin BFF proxy と `.env.local` の注意を追記
- `docs/frontend-features.md`
  - API client の既定接続先と Public API 直指定禁止の説明を更新

## AI Harness

- `AGENTS.md`
  - shell command を原則 `rtk` / `rtk proxy` 経由で実行する入口ルールを追記
  - Codex sandbox と GitHub CLI の認証・sandbox 外実行に関する運用メモを追記
- `docs/ai/harness.md`
  - RTK の正本ルールとして、通常実行・raw output・approval 付き実行・bare command fallback の判断基準を追加

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| フロントエンド変更あり | API client 個別テスト | `pnpm vitest run --reporter=verbose src/lib/__tests__/apiClient.test.ts` | すべて成功する | 成功 |
| フロントエンド変更あり | フロントエンド全テスト | `pnpm vitest run` | すべて成功する | 成功 |
| フロントエンド変更あり | 型チェック | `pnpm tsc -b --noEmit` | 成功する | 成功 |
| フロントエンド変更あり | ESLint | `pnpm eslint .` | 成功する | 成功 |
| Docker 起動済み環境 | frontend proxy 経由の CSRF bootstrap | `curl -i -sS http://localhost:3005/api/session/csrf` | `200 OK` で `csrfToken` を返す | 成功 |
| ドキュメント変更あり | 空白エラー確認 | `git diff --cached --check` | 空白エラーがない | 成功 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: `frontend/.env.example` から `VITE_API_BASE_URL=http://localhost:8080` を削除。既存のローカル `frontend/.env.local` に同設定がある場合は削除が必要
- レビュー時に重点確認してほしい点: `createApiClient({ baseUrl })` の明示指定は維持しつつ、既定値だけを same-origin BFF に限定している点
- AI harness 変更: sandbox 外実行でも原則 `rtk proxy ...` を使い、bare command fallback は理由を残す運用にしています
