### PR TITLE
[#152]: Popular Tags読み込みを修正

### DIFF
--- a/backend/app/Application/Publishing/Queries/ListTagsQuery.php
+++ b/backend/app/Application/Publishing/Queries/ListTagsQuery.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\Queries;
+
+use App\Infrastructure\Persistence\Models\Tag as TagModel;
+
+final class ListTagsQuery
+{
+    /**
+     * 登録済み Tag の distinct list を安定した順序で返す。
+     *
+     * @return list<string>
+     */
+    public function execute(): array
+    {
+        return TagModel::query()
+            ->select('name')
+            ->distinct()
+            ->orderBy('name')
+            ->pluck('name')
+            ->map(fn (mixed $name): string => (string) $name)
+            ->values()
+            ->all();
+    }
+}

--- a/backend/app/Presentation/Http/Controllers/Publishing/TagController.php
+++ b/backend/app/Presentation/Http/Controllers/Publishing/TagController.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Controllers\Publishing;
+
+use App\Application\Publishing\Queries\ListTagsQuery;
+use App\Presentation\Http\Controllers\Controller;
+use App\Presentation\Http\Resources\Publishing\TagListResource;
+use Illuminate\Http\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+final class TagController extends Controller
+{
+    /**
+     * 登録済み Tag 一覧を RealWorld tags wrapper で返す。
+     */
+    public function index(ListTagsQuery $query): JsonResponse
+    {
+        return (new TagListResource($query->execute()))
+            ->response()
+            ->setStatusCode(Response::HTTP_OK);
+    }
+}

--- a/backend/app/Presentation/Http/Resources/Publishing/TagListResource.php
+++ b/backend/app/Presentation/Http/Resources/Publishing/TagListResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Resources\Publishing;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+final class TagListResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * RealWorld tags wrapper へ変換する。
+     *
+     * @return array{tags: list<string>}
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var list<string> $tags */
+        $tags = $this->resource;
+
+        return [
+            'tags' => $tags,
+        ];
+    }
+}

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -2,9 +2,12 @@
 
 namespace Database\Seeders;
 
+use App\Infrastructure\Persistence\Models\Article;
+use App\Infrastructure\Persistence\Models\Tag;
 use App\Infrastructure\Persistence\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
@@ -18,10 +21,28 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'username' => 'testuser',
+        $user = User::query()->updateOrCreate([
             'email' => 'test@example.com',
+        ], [
+            'username' => 'testuser',
             'password_hash' => Hash::make('password'),
         ]);
+
+        $article = Article::query()->updateOrCreate([
+            'slug' => 'welcome-to-realworld',
+        ], [
+            'author_user_id' => $user->getKey(),
+            'title' => 'Welcome to RealWorld',
+            'description' => 'A demo article for the Home feed',
+            'body' => 'This article seeds tags for local development.',
+            'created_at' => Carbon::parse('2026-05-01 00:00:00'),
+            'updated_at' => Carbon::parse('2026-05-01 00:00:00'),
+        ]);
+
+        $tagIds = collect(['laravel', 'react', 'realworld'])
+            ->map(fn (string $name): int => (int) Tag::query()->updateOrCreate(['name' => $name])->getKey())
+            ->all();
+
+        $article->tags()->sync($tagIds);
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,6 +3,7 @@
 use App\Presentation\Http\Controllers\Identity\AuthController;
 use App\Presentation\Http\Controllers\Identity\CurrentUserController;
 use App\Presentation\Http\Controllers\Publishing\ArticleController;
+use App\Presentation\Http\Controllers\Publishing\TagController;
 use App\Presentation\Http\Controllers\Social\ProfileController;
 use Illuminate\Support\Facades\Route;
 
@@ -10,6 +11,7 @@ Route::post('/users', [AuthController::class, 'register']);
 Route::post('/users/login', [AuthController::class, 'login']);
 Route::get('/articles', [ArticleController::class, 'index'])->name('articles.index');
 Route::get('/articles/{slug}', [ArticleController::class, 'show'])->name('articles.show');
+Route::get('/tags', [TagController::class, 'index'])->name('tags.index');
 Route::get('/profiles/{username}', [ProfileController::class, 'show'])->name('profiles.show');
 
 Route::middleware('auth:api')->group(function (): void {

--- a/backend/tests/Feature/Publishing/TagApiTest.php
+++ b/backend/tests/Feature/Publishing/TagApiTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Infrastructure\Persistence\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+describe('Tag API', function (): void {
+    it('guestが登録済みTagのdistinct listをRealWorld wrapperで取得できる', function (): void {
+        $author = User::factory()->create();
+        tagApiCreateArticle($author, 'first-article', ['dragons', 'training']);
+        tagApiCreateArticle($author, 'second-article', ['dragons', 'laravel']);
+
+        $this->getJson('/api/tags')
+            ->assertOk()
+            ->assertExactJson([
+                'tags' => ['dragons', 'laravel', 'training'],
+            ]);
+    });
+
+    it('Tagが存在しない場合は空配列を返す', function (): void {
+        $this->getJson('/api/tags')
+            ->assertOk()
+            ->assertExactJson([
+                'tags' => [],
+            ]);
+    });
+
+    it('開発seed後にHomeで確認できるTagが用意される', function (): void {
+        $this->seed();
+
+        expect(DB::table('users')->where('username', 'testuser')->exists())->toBeTrue();
+
+        $response = $this->getJson('/api/tags')
+            ->assertOk()
+            ->assertJsonStructure(['tags']);
+
+        expect($response->json('tags'))
+            ->toBeArray()
+            ->not->toBeEmpty();
+    });
+});
+
+/**
+ * @param  list<string>  $tagNames
+ */
+function tagApiCreateArticle(User $author, string $slug, array $tagNames): int
+{
+    $createdAt = Carbon::parse('2026-05-01 00:00:00');
+    $articleId = DB::table('articles')->insertGetId([
+        'author_user_id' => $author->getKey(),
+        'slug' => $slug,
+        'title' => str($slug)->replace('-', ' ')->title()->toString(),
+        'description' => 'A seeded article for tag tests',
+        'body' => 'Tag API test body',
+        'created_at' => $createdAt,
+        'updated_at' => $createdAt,
+    ]);
+
+    foreach ($tagNames as $tagName) {
+        $tagId = DB::table('tags')->where('name', $tagName)->value('id');
+
+        if (! is_numeric($tagId)) {
+            $tagId = DB::table('tags')->insertGetId([
+                'name' => $tagName,
+                'created_at' => $createdAt,
+                'updated_at' => $createdAt,
+            ]);
+        }
+
+        DB::table('article_tag')->insertOrIgnore([
+            'article_id' => (int) $articleId,
+            'tag_id' => (int) $tagId,
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ]);
+    }
+
+    return (int) $articleId;
+}


### PR DESCRIPTION
# 概要

- `GET /api/tags` を追加し、RealWorld 互換の `{ "tags": [...] }` を返すようにしました。
- tag がない場合も `{ "tags": [] }` を返す backend feature test を追加しました。
- 開発 seed で demo article と tag を idempotent に投入し、Home の Popular Tags を初期表示で確認できるようにしました。

# 関連Issue

Closes #152

Epic: #58

# 修正ファイルの説明

## Backend API

- `backend/routes/api.php`
  - public route として `GET /api/tags` を追加
  - guest でも Popular Tags を取得できるようにするため
- `backend/app/Application/Publishing/Queries/ListTagsQuery.php`
  - `tags.name` の distinct list を name 昇順で返す Query を追加
  - Controller に DB 参照を置かず、読み取り責務を Application Query へ分離するため
- `backend/app/Presentation/Http/Controllers/Publishing/TagController.php`
  - tags endpoint の thin controller を追加
  - RealWorld response wrapper への変換を Resource に委譲するため
- `backend/app/Presentation/Http/Resources/Publishing/TagListResource.php`
  - `{ "tags": string[] }` 形式へ整形する Resource を追加
  - API contract を Presentation 層で固定するため

## Seed

- `backend/database/seeders/DatabaseSeeder.php`
  - 既存 test user を idempotent に作成し、demo article と `laravel` / `react` / `realworld` tags を投入
  - seed 後に Home の Popular Tags を目視確認できるようにするため

## Tests

- `backend/tests/Feature/Publishing/TagApiTest.php`
  - guest access、empty response、distinct response、seed 後 tag availability を検証
  - Issue #152 の受け入れ条件を backend feature test として固定するため

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| バックエンド変更あり | 追加 feature test | `docker compose exec -T backend-php sh -lc 'php artisan test --filter=TagApiTest'` | 成功する | 成功 |
| バックエンド変更あり | 全 backend test | `docker compose exec -T backend-php sh -lc 'php artisan test'` | 成功する | 成功 |
| バックエンド変更あり | Pint | `docker compose exec -T backend-php sh -lc './vendor/bin/pint --test'` | 成功する | 成功 |
| バックエンド変更あり | PHPStan | `docker compose exec -T backend-php sh -lc './vendor/bin/phpstan analyse'` | 成功する | 成功 |
| フロントエンド連携確認 | Tag/Home regression | `pnpm vitest run src/features/tag/__tests__/tagApi.test.ts src/app/routes/__tests__/HomePage.test.tsx` | 成功する | 成功 |
| フロントエンド連携確認 | 全 frontend test | `pnpm vitest run` | 成功する | 成功 |
| フロントエンド連携確認 | 型チェック | `pnpm tsc -b --noEmit` | 成功する | 成功 |
| フロントエンド連携確認 | ESLint | `pnpm eslint .` | 成功する | 成功 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: `/api/tags` の認証不要 contract と seed data の idempotency
