### PR TITLE
[#153]: login状態のリロード復元を補強

### DIFF
--- a/bff/src/app.ts
+++ b/bff/src/app.ts
@@ -158,7 +158,20 @@ async function handleAuthenticatedSessionRequest(
 ): Promise<Response> {
   const { session, sessionId } = await readRequestSession(context, config, sessions);
 
-  if (session?.publicJwt === null || session?.publicJwt === undefined) {
+  if (session === null) {
+    if (sessionId !== null) {
+      expireSessionCookie(context, config);
+
+      return context.json(
+        { errors: { body: ['Unauthorized'] } },
+        401 as ContentfulStatusCode,
+      );
+    }
+
+    return jsonResponse(401, { errors: { body: ['Unauthorized'] } });
+  }
+
+  if (session.publicJwt === null) {
     return jsonResponse(401, { errors: { body: ['Unauthorized'] } });
   }
 

--- a/bff/test/session.test.ts
+++ b/bff/test/session.test.ts
@@ -244,6 +244,102 @@ test('current user と resource forwarding は session JWT を Token scheme で�
   }
 });
 
+test('current user は BFF process restart 後も Redis session から復元する', async () => {
+  const upstream = await startUpstreamServer(({ request, response }) => {
+    if (request.url === '/api/users/login') {
+      writeJson(response, 200, {
+        user: {
+          bio: null,
+          email: 'jake@example.com',
+          image: null,
+          token: 'public-jwt',
+          username: 'jake',
+        },
+      });
+      return;
+    }
+
+    if (request.url === '/api/user') {
+      assert.equal(request.headers.authorization, 'Token public-jwt');
+      writeJson(response, 200, {
+        user: {
+          bio: null,
+          email: 'jake@example.com',
+          image: null,
+          token: 'public-jwt',
+          username: 'jake',
+        },
+      });
+      return;
+    }
+
+    writeJson(response, 404, { errors: { body: ['not found'] } });
+  });
+  const redis = new FakeRedisClient();
+  const firstBff = await startBffServer(upstream.url, redis);
+
+  try {
+    let authenticated: AuthenticatedBffSession;
+
+    try {
+      authenticated = await loginThroughBff(firstBff.url);
+    } finally {
+      await firstBff.close();
+    }
+
+    const restartedBff = await startBffServer(upstream.url, redis);
+
+    try {
+      const currentResponse = await fetch(`${restartedBff.url}/api/session`, {
+        headers: { Cookie: authenticated.cookie },
+      });
+      const currentBody = await currentResponse.json() as { user: { token?: unknown } };
+
+      assert.equal(currentResponse.status, 200);
+      assert.equal(currentBody.user.token, undefined);
+      assert.equal(upstream.requests.filter((request) => request.url === '/api/user').length, 1);
+    } finally {
+      await restartedBff.close();
+    }
+  } finally {
+    await upstream.close();
+  }
+});
+
+test('失効済み Redis session cookie での current user request は browser cookie も破棄する', async () => {
+  const upstream = await startUpstreamServer(({ response }) => {
+    writeJson(response, 200, {
+      user: {
+        bio: null,
+        email: 'jake@example.com',
+        image: null,
+        token: 'public-jwt',
+        username: 'jake',
+      },
+    });
+  });
+  const redis = new FakeRedisClient();
+  const bff = await startBffServer(upstream.url, redis);
+
+  try {
+    const authenticated = await loginThroughBff(bff.url);
+
+    redis.advance(3_600_000);
+
+    const currentResponse = await fetch(`${bff.url}/api/session`, {
+      headers: { Cookie: authenticated.cookie },
+    });
+    const expiredCookie = getFirstSetCookie(currentResponse);
+
+    assert.equal(currentResponse.status, 401);
+    assert.match(expiredCookie, /^__Host-conduit_session=;/);
+    assert.match(expiredCookie, /Max-Age=0/);
+  } finally {
+    await bff.close();
+    await upstream.close();
+  }
+});
+
 test('resource forwarding の mutating request は CSRF proof なしでは拒否する', async () => {
   const upstream = await startUpstreamServer();
   const bff = await startBffServer(upstream.url);
@@ -389,9 +485,12 @@ async function bootstrapCsrf(baseUrl: string): Promise<CsrfBootstrap> {
   };
 }
 
-async function startBffServer(publicApiBaseUrl: string): Promise<StartedServer> {
+async function startBffServer(
+  publicApiBaseUrl: string,
+  redis: FakeRedisClient = new FakeRedisClient(),
+): Promise<StartedServer> {
   const sessionStore = await createRedisSessionStore({
-    client: new FakeRedisClient(),
+    client: redis,
     keyPrefix: 'bff:test:',
     ttlSeconds: 3600,
   });


### PR DESCRIPTION
# 概要

- BFF の BrowserSession lifecycle に、Redis-backed session が BFF process restart 後も current user を復元できる回帰テストを追加
- Redis TTL 切れなどで stale session cookie が送られた場合、`GET /api/session` の `401` と同時に browser cookie を失効するよう修正
- JWT / session identifier を browser-readable storage に保存しない方針は維持

# 関連Issue

Closes #153

Epic: #123

# 修正ファイルの説明

## BFF

- `bff/src/app.ts`
  - `GET /api/session` で cookie はあるが Redis session が存在しない場合に `__Host-conduit_session` を `Max-Age=0` で失効する処理を追加
  - stale cookie が残り続けて reload 後の認証復元判定を曖昧にしないため

## Tests

- `bff/test/session.test.ts`
  - BFF process restart 後も同じ Redis store から current user を復元できることを検証
  - Redis TTL 切れ後の `GET /api/session` が `401` と cookie 失効を返すことを検証

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| BFF変更あり | BFF test | `pnpm -C bff test` | すべて成功する | 成功 |
| BFF変更あり | BFF type-check | `pnpm -C bff type-check` | 成功する | 成功 |
| BFF変更あり | BFF lint | `pnpm -C bff lint` | 成功する | 成功 |
| フロントエンド関連回帰 | フロントエンドテスト・lint・型チェック | `pnpm -C frontend test` / `pnpm -C frontend lint` / `pnpm -C frontend exec tsc -b --noEmit` | すべて成功する | 成功 |
| バックエンドAPI関連回帰 | Identity API test / Pint / PHPStan | Docker コンテナ内で `php artisan test --filter=CurrentUserApiTest` / `./vendor/bin/pint --test` / `./vendor/bin/phpstan analyse` | すべて成功する | 成功 |
| 認証integration | same-origin frontend -> BFF -> Public API smoke | `node scripts/qa/auth-integration-qa.mjs` | 成功する | 成功 |
| 実ブラウザ確認 | BFF再起動後の `/settings` reload | in-app Browser で authenticated nav と Settings 表示を確認 | login state が復元される | 成功 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: stale session cookie を消す条件が CSRF / BrowserSession 方針と矛盾していないか
