### PR TITLE
[#70]: Comment APIを実装

### DIFF
--- a/backend/app/Application/Publishing/Commands/AddCommentCommand.php
+++ b/backend/app/Application/Publishing/Commands/AddCommentCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\Commands;
+
+use App\Application\Publishing\DTOs\CreateCommentDto;
+use App\Domain\Publishing\Entities\Comment;
+use App\Domain\Publishing\Exceptions\ArticleNotFoundException;
+use App\Domain\Publishing\ValueObjects\CommentBody;
+use App\Domain\Publishing\ValueObjects\CommentId;
+use App\Infrastructure\Persistence\Models\Article as ArticleModel;
+use Illuminate\Support\Facades\DB;
+
+final readonly class AddCommentCommand
+{
+    /**
+     * 認証済み User が Article へ Comment を追加する。
+     */
+    public function execute(int $authorUserId, string $slug, CreateCommentDto $dto): Comment
+    {
+        $articleId = $this->articleIdForSlug($slug);
+        $comment = Comment::create(
+            articleId: $articleId,
+            authorUserId: $authorUserId,
+            body: new CommentBody($dto->body),
+        );
+
+        return DB::transaction(function () use ($comment): Comment {
+            $commentId = DB::table('comments')->insertGetId([
+                'article_id' => $comment->articleId(),
+                'author_user_id' => $comment->authorUserId(),
+                'body' => $comment->body()->value,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            return $comment->withId(new CommentId((int) $commentId));
+        });
+    }
+
+    /**
+     * slug に一致する Article ID を取得する。
+     */
+    private function articleIdForSlug(string $slug): int
+    {
+        $articleId = ArticleModel::query()
+            ->where('slug', $slug)
+            ->value('id');
+
+        if (! is_numeric($articleId)) {
+            throw ArticleNotFoundException::forSlug($slug);
+        }
+
+        return (int) $articleId;
+    }
+}

--- a/backend/app/Application/Publishing/Commands/DeleteCommentCommand.php
+++ b/backend/app/Application/Publishing/Commands/DeleteCommentCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\Commands;
+
+use App\Domain\Publishing\Entities\Comment;
+use Illuminate\Support\Facades\DB;
+
+final readonly class DeleteCommentCommand
+{
+    /**
+     * Comment を削除する。
+     */
+    public function execute(Comment $comment): void
+    {
+        $commentId = $comment->id();
+
+        if ($commentId === null) {
+            return;
+        }
+
+        DB::transaction(function () use ($commentId): void {
+            DB::table('comments')->where('id', $commentId->value)->delete();
+        });
+    }
+}

--- a/backend/app/Application/Publishing/DTOs/CommentAuthorDto.php
+++ b/backend/app/Application/Publishing/DTOs/CommentAuthorDto.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\DTOs;
+
+final readonly class CommentAuthorDto
+{
+    public function __construct(
+        public string $username,
+        public ?string $bio,
+        public ?string $image,
+        public bool $following,
+    ) {}
+}

--- a/backend/app/Application/Publishing/DTOs/CommentListDto.php
+++ b/backend/app/Application/Publishing/DTOs/CommentListDto.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\DTOs;
+
+final readonly class CommentListDto
+{
+    /**
+     * @param  list<CommentViewDto>  $comments
+     */
+    public function __construct(public array $comments) {}
+}

--- a/backend/app/Application/Publishing/DTOs/CommentViewDto.php
+++ b/backend/app/Application/Publishing/DTOs/CommentViewDto.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\DTOs;
+
+final readonly class CommentViewDto
+{
+    public function __construct(
+        public int $id,
+        public string $createdAt,
+        public string $updatedAt,
+        public string $body,
+        public CommentAuthorDto $author,
+    ) {}
+}

--- a/backend/app/Application/Publishing/DTOs/CreateCommentDto.php
+++ b/backend/app/Application/Publishing/DTOs/CreateCommentDto.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\DTOs;
+
+final readonly class CreateCommentDto
+{
+    public function __construct(public string $body) {}
+}

--- a/backend/app/Application/Publishing/Queries/CommentViewFactory.php
+++ b/backend/app/Application/Publishing/Queries/CommentViewFactory.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\Queries;
+
+use App\Application\Publishing\DTOs\CommentAuthorDto;
+use App\Application\Publishing\DTOs\CommentViewDto;
+use App\Infrastructure\Persistence\Models\Comment as CommentModel;
+use App\Infrastructure\Persistence\Models\User as UserModel;
+use DateTimeInterface;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+final class CommentViewFactory
+{
+    /**
+     * Comment Eloquent model 群を RealWorld response 用 DTO へ変換する。
+     *
+     * @param  Collection<int, CommentModel>  $models
+     * @return list<CommentViewDto>
+     */
+    public function fromModels(Collection $models, ?int $currentUserId): array
+    {
+        if ($models->isEmpty()) {
+            return [];
+        }
+
+        $models->each(fn (CommentModel $model): CommentModel => $model->loadMissing('author'));
+        $authorUserIds = $models->map(fn (CommentModel $model): int => $model->author_user_id)->unique()->all();
+        $followingUserIds = $this->followingUserIds($authorUserIds, $currentUserId);
+
+        return $models
+            ->map(fn (CommentModel $model): CommentViewDto => $this->buildDto($model, $followingUserIds))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * 1件の Comment Eloquent model を RealWorld response 用 DTO へ変換する。
+     */
+    public function fromModel(CommentModel $model, ?int $currentUserId): CommentViewDto
+    {
+        return $this->fromModels(collect([$model]), $currentUserId)[0];
+    }
+
+    /**
+     * @param  list<int>  $followingUserIds
+     */
+    private function buildDto(CommentModel $model, array $followingUserIds): CommentViewDto
+    {
+        /** @var UserModel $author */
+        $author = $model->author;
+
+        return new CommentViewDto(
+            id: (int) $model->getKey(),
+            createdAt: $this->formatTimestamp($model->created_at),
+            updatedAt: $this->formatTimestamp($model->updated_at),
+            body: $model->body,
+            author: new CommentAuthorDto(
+                username: $author->username,
+                bio: $author->bio,
+                image: $author->image,
+                following: in_array($model->author_user_id, $followingUserIds, true),
+            ),
+        );
+    }
+
+    /**
+     * @param  list<int>  $authorUserIds
+     * @return list<int>
+     */
+    private function followingUserIds(array $authorUserIds, ?int $currentUserId): array
+    {
+        if ($currentUserId === null) {
+            return [];
+        }
+
+        return DB::table('follows')
+            ->where('follower_user_id', $currentUserId)
+            ->whereIn('followee_user_id', $authorUserIds)
+            ->pluck('followee_user_id')
+            ->map(fn (mixed $userId): int => (int) $userId)
+            ->values()
+            ->all();
+    }
+
+    /**
+     * RealWorld API の timestamp 形式へ変換する。
+     */
+    private function formatTimestamp(DateTimeInterface|string|null $value): string
+    {
+        return Carbon::parse($value)->utc()->format('Y-m-d\TH:i:s.v\Z');
+    }
+}

--- a/backend/app/Application/Publishing/Queries/GetCommentForAuthorizationQuery.php
+++ b/backend/app/Application/Publishing/Queries/GetCommentForAuthorizationQuery.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\Queries;
+
+use App\Domain\Publishing\Entities\Comment;
+use App\Domain\Publishing\Exceptions\ArticleNotFoundException;
+use App\Domain\Publishing\Exceptions\CommentNotFoundException;
+use App\Domain\Publishing\ValueObjects\CommentBody;
+use App\Domain\Publishing\ValueObjects\CommentId;
+use App\Infrastructure\Persistence\Models\Article as ArticleModel;
+use App\Infrastructure\Persistence\Models\Comment as CommentModel;
+
+final readonly class GetCommentForAuthorizationQuery
+{
+    /**
+     * slug と Comment ID に一致する Comment を認可判定用 Entity として取得する。
+     */
+    public function execute(string $slug, int $commentId): Comment
+    {
+        $articleId = $this->articleIdForSlug($slug);
+        $model = CommentModel::query()
+            ->where('article_id', $articleId)
+            ->find($commentId);
+
+        if (! $model instanceof CommentModel) {
+            throw CommentNotFoundException::forId($commentId);
+        }
+
+        return new Comment(
+            id: new CommentId((int) $model->getKey()),
+            articleId: $model->article_id,
+            authorUserId: $model->author_user_id,
+            body: new CommentBody($model->body),
+        );
+    }
+
+    /**
+     * slug に一致する Article ID を取得する。
+     */
+    private function articleIdForSlug(string $slug): int
+    {
+        $articleId = ArticleModel::query()
+            ->where('slug', $slug)
+            ->value('id');
+
+        if (! is_numeric($articleId)) {
+            throw ArticleNotFoundException::forSlug($slug);
+        }
+
+        return (int) $articleId;
+    }
+}

--- a/backend/app/Application/Publishing/Queries/GetCommentQuery.php
+++ b/backend/app/Application/Publishing/Queries/GetCommentQuery.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\Queries;
+
+use App\Application\Publishing\DTOs\CommentViewDto;
+use App\Domain\Publishing\Exceptions\CommentNotFoundException;
+use App\Infrastructure\Persistence\Models\Comment as CommentModel;
+
+final readonly class GetCommentQuery
+{
+    public function __construct(private CommentViewFactory $comments) {}
+
+    /**
+     * ID に一致する Comment を response DTO として取得する。
+     */
+    public function execute(int $commentId, ?int $currentUserId): CommentViewDto
+    {
+        $model = CommentModel::query()
+            ->with('author')
+            ->find($commentId);
+
+        if (! $model instanceof CommentModel) {
+            throw CommentNotFoundException::forId($commentId);
+        }
+
+        return $this->comments->fromModel($model, $currentUserId);
+    }
+}

--- a/backend/app/Application/Publishing/Queries/ListCommentsQuery.php
+++ b/backend/app/Application/Publishing/Queries/ListCommentsQuery.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Publishing\Queries;
+
+use App\Application\Publishing\DTOs\CommentListDto;
+use App\Domain\Publishing\Exceptions\ArticleNotFoundException;
+use App\Infrastructure\Persistence\Models\Article as ArticleModel;
+use App\Infrastructure\Persistence\Models\Comment as CommentModel;
+
+final readonly class ListCommentsQuery
+{
+    public function __construct(private CommentViewFactory $comments) {}
+
+    /**
+     * Article に属する Comment 一覧を取得する。
+     */
+    public function execute(string $slug, ?int $currentUserId): CommentListDto
+    {
+        $articleId = $this->articleIdForSlug($slug);
+        $models = CommentModel::query()
+            ->with('author')
+            ->where('article_id', $articleId)
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->get();
+
+        return new CommentListDto(
+            comments: $this->comments->fromModels($models, $currentUserId),
+        );
+    }
+
+    /**
+     * slug に一致する Article ID を取得する。
+     */
+    private function articleIdForSlug(string $slug): int
+    {
+        $articleId = ArticleModel::query()
+            ->where('slug', $slug)
+            ->value('id');
+
+        if (! is_numeric($articleId)) {
+            throw ArticleNotFoundException::forSlug($slug);
+        }
+
+        return (int) $articleId;
+    }
+}

--- a/backend/app/Domain/Publishing/Entities/Comment.php
+++ b/backend/app/Domain/Publishing/Entities/Comment.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Publishing\Entities;
+
+use App\Domain\Publishing\ValueObjects\CommentBody;
+use App\Domain\Publishing\ValueObjects\CommentId;
+use InvalidArgumentException;
+
+final readonly class Comment
+{
+    public function __construct(
+        private ?CommentId $id,
+        private int $articleId,
+        private int $authorUserId,
+        private CommentBody $body,
+    ) {
+        if ($articleId < 1) {
+            throw new InvalidArgumentException('Comment article id must be positive.');
+        }
+
+        if ($authorUserId < 1) {
+            throw new InvalidArgumentException('Comment author user id must be positive.');
+        }
+    }
+
+    /**
+     * 新規 Comment を生成する。
+     */
+    public static function create(int $articleId, int $authorUserId, CommentBody $body): self
+    {
+        return new self(
+            id: null,
+            articleId: $articleId,
+            authorUserId: $authorUserId,
+            body: $body,
+        );
+    }
+
+    /**
+     * 永続化後の ID を持つ Comment として複製する。
+     */
+    public function withId(CommentId $id): self
+    {
+        return new self(
+            id: $id,
+            articleId: $this->articleId,
+            authorUserId: $this->authorUserId,
+            body: $this->body,
+        );
+    }
+
+    public function id(): ?CommentId
+    {
+        return $this->id;
+    }
+
+    public function articleId(): int
+    {
+        return $this->articleId;
+    }
+
+    public function authorUserId(): int
+    {
+        return $this->authorUserId;
+    }
+
+    public function body(): CommentBody
+    {
+        return $this->body;
+    }
+}

--- a/backend/app/Domain/Publishing/Exceptions/CommentNotFoundException.php
+++ b/backend/app/Domain/Publishing/Exceptions/CommentNotFoundException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Publishing\Exceptions;
+
+use DomainException;
+
+final class CommentNotFoundException extends DomainException
+{
+    /**
+     * ID に一致する Comment が存在しないことを表す。
+     */
+    public static function forId(int $commentId): self
+    {
+        return new self("comment not found: {$commentId}");
+    }
+}

--- a/backend/app/Domain/Publishing/ValueObjects/CommentBody.php
+++ b/backend/app/Domain/Publishing/ValueObjects/CommentBody.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Publishing\ValueObjects;
+
+use InvalidArgumentException;
+
+final readonly class CommentBody
+{
+    public string $value;
+
+    /**
+     * Comment の本文を表す。
+     */
+    public function __construct(string $value)
+    {
+        if (trim($value) === '') {
+            throw new InvalidArgumentException('Comment body is invalid.');
+        }
+
+        $this->value = $value;
+    }
+}

--- a/backend/app/Domain/Publishing/ValueObjects/CommentId.php
+++ b/backend/app/Domain/Publishing/ValueObjects/CommentId.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Publishing\ValueObjects;
+
+use InvalidArgumentException;
+
+final readonly class CommentId
+{
+    /**
+     * Comment の識別子を表す。
+     */
+    public function __construct(public int $value)
+    {
+        if ($value < 1) {
+            throw new InvalidArgumentException('Comment id must be positive.');
+        }
+    }
+}

--- a/backend/app/Infrastructure/Persistence/Models/Comment.php
+++ b/backend/app/Infrastructure/Persistence/Models/Comment.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $article_id
+ * @property int $author_user_id
+ * @property string $body
+ */
+class Comment extends Model
+{
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'article_id',
+        'author_user_id',
+        'body',
+    ];
+
+    /**
+     * Comment が属する Article を返す。
+     *
+     * @return BelongsTo<Article, $this>
+     */
+    public function article(): BelongsTo
+    {
+        return $this->belongsTo(Article::class);
+    }
+
+    /**
+     * Comment author の User を返す。
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'author_user_id');
+    }
+}

--- a/backend/app/Policies/CommentPolicy.php
+++ b/backend/app/Policies/CommentPolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Domain\Publishing\Entities\Comment;
+use App\Infrastructure\Persistence\Models\User;
+
+final class CommentPolicy
+{
+    /**
+     * Comment author のみ削除を許可する。
+     */
+    public function delete(User $user, Comment $comment): bool
+    {
+        return (int) $user->getKey() === $comment->authorUserId();
+    }
+}

--- a/backend/app/Presentation/Http/Controllers/Publishing/CommentController.php
+++ b/backend/app/Presentation/Http/Controllers/Publishing/CommentController.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Controllers\Publishing;
+
+use App\Application\Publishing\Commands\AddCommentCommand;
+use App\Application\Publishing\Commands\DeleteCommentCommand;
+use App\Application\Publishing\Queries\GetCommentForAuthorizationQuery;
+use App\Application\Publishing\Queries\GetCommentQuery;
+use App\Application\Publishing\Queries\ListCommentsQuery;
+use App\Domain\Publishing\Exceptions\CommentNotFoundException;
+use App\Presentation\Http\Controllers\Controller;
+use App\Presentation\Http\Requests\Publishing\CreateCommentRequest;
+use App\Presentation\Http\Resources\Publishing\CommentListResource;
+use App\Presentation\Http\Resources\Publishing\SingleCommentResource;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CommentController extends Controller
+{
+    /**
+     * Article の Comment 一覧を RealWorld comments wrapper で返す。
+     */
+    public function index(Request $request, string $slug, ListCommentsQuery $query): JsonResponse
+    {
+        return (new CommentListResource($query->execute(
+            slug: $slug,
+            currentUserId: $this->optionalAuthenticatedUserId($request),
+        )))
+            ->response()
+            ->setStatusCode(Response::HTTP_OK);
+    }
+
+    /**
+     * 認証済み User が Article へ Comment を投稿する。
+     */
+    public function store(
+        CreateCommentRequest $request,
+        string $slug,
+        AddCommentCommand $command,
+        GetCommentQuery $query,
+    ): JsonResponse {
+        $currentUserId = $this->authenticatedUserId($request);
+        $comment = $command->execute(
+            authorUserId: $currentUserId,
+            slug: $slug,
+            dto: $request->toDto(),
+        );
+        $commentId = $comment->id();
+
+        if ($commentId === null) {
+            throw CommentNotFoundException::forId(0);
+        }
+
+        return (new SingleCommentResource($query->execute(
+            commentId: $commentId->value,
+            currentUserId: $currentUserId,
+        )))
+            ->response()
+            ->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    /**
+     * Comment author が Comment を削除する。
+     */
+    public function destroy(
+        Request $request,
+        string $slug,
+        string $id,
+        GetCommentForAuthorizationQuery $commentForAuthorization,
+        DeleteCommentCommand $command,
+    ): JsonResponse {
+        $commentId = ctype_digit($id) ? (int) $id : 0;
+        $comment = $commentForAuthorization->execute($slug, $commentId);
+        Gate::forUser($request->user('api'))->authorize('delete', $comment);
+
+        $command->execute($comment);
+
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * 認証必須 endpoint の認証済み User ID を取得する。
+     */
+    private function authenticatedUserId(Request $request): int
+    {
+        $userId = $request->user()?->getAuthIdentifier();
+
+        if (! is_numeric($userId)) {
+            throw new AuthenticationException;
+        }
+
+        return (int) $userId;
+    }
+
+    /**
+     * Optional auth endpoint で JWT があれば認証済み User ID を取得する。
+     */
+    private function optionalAuthenticatedUserId(Request $request): ?int
+    {
+        if ($request->headers->get('Authorization') === null) {
+            return null;
+        }
+
+        $user = Auth::guard('api')->user();
+        $userId = $user?->getAuthIdentifier();
+
+        if (! is_numeric($userId)) {
+            throw new AuthenticationException;
+        }
+
+        return (int) $userId;
+    }
+}

--- a/backend/app/Presentation/Http/Requests/Publishing/CreateCommentRequest.php
+++ b/backend/app/Presentation/Http/Requests/Publishing/CreateCommentRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Requests\Publishing;
+
+use App\Application\Publishing\DTOs\CreateCommentDto;
+use Illuminate\Foundation\Http\FormRequest;
+
+final class CreateCommentRequest extends FormRequest
+{
+    /**
+     * 認証済み User の Comment 投稿リクエストとして許可する。
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * RealWorld add comment request の nested comment payload を検証する。
+     *
+     * @return array<string, list<mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'comment' => ['required', 'array'],
+            'comment.body' => ['required', 'string'],
+        ];
+    }
+
+    /**
+     * 検証済み payload を Application DTO へ変換する。
+     */
+    public function toDto(): CreateCommentDto
+    {
+        /** @var array{comment: array{body: string}} $payload */
+        $payload = $this->validated();
+
+        return new CreateCommentDto(body: $payload['comment']['body']);
+    }
+}

--- a/backend/app/Presentation/Http/Resources/Publishing/CommentListResource.php
+++ b/backend/app/Presentation/Http/Resources/Publishing/CommentListResource.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Resources\Publishing;
+
+use App\Application\Publishing\DTOs\CommentListDto;
+use App\Application\Publishing\DTOs\CommentViewDto;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CommentListDto
+ */
+final class CommentListResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * RealWorld multiple comments wrapper へ変換する。
+     *
+     * @return array{comments: list<array<string, mixed>>}
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CommentListDto $commentList */
+        $commentList = $this->resource;
+
+        return [
+            'comments' => array_map(
+                fn (CommentViewDto $comment): array => (new CommentResource($comment))->toArray($request),
+                $commentList->comments,
+            ),
+        ];
+    }
+}

--- a/backend/app/Presentation/Http/Resources/Publishing/CommentResource.php
+++ b/backend/app/Presentation/Http/Resources/Publishing/CommentResource.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Resources\Publishing;
+
+use App\Application\Publishing\DTOs\CommentViewDto;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CommentViewDto
+ */
+final class CommentResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * RealWorld comment object へ変換する。
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var CommentViewDto $comment */
+        $comment = $this->resource;
+
+        return [
+            'id' => $comment->id,
+            'createdAt' => $comment->createdAt,
+            'updatedAt' => $comment->updatedAt,
+            'body' => $comment->body,
+            'author' => [
+                'username' => $comment->author->username,
+                'bio' => $comment->author->bio,
+                'image' => $comment->author->image,
+                'following' => $comment->author->following,
+            ],
+        ];
+    }
+}

--- a/backend/app/Presentation/Http/Resources/Publishing/SingleCommentResource.php
+++ b/backend/app/Presentation/Http/Resources/Publishing/SingleCommentResource.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Http\Resources\Publishing;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+final class SingleCommentResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * RealWorld single comment wrapper へ変換する。
+     *
+     * @return array{comment: array<string, mixed>}
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'comment' => (new CommentResource($this->resource))->toArray($request),
+        ];
+    }
+}

--- a/backend/app/Presentation/Http/Responses/RealWorldErrorResponse.php
+++ b/backend/app/Presentation/Http/Responses/RealWorldErrorResponse.php
@@ -6,6 +6,7 @@ namespace App\Presentation\Http\Responses;
 
 use App\Domain\Identity\Exceptions\UserNotFoundException;
 use App\Domain\Publishing\Exceptions\ArticleNotFoundException;
+use App\Domain\Publishing\Exceptions\CommentNotFoundException;
 use DomainException;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
@@ -57,7 +58,7 @@ final class RealWorldErrorResponse
             return [Response::HTTP_UNPROCESSABLE_ENTITY, self::validationMessages($exception)];
         }
 
-        if ($exception instanceof ArticleNotFoundException || $exception instanceof UserNotFoundException) {
+        if ($exception instanceof ArticleNotFoundException || $exception instanceof CommentNotFoundException || $exception instanceof UserNotFoundException) {
             return [Response::HTTP_NOT_FOUND, ['Resource not found.']];
         }
 

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Providers;
 
 use App\Domain\Publishing\Entities\Article;
+use App\Domain\Publishing\Entities\Comment;
 use App\Policies\ArticlePolicy;
+use App\Policies\CommentPolicy;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
@@ -25,5 +27,6 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Gate::policy(Article::class, ArticlePolicy::class);
+        Gate::policy(Comment::class, CommentPolicy::class);
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,6 +3,7 @@
 use App\Presentation\Http\Controllers\Identity\AuthController;
 use App\Presentation\Http\Controllers\Identity\CurrentUserController;
 use App\Presentation\Http\Controllers\Publishing\ArticleController;
+use App\Presentation\Http\Controllers\Publishing\CommentController;
 use App\Presentation\Http\Controllers\Publishing\TagController;
 use App\Presentation\Http\Controllers\Social\ProfileController;
 use Illuminate\Support\Facades\Route;
@@ -10,6 +11,7 @@ use Illuminate\Support\Facades\Route;
 Route::post('/users', [AuthController::class, 'register']);
 Route::post('/users/login', [AuthController::class, 'login']);
 Route::get('/articles', [ArticleController::class, 'index'])->name('articles.index');
+Route::get('/articles/{slug}/comments', [CommentController::class, 'index'])->name('articles.comments.index');
 Route::get('/articles/{slug}', [ArticleController::class, 'show'])->name('articles.show');
 Route::get('/tags', [TagController::class, 'index'])->name('tags.index');
 Route::get('/profiles/{username}', [ProfileController::class, 'show'])->name('profiles.show');
@@ -20,6 +22,8 @@ Route::middleware('auth:api')->group(function (): void {
     Route::post('/articles', [ArticleController::class, 'store'])->name('articles.store');
     Route::put('/articles/{slug}', [ArticleController::class, 'update'])->name('articles.update');
     Route::delete('/articles/{slug}', [ArticleController::class, 'destroy'])->name('articles.destroy');
+    Route::post('/articles/{slug}/comments', [CommentController::class, 'store'])->name('articles.comments.store');
+    Route::delete('/articles/{slug}/comments/{id}', [CommentController::class, 'destroy'])->name('articles.comments.destroy');
     Route::post('/articles/{slug}/favorite', [ArticleController::class, 'favorite'])->name('articles.favorite');
     Route::delete('/articles/{slug}/favorite', [ArticleController::class, 'unfavorite'])->name('articles.unfavorite');
     Route::post('/profiles/{username}/follow', [ProfileController::class, 'follow'])->name('profiles.follow');

--- a/backend/tests/Feature/Publishing/CommentApiTest.php
+++ b/backend/tests/Feature/Publishing/CommentApiTest.php
@@ -59,6 +59,8 @@ describe('Comment API', function (): void {
             ->assertOk()
             ->assertJsonPath('comments.0.author.following', true);
 
+        Auth::forgetGuards();
+
         $this->withRealWorldToken('not-a-jwt')
             ->getJson('/api/articles/how-to-train-your-dragon/comments')
             ->assertUnauthorized()

--- a/backend/tests/Feature/Publishing/CommentApiTest.php
+++ b/backend/tests/Feature/Publishing/CommentApiTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Infrastructure\Persistence\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+describe('Comment API', function (): void {
+    it('guestがArticleのComment一覧をRealWorld comments wrapperで取得できる', function (): void {
+        $author = User::factory()->create([
+            'username' => 'jake',
+            'bio' => 'I like APIs',
+            'image' => 'https://example.com/avatar.png',
+        ]);
+        $otherAuthor = User::factory()->create(['username' => 'jane']);
+        $articleId = commentApiCreateArticle($author, ['slug' => 'how-to-train-your-dragon']);
+        commentApiCreateComment($articleId, $otherAuthor, [
+            'body' => 'Second comment',
+            'created_at' => Carbon::parse('2026-05-02 00:00:00'),
+            'updated_at' => Carbon::parse('2026-05-02 00:00:00'),
+        ]);
+        commentApiCreateComment($articleId, $author, [
+            'body' => 'First comment',
+            'created_at' => Carbon::parse('2026-05-01 00:00:00'),
+            'updated_at' => Carbon::parse('2026-05-01 00:00:00'),
+        ]);
+
+        $response = $this->getJson('/api/articles/how-to-train-your-dragon/comments');
+
+        $response
+            ->assertOk()
+            ->assertJsonCount(2, 'comments')
+            ->assertJsonPath('comments.0.body', 'First comment')
+            ->assertJsonPath('comments.0.createdAt', '2026-05-01T00:00:00.000Z')
+            ->assertJsonPath('comments.0.updatedAt', '2026-05-01T00:00:00.000Z')
+            ->assertJsonPath('comments.0.author.username', 'jake')
+            ->assertJsonPath('comments.0.author.bio', 'I like APIs')
+            ->assertJsonPath('comments.0.author.image', 'https://example.com/avatar.png')
+            ->assertJsonPath('comments.0.author.following', false)
+            ->assertJsonPath('comments.1.body', 'Second comment')
+            ->assertJsonPath('comments.1.author.username', 'jane');
+    });
+
+    it('Comment一覧のauthor followingをoptional authで算出する', function (): void {
+        $author = User::factory()->create(['username' => 'jake']);
+        $viewer = User::factory()->create(['username' => 'bob']);
+        $articleId = commentApiCreateArticle($author, ['slug' => 'how-to-train-your-dragon']);
+        commentApiCreateComment($articleId, $author, ['body' => 'Nice article']);
+        commentApiFollow($viewer, $author);
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($viewer))
+            ->getJson('/api/articles/how-to-train-your-dragon/comments')
+            ->assertOk()
+            ->assertJsonPath('comments.0.author.following', true);
+
+        $this->withRealWorldToken('not-a-jwt')
+            ->getJson('/api/articles/how-to-train-your-dragon/comments')
+            ->assertUnauthorized()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+
+    it('認証済みUserがCommentを投稿してRealWorld comment wrapperを返す', function (): void {
+        $author = User::factory()->create(['username' => 'jake']);
+        $commenter = User::factory()->create([
+            'username' => 'bob',
+            'bio' => 'I write comments',
+            'image' => 'https://example.com/bob.png',
+        ]);
+        commentApiCreateArticle($author, ['slug' => 'how-to-train-your-dragon']);
+
+        $response = $this->withRealWorldToken($this->issueRealWorldTokenFor($commenter))
+            ->postJson('/api/articles/how-to-train-your-dragon/comments', [
+                'comment' => [
+                    'body' => 'Nice article',
+                ],
+            ]);
+
+        $response
+            ->assertCreated()
+            ->assertJsonPath('comment.body', 'Nice article')
+            ->assertJsonPath('comment.author.username', 'bob')
+            ->assertJsonPath('comment.author.bio', 'I write comments')
+            ->assertJsonPath('comment.author.image', 'https://example.com/bob.png')
+            ->assertJsonPath('comment.author.following', false)
+            ->assertJsonStructure([
+                'comment' => [
+                    'id',
+                    'createdAt',
+                    'updatedAt',
+                    'body',
+                    'author' => ['username', 'bio', 'image', 'following'],
+                ],
+            ]);
+
+        expect(DB::table('comments')->where('body', 'Nice article')->exists())->toBeTrue();
+    });
+
+    it('未認証投稿とvalidation failureを拒否する', function (): void {
+        $author = User::factory()->create();
+        $commenter = User::factory()->create();
+        commentApiCreateArticle($author, ['slug' => 'how-to-train-your-dragon']);
+
+        $this->postJson('/api/articles/how-to-train-your-dragon/comments', [
+            'comment' => ['body' => 'Nice article'],
+        ])
+            ->assertUnauthorized()
+            ->assertJsonStructure(['errors' => ['body']]);
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($commenter))
+            ->postJson('/api/articles/how-to-train-your-dragon/comments', [
+                'comment' => ['body' => ''],
+            ])
+            ->assertUnprocessable()
+            ->assertJsonStructure(['errors' => ['body']]);
+    });
+
+    it('Comment authorのみCommentを削除できる', function (): void {
+        $articleAuthor = User::factory()->create(['username' => 'jake']);
+        $commentAuthor = User::factory()->create(['username' => 'bob']);
+        $other = User::factory()->create(['username' => 'other']);
+        $articleId = commentApiCreateArticle($articleAuthor, ['slug' => 'how-to-train-your-dragon']);
+        $commentId = commentApiCreateComment($articleId, $commentAuthor, ['body' => 'Delete me']);
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($other))
+            ->deleteJson("/api/articles/how-to-train-your-dragon/comments/{$commentId}")
+            ->assertForbidden()
+            ->assertJsonStructure(['errors' => ['body']]);
+
+        Auth::forgetGuards();
+
+        expect(DB::table('comments')->where('id', $commentId)->exists())->toBeTrue();
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($commentAuthor))
+            ->deleteJson("/api/articles/how-to-train-your-dragon/comments/{$commentId}")
+            ->assertNoContent();
+
+        expect(DB::table('comments')->where('id', $commentId)->exists())->toBeFalse();
+    });
+
+    it('存在しないArticleとCommentは404を返す', function (): void {
+        $author = User::factory()->create();
+        $commentAuthor = User::factory()->create();
+        $articleId = commentApiCreateArticle($author, ['slug' => 'how-to-train-your-dragon']);
+        $otherArticleId = commentApiCreateArticle($author, ['slug' => 'other-article']);
+        $otherCommentId = commentApiCreateComment($otherArticleId, $commentAuthor, ['body' => 'Other article comment']);
+
+        $this->getJson('/api/articles/missing-article/comments')
+            ->assertNotFound()
+            ->assertJsonStructure(['errors' => ['body']]);
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($commentAuthor))
+            ->postJson('/api/articles/missing-article/comments', [
+                'comment' => ['body' => 'Nice article'],
+            ])
+            ->assertNotFound()
+            ->assertJsonStructure(['errors' => ['body']]);
+
+        Auth::forgetGuards();
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($commentAuthor))
+            ->deleteJson('/api/articles/how-to-train-your-dragon/comments/999999')
+            ->assertNotFound()
+            ->assertJsonStructure(['errors' => ['body']]);
+
+        Auth::forgetGuards();
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($commentAuthor))
+            ->deleteJson("/api/articles/how-to-train-your-dragon/comments/{$otherCommentId}")
+            ->assertNotFound()
+            ->assertJsonStructure(['errors' => ['body']]);
+
+        expect(DB::table('comments')->where('article_id', $articleId)->count())->toBe(0);
+    });
+});
+
+/**
+ * @param  array<string, mixed>  $attributes
+ */
+function commentApiCreateArticle(User $author, array $attributes = []): int
+{
+    $createdAt = $attributes['created_at'] ?? Carbon::parse('2026-05-01 00:00:00');
+    $updatedAt = $attributes['updated_at'] ?? $createdAt;
+
+    return (int) DB::table('articles')->insertGetId([
+        'author_user_id' => $author->getKey(),
+        'slug' => $attributes['slug'] ?? 'how-to-train-your-dragon',
+        'title' => $attributes['title'] ?? 'How to train your dragon',
+        'description' => $attributes['description'] ?? 'Ever wonder how?',
+        'body' => $attributes['body'] ?? 'You have to believe',
+        'created_at' => $createdAt,
+        'updated_at' => $updatedAt,
+    ]);
+}
+
+/**
+ * @param  array<string, mixed>  $attributes
+ */
+function commentApiCreateComment(int $articleId, User $author, array $attributes = []): int
+{
+    $createdAt = $attributes['created_at'] ?? Carbon::parse('2026-05-02 00:00:00');
+    $updatedAt = $attributes['updated_at'] ?? $createdAt;
+
+    return (int) DB::table('comments')->insertGetId([
+        'article_id' => $articleId,
+        'author_user_id' => $author->getKey(),
+        'body' => $attributes['body'] ?? 'Nice article',
+        'created_at' => $createdAt,
+        'updated_at' => $updatedAt,
+    ]);
+}
+
+function commentApiFollow(User $follower, User $followee): void
+{
+    DB::table('follows')->insert([
+        'follower_user_id' => $follower->getKey(),
+        'followee_user_id' => $followee->getKey(),
+        'created_at' => Carbon::parse('2026-05-04 00:00:00'),
+        'updated_at' => Carbon::parse('2026-05-04 00:00:00'),
+    ]);
+}


### PR DESCRIPTION
# 概要

- Article ごとの Comment list / create / delete API を RealWorld 互換で追加
- Comment author の Profile response と optional auth の `following` 算出を実装
- Comment author のみ削除できる Policy / Gate 認可を追加

# 関連Issue

Closes #70

Epic: #58

# 修正ファイルの説明

## Backend / Domain

- `backend/app/Domain/Publishing/Entities/Comment.php`
  - Publishing Context の Comment entity を追加
  - Comment author-only 認可の判定対象として使うため
- `backend/app/Domain/Publishing/ValueObjects/CommentBody.php`
  - Comment body の空文字禁止を表現
  - Domain 側でも Comment の本文不変条件を持つため
- `backend/app/Domain/Publishing/ValueObjects/CommentId.php`
  - Comment ID を意味のある型で扱うため追加
- `backend/app/Domain/Publishing/Exceptions/CommentNotFoundException.php`
  - missing comment を RealWorld API の 404 に変換するため追加

## Backend / Application

- `backend/app/Application/Publishing/Commands/AddCommentCommand.php`
  - 認証済み User による Comment 作成を追加
  - 書き込み処理を Application 層の transaction に閉じるため
- `backend/app/Application/Publishing/Commands/DeleteCommentCommand.php`
  - Comment 削除処理を追加
  - Controller から DB 操作を分離するため
- `backend/app/Application/Publishing/Queries/ListCommentsQuery.php`
  - Article slug に属する Comment 一覧取得を追加
  - missing article を 404 として扱うため
- `backend/app/Application/Publishing/Queries/GetCommentQuery.php`
  - 作成後の Comment response 取得を追加
  - Resource 整形を Query 側 DTO に寄せるため
- `backend/app/Application/Publishing/Queries/GetCommentForAuthorizationQuery.php`
  - delete 認可対象の Comment entity 取得を追加
  - 対象 article に属さない comment id を 404 として扱うため
- `backend/app/Application/Publishing/Queries/CommentViewFactory.php`
  - Comment response DTO と author following の一括算出を追加
  - list response で N+1 を避けるため
- `backend/app/Application/Publishing/DTOs/*Comment*.php`
  - request / response の DTO を追加
  - Presentation と Application の境界を明確にするため

## Backend / Presentation

- `backend/app/Presentation/Http/Controllers/Publishing/CommentController.php`
  - list / create / delete endpoint を追加
  - Controller は request 受付と response 返却に限定
- `backend/app/Presentation/Http/Requests/Publishing/CreateCommentRequest.php`
  - `comment.body` の FormRequest validation を追加
  - サーバーサイド validation を必須にするため
- `backend/app/Presentation/Http/Resources/Publishing/*Comment*Resource.php`
  - RealWorld compatible `comment` / `comments` wrapper を追加
  - author profile shape を API contract に合わせるため
- `backend/routes/api.php`
  - Comment endpoints を Public / auth route に追加
- `backend/app/Policies/CommentPolicy.php`
  - Comment author-only delete policy を追加
- `backend/app/Providers/AppServiceProvider.php`
  - Comment policy を Gate に登録
- `backend/app/Presentation/Http/Responses/RealWorldErrorResponse.php`
  - `CommentNotFoundException` を 404 に変換

## Tests

- `backend/tests/Feature/Publishing/CommentApiTest.php`
  - Comment list / create / delete の正常系を追加
  - optional auth、未認証 create、validation failure、非 author delete、missing article/comment を検証

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| バックエンド変更あり | Pest 全体 | Docker コンテナ内で `php artisan test` | すべて成功する | 成功: 80 passed |
| バックエンド変更あり | Pint | Docker コンテナ内で `./vendor/bin/pint --test` | すべて成功する | 成功: 145 files |
| バックエンド変更あり | PHPStan | Docker コンテナ内で `./vendor/bin/phpstan analyse` | エラーがない | 成功: No errors |
| DB・マイグレーション変更あり | migrate / rollback 確認 | 追加 migration なし | 既存 comments table を利用 | 対象外 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし。`comments` table は既存 migration / DBML に存在
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: Comment author-only delete、optional auth の invalid JWT 401、Comment response の author profile shape
