### PR TITLE
[#79]: Backend API contract coverageを補強

### DIFF
--- a/backend/app/Application/Publishing/Commands/FavoriteArticleCommand.php
+++ b/backend/app/Application/Publishing/Commands/FavoriteArticleCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\Commands;
+
+use App\Domain\Publishing\Exceptions\ArticleNotFoundException;
+use App\Infrastructure\Persistence\Models\Article as ArticleModel;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+final readonly class FavoriteArticleCommand
+{
+    /**
+     * 現在 User が Article を favorite する。
+     */
+    public function execute(int $userId, string $slug): void
+    {
+        $articleId = $this->articleIdForSlug($slug);
+
+        DB::transaction(function () use ($userId, $articleId): void {
+            $now = Carbon::now();
+
+            DB::table('favorites')->insertOrIgnore([
+                'user_id' => $userId,
+                'article_id' => $articleId,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        });
+    }
+
+    /**
+     * slug に一致する Article ID を取得する。
+     */
+    private function articleIdForSlug(string $slug): int
+    {
+        $articleId = ArticleModel::query()
+            ->where('slug', $slug)
+            ->value('id');
+
+        if (! is_numeric($articleId)) {
+            throw ArticleNotFoundException::forSlug($slug);
+        }
+
+        return (int) $articleId;
+    }
+}

--- a/backend/app/Application/Publishing/Commands/UnfavoriteArticleCommand.php
+++ b/backend/app/Application/Publishing/Commands/UnfavoriteArticleCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\Commands;
+
+use App\Domain\Publishing\Exceptions\ArticleNotFoundException;
+use App\Infrastructure\Persistence\Models\Article as ArticleModel;
+use Illuminate\Support\Facades\DB;
+
+final readonly class UnfavoriteArticleCommand
+{
+    /**
+     * 現在 User が Article の favorite を解除する。
+     */
+    public function execute(int $userId, string $slug): void
+    {
+        $articleId = $this->articleIdForSlug($slug);
+
+        DB::transaction(function () use ($userId, $articleId): void {
+            DB::table('favorites')
+                ->where('user_id', $userId)
+                ->where('article_id', $articleId)
+                ->delete();
+        });
+    }
+
+    /**
+     * slug に一致する Article ID を取得する。
+     */
+    private function articleIdForSlug(string $slug): int
+    {
+        $articleId = ArticleModel::query()
+            ->where('slug', $slug)
+            ->value('id');
+
+        if (! is_numeric($articleId)) {
+            throw ArticleNotFoundException::forSlug($slug);
+        }
+
+        return (int) $articleId;
+    }
+}

--- a/backend/app/Application/Social/Commands/FollowUserCommand.php
+++ b/backend/app/Application/Social/Commands/FollowUserCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Social\Commands;
+
+use App\Domain\Identity\Exceptions\UserNotFoundException;
+use App\Infrastructure\Persistence\Models\User as UserModel;
+use DomainException;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+final readonly class FollowUserCommand
+{
+    /**
+     * 現在 User が対象 User を follow する。
+     */
+    public function execute(int $followerUserId, string $username): void
+    {
+        $target = $this->findTargetUser($username);
+        $targetUserId = (int) $target->getKey();
+
+        if ($followerUserId === $targetUserId) {
+            throw new DomainException('cannot follow yourself');
+        }
+
+        DB::transaction(function () use ($followerUserId, $targetUserId): void {
+            $now = Carbon::now();
+
+            DB::table('follows')->insertOrIgnore([
+                'follower_user_id' => $followerUserId,
+                'followee_user_id' => $targetUserId,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        });
+    }
+
+    /**
+     * follow 対象 User を取得する。
+     */
+    private function findTargetUser(string $username): UserModel
+    {
+        $target = UserModel::query()
+            ->where('username', $username)
+            ->first();
+
+        if (! $target instanceof UserModel) {
+            throw UserNotFoundException::forUsername($username);
+        }
+
+        return $target;
+    }
+}

--- a/backend/app/Application/Social/Commands/UnfollowUserCommand.php
+++ b/backend/app/Application/Social/Commands/UnfollowUserCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Social\Commands;
+
+use App\Domain\Identity\Exceptions\UserNotFoundException;
+use App\Infrastructure\Persistence\Models\User as UserModel;
+use DomainException;
+use Illuminate\Support\Facades\DB;
+
+final readonly class UnfollowUserCommand
+{
+    /**
+     * 現在 User が対象 User の follow を解除する。
+     */
+    public function execute(int $followerUserId, string $username): void
+    {
+        $target = $this->findTargetUser($username);
+        $targetUserId = (int) $target->getKey();
+
+        if ($followerUserId === $targetUserId) {
+            throw new DomainException('cannot follow yourself');
+        }
+
+        DB::transaction(function () use ($followerUserId, $targetUserId): void {
+            DB::table('follows')
+                ->where('follower_user_id', $followerUserId)
+                ->where('followee_user_id', $targetUserId)
+                ->delete();
+        });
+    }
+
+    /**
+     * unfollow 対象 User を取得する。
+     */
+    private function findTargetUser(string $username): UserModel
+    {
+        $target = UserModel::query()
+            ->where('username', $username)
+            ->first();
+
+        if (! $target instanceof UserModel) {
+            throw UserNotFoundException::forUsername($username);
+        }
+
+        return $target;
+    }
+}

--- a/backend/app/Application/Social/DTOs/ProfileDto.php
+++ b/backend/app/Application/Social/DTOs/ProfileDto.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Social\DTOs;
+
+final readonly class ProfileDto
+{
+    public function __construct(
+        public string $username,
+        public ?string $bio,
+        public ?string $image,
+        public bool $following,
+    ) {}
+}

--- a/backend/app/Application/Social/Queries/GetProfileQuery.php
+++ b/backend/app/Application/Social/Queries/GetProfileQuery.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Social\Queries;
+
+use App\Application\Social\DTOs\ProfileDto;
+use App\Domain\Identity\Exceptions\UserNotFoundException;
+use App\Infrastructure\Persistence\Models\User as UserModel;
+use Illuminate\Support\Facades\DB;
+
+final readonly class GetProfileQuery
+{
+    /**
+     * username に一致する Profile を現在 User 視点で取得する。
+     */
+    public function execute(string $username, ?int $currentUserId): ProfileDto
+    {
+        $user = UserModel::query()
+            ->where('username', $username)
+            ->first();
+
+        if (! $user instanceof UserModel) {
+            throw UserNotFoundException::forUsername($username);
+        }
+
+        return new ProfileDto(
+            username: $user->username,
+            bio: $user->bio,
+            image: $user->image,
+            following: $this->isFollowing($currentUserId, (int) $user->getKey()),
+        );
+    }
+
+    /**
+     * 現在 User が対象 User を follow 済みか確認する。
+     */
+    private function isFollowing(?int $currentUserId, int $targetUserId): bool
+    {
+        if ($currentUserId === null) {
+            return false;
+        }
+
+        return DB::table('follows')
+            ->where('follower_user_id', $currentUserId)
+            ->where('followee_user_id', $targetUserId)
+            ->exists();
+    }
+}

--- a/backend/app/Domain/Identity/Exceptions/UserNotFoundException.php
+++ b/backend/app/Domain/Identity/Exceptions/UserNotFoundException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Identity\Exceptions;
+
+use DomainException;
+
+final class UserNotFoundException extends DomainException
+{
+    /**
+     * username に一致する User が存在しないことを表す。
+     */
+    public static function forUsername(string $username): self
+    {
+        return new self("user not found: {$username}");
+    }
+}

--- a/backend/app/Presentation/Http/Controllers/Publishing/ArticleController.php
+++ b/backend/app/Presentation/Http/Controllers/Publishing/ArticleController.php
@@ -6,6 +6,8 @@ namespace App\Presentation\Http\Controllers\Publishing;
 
 use App\Application\Publishing\Commands\CreateArticleCommand;
 use App\Application\Publishing\Commands\DeleteArticleCommand;
+use App\Application\Publishing\Commands\FavoriteArticleCommand;
+use App\Application\Publishing\Commands\UnfavoriteArticleCommand;
 use App\Application\Publishing\Commands\UpdateArticleCommand;
 use App\Application\Publishing\Queries\GetArticleForAuthorizationQuery;
 use App\Application\Publishing\Queries\GetArticleQuery;
@@ -110,6 +112,46 @@ final class ArticleController extends Controller
         $command->execute($article);
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * 認証済み User が Article を favorite する。
+     */
+    public function favorite(
+        Request $request,
+        string $slug,
+        FavoriteArticleCommand $command,
+        GetArticleQuery $query,
+    ): JsonResponse {
+        $currentUserId = $this->authenticatedUserId($request);
+        $command->execute($currentUserId, $slug);
+
+        return (new SingleArticleResource($query->execute(
+            slug: $slug,
+            currentUserId: $currentUserId,
+        )))
+            ->response()
+            ->setStatusCode(Response::HTTP_OK);
+    }
+
+    /**
+     * 認証済み User が Article の favorite を解除する。
+     */
+    public function unfavorite(
+        Request $request,
+        string $slug,
+        UnfavoriteArticleCommand $command,
+        GetArticleQuery $query,
+    ): JsonResponse {
+        $currentUserId = $this->authenticatedUserId($request);
+        $command->execute($currentUserId, $slug);
+
+        return (new SingleArticleResource($query->execute(
+            slug: $slug,
+            currentUserId: $currentUserId,
+        )))
+            ->response()
+            ->setStatusCode(Response::HTTP_OK);
     }
 
     /**

--- a/backend/app/Presentation/Http/Controllers/Social/ProfileController.php
+++ b/backend/app/Presentation/Http/Controllers/Social/ProfileController.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Controllers\Social;
+
+use App\Application\Social\Commands\FollowUserCommand;
+use App\Application\Social\Commands\UnfollowUserCommand;
+use App\Application\Social\Queries\GetProfileQuery;
+use App\Presentation\Http\Controllers\Controller;
+use App\Presentation\Http\Resources\Social\ProfileResource;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ProfileController extends Controller
+{
+    /**
+     * 公開 Profile を RealWorld profile wrapper で返す。
+     */
+    public function show(Request $request, string $username, GetProfileQuery $query): JsonResponse
+    {
+        return (new ProfileResource($query->execute(
+            username: $username,
+            currentUserId: $this->optionalAuthenticatedUserId($request),
+        )))
+            ->response()
+            ->setStatusCode(Response::HTTP_OK);
+    }
+
+    /**
+     * 認証済み User が target User を follow する。
+     */
+    public function follow(
+        Request $request,
+        string $username,
+        FollowUserCommand $command,
+        GetProfileQuery $query,
+    ): JsonResponse {
+        $currentUserId = $this->authenticatedUserId($request);
+        $command->execute($currentUserId, $username);
+
+        return (new ProfileResource($query->execute($username, $currentUserId)))
+            ->response()
+            ->setStatusCode(Response::HTTP_OK);
+    }
+
+    /**
+     * 認証済み User が target User の follow を解除する。
+     */
+    public function unfollow(
+        Request $request,
+        string $username,
+        UnfollowUserCommand $command,
+        GetProfileQuery $query,
+    ): JsonResponse {
+        $currentUserId = $this->authenticatedUserId($request);
+        $command->execute($currentUserId, $username);
+
+        return (new ProfileResource($query->execute($username, $currentUserId)))
+            ->response()
+            ->setStatusCode(Response::HTTP_OK);
+    }
+
+    /**
+     * 認証必須 endpoint の認証済み User ID を取得する。
+     */
+    private function authenticatedUserId(Request $request): int
+    {
+        $userId = $request->user()?->getAuthIdentifier();
+
+        if (! is_numeric($userId)) {
+            throw new AuthenticationException;
+        }
+
+        return (int) $userId;
+    }
+
+    /**
+     * Optional auth endpoint で JWT があれば認証済み User ID を取得する。
+     */
+    private function optionalAuthenticatedUserId(Request $request): ?int
+    {
+        if ($request->headers->get('Authorization') === null) {
+            return null;
+        }
+
+        $user = Auth::guard('api')->user();
+        $userId = $user?->getAuthIdentifier();
+
+        if (! is_numeric($userId)) {
+            throw new AuthenticationException;
+        }
+
+        return (int) $userId;
+    }
+}

--- a/backend/app/Presentation/Http/Resources/Social/ProfileResource.php
+++ b/backend/app/Presentation/Http/Resources/Social/ProfileResource.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Resources\Social;
+
+use App\Application\Social\DTOs\ProfileDto;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin ProfileDto
+ */
+final class ProfileResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * RealWorld profile wrapper へ変換する。
+     *
+     * @return array{profile: array{username: string, bio: string|null, image: string|null, following: bool}}
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var ProfileDto $profile */
+        $profile = $this->resource;
+
+        return [
+            'profile' => [
+                'username' => $profile->username,
+                'bio' => $profile->bio,
+                'image' => $profile->image,
+                'following' => $profile->following,
+            ],
+        ];
+    }
+}

--- a/backend/app/Presentation/Http/Responses/RealWorldErrorResponse.php
+++ b/backend/app/Presentation/Http/Responses/RealWorldErrorResponse.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Presentation\Http\Responses;
 
+use App\Domain\Identity\Exceptions\UserNotFoundException;
 use App\Domain\Publishing\Exceptions\ArticleNotFoundException;
 use DomainException;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -56,7 +57,7 @@ final class RealWorldErrorResponse
             return [Response::HTTP_UNPROCESSABLE_ENTITY, self::validationMessages($exception)];
         }
 
-        if ($exception instanceof ArticleNotFoundException) {
+        if ($exception instanceof ArticleNotFoundException || $exception instanceof UserNotFoundException) {
             return [Response::HTTP_NOT_FOUND, ['Resource not found.']];
         }
 

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,12 +3,14 @@
 use App\Presentation\Http\Controllers\Identity\AuthController;
 use App\Presentation\Http\Controllers\Identity\CurrentUserController;
 use App\Presentation\Http\Controllers\Publishing\ArticleController;
+use App\Presentation\Http\Controllers\Social\ProfileController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/users', [AuthController::class, 'register']);
 Route::post('/users/login', [AuthController::class, 'login']);
 Route::get('/articles', [ArticleController::class, 'index'])->name('articles.index');
 Route::get('/articles/{slug}', [ArticleController::class, 'show'])->name('articles.show');
+Route::get('/profiles/{username}', [ProfileController::class, 'show'])->name('profiles.show');
 
 Route::middleware('auth:api')->group(function (): void {
     Route::get('/user', [CurrentUserController::class, 'show']);
@@ -16,4 +18,8 @@ Route::middleware('auth:api')->group(function (): void {
     Route::post('/articles', [ArticleController::class, 'store'])->name('articles.store');
     Route::put('/articles/{slug}', [ArticleController::class, 'update'])->name('articles.update');
     Route::delete('/articles/{slug}', [ArticleController::class, 'destroy'])->name('articles.destroy');
+    Route::post('/articles/{slug}/favorite', [ArticleController::class, 'favorite'])->name('articles.favorite');
+    Route::delete('/articles/{slug}/favorite', [ArticleController::class, 'unfavorite'])->name('articles.unfavorite');
+    Route::post('/profiles/{username}/follow', [ProfileController::class, 'follow'])->name('profiles.follow');
+    Route::delete('/profiles/{username}/follow', [ProfileController::class, 'unfollow'])->name('profiles.unfollow');
 });

--- a/backend/tests/Feature/Publishing/ArticleCrudApiTest.php
+++ b/backend/tests/Feature/Publishing/ArticleCrudApiTest.php
@@ -97,6 +97,16 @@ describe('Article CRUD API', function (): void {
             ->assertJsonStructure(['errors' => ['body']]);
     });
 
+    it('Article一覧のquery validation failureを422のerrors.bodyで返す', function (): void {
+        $response = $this->getJson('/api/articles?limit=0&offset=-1');
+
+        $response
+            ->assertUnprocessable()
+            ->assertJsonStructure(['errors' => ['body']]);
+
+        expect($response->json('errors.body'))->toBeArray()->toHaveCount(2);
+    });
+
     it('Article一覧をfilterとpaginationつきで返しbodyを含めない', function (): void {
         $jake = User::factory()->create(['username' => 'jake']);
         $jane = User::factory()->create(['username' => 'jane']);
@@ -167,12 +177,33 @@ describe('Article CRUD API', function (): void {
             ->assertJsonPath('article.author.following', false);
     });
 
+    it('Article一覧のoptional auth endpointでも無効JWTは401を返す', function (): void {
+        $author = User::factory()->create();
+        articleApiCreateArticle($author, ['slug' => 'how-to-train-your-dragon']);
+
+        $this->withRealWorldToken('not-a-jwt')
+            ->getJson('/api/articles')
+            ->assertUnauthorized()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+
     it('optional auth endpointでも無効JWTは401を返す', function (): void {
         $author = User::factory()->create();
         articleApiCreateArticle($author, ['slug' => 'how-to-train-your-dragon']);
 
         $this->withRealWorldToken('not-a-jwt')
             ->getJson('/api/articles/how-to-train-your-dragon')
+            ->assertUnauthorized()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+
+    it('未認証のArticle更新を401で拒否する', function (): void {
+        $author = User::factory()->create();
+        articleApiCreateArticle($author, ['slug' => 'how-to-train-your-dragon']);
+
+        $this->putJson('/api/articles/how-to-train-your-dragon', [
+            'article' => ['title' => 'Hacked'],
+        ])
             ->assertUnauthorized()
             ->assertJsonStructure(['errors' => ['body']]);
     });
@@ -221,6 +252,15 @@ describe('Article CRUD API', function (): void {
                 'article' => ['title' => 'Missing'],
             ])
             ->assertNotFound()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+
+    it('未認証のArticle削除を401で拒否する', function (): void {
+        $author = User::factory()->create();
+        articleApiCreateArticle($author, ['slug' => 'how-to-train-your-dragon']);
+
+        $this->deleteJson('/api/articles/how-to-train-your-dragon')
+            ->assertUnauthorized()
             ->assertJsonStructure(['errors' => ['body']]);
     });
 

--- a/backend/tests/Feature/Publishing/ArticleFavoriteApiTest.php
+++ b/backend/tests/Feature/Publishing/ArticleFavoriteApiTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Infrastructure\Persistence\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+describe('Article Favorite API', function (): void {
+    it('未認証favoriteを401で拒否する', function (): void {
+        $author = User::factory()->create();
+        favoriteApiCreateArticle($author, ['slug' => 'how-to-train-your-dragon']);
+
+        $this->postJson('/api/articles/how-to-train-your-dragon/favorite')
+            ->assertUnauthorized()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+
+    it('Articleをidempotentにfavoriteしてarticle wrapperを返す', function (): void {
+        $author = User::factory()->create(['username' => 'jake']);
+        $viewer = User::factory()->create(['username' => 'bob']);
+        favoriteApiCreateArticle($author, ['slug' => 'how-to-train-your-dragon']);
+
+        $token = $this->issueRealWorldTokenFor($viewer);
+
+        $this->withRealWorldToken($token)
+            ->postJson('/api/articles/how-to-train-your-dragon/favorite')
+            ->assertOk()
+            ->assertJsonPath('article.slug', 'how-to-train-your-dragon')
+            ->assertJsonPath('article.favorited', true)
+            ->assertJsonPath('article.favoritesCount', 1);
+
+        $this->withRealWorldToken($token)
+            ->postJson('/api/articles/how-to-train-your-dragon/favorite')
+            ->assertOk()
+            ->assertJsonPath('article.favorited', true)
+            ->assertJsonPath('article.favoritesCount', 1);
+
+        expect(DB::table('favorites')->count())->toBe(1);
+    });
+
+    it('Articleをidempotentにunfavoriteしてarticle wrapperを返す', function (): void {
+        $author = User::factory()->create(['username' => 'jake']);
+        $viewer = User::factory()->create(['username' => 'bob']);
+        $articleId = favoriteApiCreateArticle($author, ['slug' => 'how-to-train-your-dragon']);
+        favoriteApiFavorite($viewer, $articleId);
+
+        $token = $this->issueRealWorldTokenFor($viewer);
+
+        $this->withRealWorldToken($token)
+            ->deleteJson('/api/articles/how-to-train-your-dragon/favorite')
+            ->assertOk()
+            ->assertJsonPath('article.slug', 'how-to-train-your-dragon')
+            ->assertJsonPath('article.favorited', false)
+            ->assertJsonPath('article.favoritesCount', 0);
+
+        $this->withRealWorldToken($token)
+            ->deleteJson('/api/articles/how-to-train-your-dragon/favorite')
+            ->assertOk()
+            ->assertJsonPath('article.favorited', false)
+            ->assertJsonPath('article.favoritesCount', 0);
+
+        expect(DB::table('favorites')->count())->toBe(0);
+    });
+
+    it('存在しないArticleのfavoriteは404のerrors.bodyを返す', function (): void {
+        $viewer = User::factory()->create();
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($viewer))
+            ->postJson('/api/articles/missing-article/favorite')
+            ->assertNotFound()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+});
+
+/**
+ * @param  array<string, mixed>  $attributes
+ */
+function favoriteApiCreateArticle(User $author, array $attributes = []): int
+{
+    $createdAt = $attributes['created_at'] ?? Carbon::parse('2026-05-01 00:00:00');
+    $updatedAt = $attributes['updated_at'] ?? $createdAt;
+
+    return (int) DB::table('articles')->insertGetId([
+        'author_user_id' => $author->getKey(),
+        'slug' => $attributes['slug'] ?? 'how-to-train-your-dragon',
+        'title' => $attributes['title'] ?? 'How to train your dragon',
+        'description' => $attributes['description'] ?? 'Ever wonder how?',
+        'body' => $attributes['body'] ?? 'You have to believe',
+        'created_at' => $createdAt,
+        'updated_at' => $updatedAt,
+    ]);
+}
+
+function favoriteApiFavorite(User $user, int $articleId): void
+{
+    DB::table('favorites')->insert([
+        'user_id' => $user->getKey(),
+        'article_id' => $articleId,
+        'created_at' => Carbon::parse('2026-05-04 00:00:00'),
+        'updated_at' => Carbon::parse('2026-05-04 00:00:00'),
+    ]);
+}

--- a/backend/tests/Feature/Social/ProfileFollowApiTest.php
+++ b/backend/tests/Feature/Social/ProfileFollowApiTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Infrastructure\Persistence\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+describe('Profile and Follow API', function (): void {
+    it('公開profileをRealWorld profile wrapperで返す', function (): void {
+        User::factory()->create([
+            'username' => 'jake',
+            'bio' => 'I like APIs',
+            'image' => 'https://example.com/avatar.png',
+        ]);
+
+        $this->getJson('/api/profiles/jake')
+            ->assertOk()
+            ->assertExactJson([
+                'profile' => [
+                    'username' => 'jake',
+                    'bio' => 'I like APIs',
+                    'image' => 'https://example.com/avatar.png',
+                    'following' => false,
+                ],
+            ]);
+    });
+
+    it('認証済みUser視点でprofile followingを算出する', function (): void {
+        $viewer = User::factory()->create(['username' => 'viewer']);
+        $target = User::factory()->create(['username' => 'jake']);
+        profileApiFollow($viewer, $target);
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($viewer))
+            ->getJson('/api/profiles/jake')
+            ->assertOk()
+            ->assertJsonPath('profile.following', true);
+    });
+
+    it('存在しないprofileは404のerrors.bodyを返す', function (): void {
+        $this->getJson('/api/profiles/missing')
+            ->assertNotFound()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+
+    it('未認証followを401で拒否する', function (): void {
+        User::factory()->create(['username' => 'jake']);
+
+        $this->postJson('/api/profiles/jake/follow')
+            ->assertUnauthorized()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+
+    it('target Userをfollowしてprofile wrapperを返す', function (): void {
+        $viewer = User::factory()->create(['username' => 'viewer']);
+        User::factory()->create([
+            'username' => 'jake',
+            'bio' => null,
+            'image' => null,
+        ]);
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($viewer))
+            ->postJson('/api/profiles/jake/follow')
+            ->assertOk()
+            ->assertExactJson([
+                'profile' => [
+                    'username' => 'jake',
+                    'bio' => null,
+                    'image' => null,
+                    'following' => true,
+                ],
+            ]);
+
+        expect(DB::table('follows')->count())->toBe(1);
+    });
+
+    it('self-followを422で拒否する', function (): void {
+        $viewer = User::factory()->create(['username' => 'jake']);
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($viewer))
+            ->postJson('/api/profiles/jake/follow')
+            ->assertUnprocessable()
+            ->assertExactJson([
+                'errors' => [
+                    'body' => ['cannot follow yourself'],
+                ],
+            ]);
+
+        expect(DB::table('follows')->count())->toBe(0);
+    });
+
+    it('unfollowは未follow状態でもidempotentにprofile wrapperを返す', function (): void {
+        $viewer = User::factory()->create(['username' => 'viewer']);
+        User::factory()->create(['username' => 'jake']);
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($viewer))
+            ->deleteJson('/api/profiles/jake/follow')
+            ->assertOk()
+            ->assertJsonPath('profile.following', false);
+
+        expect(DB::table('follows')->count())->toBe(0);
+    });
+});
+
+function profileApiFollow(User $follower, User $followee): void
+{
+    DB::table('follows')->insert([
+        'follower_user_id' => $follower->getKey(),
+        'followee_user_id' => $followee->getKey(),
+        'created_at' => Carbon::parse('2026-05-04 00:00:00'),
+        'updated_at' => Carbon::parse('2026-05-04 00:00:00'),
+    ]);
+}

--- a/docs/api-contract-coverage.md
+++ b/docs/api-contract-coverage.md
@@ -1,0 +1,45 @@
+# Backend API Contract Coverage
+
+> Issue: #79
+> 作成日: 2026-06-04
+> 対象: Public RealWorld API
+
+この文書は `docs/api-requirements.md` の MVP endpoint list に対する backend Feature test coverage の確認表である。
+API 仕様そのものは `docs/api-requirements.md` を正本とし、この文書は response wrapper、status code、認証・認可、validation のテスト状況を追跡する。
+
+## Coverage Status
+
+| Endpoint | Auth | Response wrapper | Status / negative coverage | Test file | Status |
+| --- | --- | --- | --- | --- | --- |
+| `POST /api/users` | None | `user` | `201`, duplicate `422`, validation `422` | `backend/tests/Feature/Identity/RegisterUserApiTest.php` | Covered |
+| `POST /api/users/login` | None | `user` | `200`, invalid credentials `422`, validation `422` | `backend/tests/Feature/Identity/LoginUserApiTest.php` | Covered |
+| `GET /api/user` | Required | `user` | `200`, missing / malformed / invalid / expired token `401` | `backend/tests/Feature/Identity/CurrentUserApiTest.php` | Covered |
+| `PUT /api/user` | Required | `user` | `200`, missing token `401`, duplicate / invalid input `422` | `backend/tests/Feature/Identity/CurrentUserApiTest.php` | Covered |
+| `GET /api/profiles/{username}` | Optional | `profile` | `200`, following state, missing profile `404` | `backend/tests/Feature/Social/ProfileFollowApiTest.php` | Covered |
+| `POST /api/profiles/{username}/follow` | Required | `profile` | missing token `401`, self-follow `422`, idempotent insert | `backend/tests/Feature/Social/ProfileFollowApiTest.php` | Covered |
+| `DELETE /api/profiles/{username}/follow` | Required | `profile` | missing favorite equivalent is idempotent for unfollow state | `backend/tests/Feature/Social/ProfileFollowApiTest.php` | Covered |
+| `GET /api/articles` | Optional | `articles`, `articlesCount` | filter / pagination, invalid query `422`, invalid optional token `401`, no `body` in list item | `backend/tests/Feature/Publishing/ArticleCrudApiTest.php` | Covered |
+| `POST /api/articles` | Required | `article` | `201`, missing token `401`, validation `422` | `backend/tests/Feature/Publishing/ArticleCrudApiTest.php` | Covered |
+| `GET /api/articles/{slug}` | Optional | `article` | `200`, favorited / following state, missing article `404`, invalid optional token `401` | `backend/tests/Feature/Publishing/ArticleCrudApiTest.php` | Covered |
+| `PUT /api/articles/{slug}` | Required | `article` | missing token `401`, non-author `403`, missing article `404`, update wrapper | `backend/tests/Feature/Publishing/ArticleCrudApiTest.php` | Covered |
+| `DELETE /api/articles/{slug}` | Required | empty | missing token `401`, non-author `403`, missing article `404`, success `204` | `backend/tests/Feature/Publishing/ArticleCrudApiTest.php` | Covered |
+| `POST /api/articles/{slug}/favorite` | Required | `article` | missing token `401`, missing article `404`, duplicate favorite idempotency | `backend/tests/Feature/Publishing/ArticleFavoriteApiTest.php` | Covered |
+| `DELETE /api/articles/{slug}/favorite` | Required | `article` | missing favorite idempotency | `backend/tests/Feature/Publishing/ArticleFavoriteApiTest.php` | Covered |
+| `GET /api/articles/{slug}/comments` | Optional | `comments` | Not implemented yet | none | Gap |
+| `POST /api/articles/{slug}/comments` | Required | `comment` | Not implemented yet | none | Gap |
+| `DELETE /api/articles/{slug}/comments/{id}` | Required | empty | Comment author ownership is not covered yet | none | Gap |
+| `GET /api/articles/feed` | Required | `articles`, `articlesCount` | Not implemented yet | none | Gap |
+| `GET /api/tags` | None | `tags` | Not implemented yet | none | Gap |
+
+## Remaining Gaps
+
+- Comment API の `comments` / `comment` wrapper、comment author ownership、missing article / comment の `404` は未実装 endpoint のため未対応。
+- Feed API の required auth `401`、followee article list、pagination contract は未実装 endpoint のため未対応。
+- Tag API の distinct tag list wrapper は未実装 endpoint のため未対応。
+- Follow の duplicate follow は `insertOrIgnore` による idempotent insert として扱うが、重複 follow 専用の独立テストは未追加。
+
+## Review Notes
+
+- Error wrapper 共通仕様は `backend/tests/Feature/RealWorldApiErrorResponseTest.php` で `errors.body`、`401` / `403` / `404` / `422` / `500` を横断確認している。
+- Public API JWT は `Authorization: Token <token>` を維持し、invalid optional token は guest に降格せず `401` にする。
+- `.env`、JWT signing secret、実 token 値はこの checklist に記載しない。


### PR DESCRIPTION
# 概要

- Profile / Follow API と Article Favorite API を追加し、RealWorld wrapper と認証・認可・idempotency contract を補強
- Article CRUD / list の Feature test に query validation、optional auth、未認証 update/delete の代表ケースを追加
- MVP endpoint ごとの backend API contract coverage checklist を追加し、未実装 endpoint の残課題を明記

# 関連Issue

Closes #79

Epic: #57

# 修正ファイルの説明

## Backend API

- `backend/routes/api.php`
  - Profile / Follow / Favorite endpoint を Public API route として追加
  - `docs/api-requirements.md` の MVP endpoint contract に沿うため
- `backend/app/Presentation/Http/Controllers/Social/ProfileController.php`
  - Profile 取得、follow、unfollow の HTTP 境界を追加
  - Controller を薄くし、処理を Application query / command へ委譲するため
- `backend/app/Presentation/Http/Controllers/Publishing/ArticleController.php`
  - favorite / unfavorite action を追加
  - 既存 Article wrapper で favorite 結果を返すため
- `backend/app/Application/Social/*`
  - Profile DTO、Profile query、Follow / Unfollow command を追加
  - self-follow rejection と following state 算出を API contract として扱うため
- `backend/app/Application/Publishing/Commands/*FavoriteArticleCommand.php`
  - favorite / unfavorite を idempotent に実行する command を追加
  - duplicate favorite / missing favorite を contract として固定するため
- `backend/app/Presentation/Http/Resources/Social/ProfileResource.php`
  - RealWorld `profile` response wrapper を追加
  - API response shape を resource に集約するため
- `backend/app/Domain/Identity/Exceptions/UserNotFoundException.php`
  - profile 対象 User の not found を domain exception として追加
  - `404 errors.body` へ一貫して変換するため
- `backend/app/Presentation/Http/Responses/RealWorldErrorResponse.php`
  - `UserNotFoundException` を `404 Resource not found.` に mapping
  - Profile API の missing user contract を満たすため

## Tests

- `backend/tests/Feature/Social/ProfileFollowApiTest.php`
  - `profile` wrapper、following state、missing profile、未認証 follow、self-follow、unfollow idempotency を追加
- `backend/tests/Feature/Publishing/ArticleFavoriteApiTest.php`
  - favorite / unfavorite の `article` wrapper、未認証、missing article、idempotency を追加
- `backend/tests/Feature/Publishing/ArticleCrudApiTest.php`
  - Article list query validation、list optional auth invalid token、未認証 update/delete を追加

## Docs

- `docs/api-contract-coverage.md`
  - MVP endpoint の coverage checklist を追加
  - Comment / Feed / Tags の未実装 endpoint を残課題として明記

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| バックエンド変更あり | backend 全テスト | `docker compose run --rm --no-deps -e APP_KEY=base64:... backend-php php artisan test` | すべて成功する | 成功（worktree に `.env` がないため dotenv warning あり） |
| バックエンド変更あり | Pint format 確認 | `docker compose run --rm --no-deps backend-php ./vendor/bin/pint --test` | 成功する | 成功 |
| バックエンド変更あり | PHPStan 静的解析 | `docker compose run --rm --no-deps -e APP_KEY=base64:... backend-php ./vendor/bin/phpstan analyse` | 成功する | 成功 |
| ドキュメント変更あり | 空白チェック | `git diff --check` | 空白エラーがない | 成功 |
| DB・マイグレーション変更なし | migrate / rollback | 既存 table を利用し migration 追加なし | 対象外 | 対象外 |
| フロントエンド変更なし | frontend test / lint / typecheck | frontend 差分なし | 対象外 | 対象外 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: Social command/query の責務分離、favorite idempotency、coverage checklist の gap 表現
