### PR TITLE
[#76]: self-unfollowのFeatureテストを追加

### DIFF
--- a/backend/tests/Feature/Social/ProfileFollowApiTest.php
+++ b/backend/tests/Feature/Social/ProfileFollowApiTest.php
@@ -93,6 +93,21 @@ describe('Profile and Follow API', function (): void {
         expect(DB::table('follows')->count())->toBe(0);
     });
 
+    it('self-unfollowを422で拒否する', function (): void {
+        $viewer = User::factory()->create(['username' => 'jake']);
+
+        $this->withRealWorldToken($this->issueRealWorldTokenFor($viewer))
+            ->deleteJson('/api/profiles/jake/follow')
+            ->assertUnprocessable()
+            ->assertExactJson([
+                'errors' => [
+                    'body' => ['cannot follow yourself'],
+                ],
+            ]);
+
+        expect(DB::table('follows')->count())->toBe(0);
+    });
+
     it('unfollowは未follow状態でもidempotentにprofile wrapperを返す', function (): void {
         $viewer = User::factory()->create(['username' => 'viewer']);
         User::factory()->create(['username' => 'jake']);


### PR DESCRIPTION
# 概要

- Profile / Follow API の受け入れ条件に合わせて、self-unfollow を 422 の `errors.body` で拒否する Feature テストを追加
- 実装コードは既存の `UnfollowUserCommand` で満たされているため、変更はテストのみ

# 関連Issue

Closes #76

Epic: #54

# 修正ファイルの説明

## Backend Test

- `backend/tests/Feature/Social/ProfileFollowApiTest.php`
  - `DELETE /api/profiles/{username}/follow` で自身を unfollow しようとした場合に `422` と `cannot follow yourself` を返すことを検証
  - self-follow と同じ domain rule が unfollow 側でも API 仕様として担保されることを明示

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| バックエンド変更あり | Profile Follow Feature テスト | Docker コンテナ内で `php artisan test tests/Feature/Social/ProfileFollowApiTest.php` | すべて成功する | 成功: 8 passed / 22 assertions |
| バックエンド変更あり | 対象テストファイルの format 確認 | Docker コンテナ内で `./vendor/bin/pint --test tests/Feature/Social/ProfileFollowApiTest.php` | format 差分なし | 成功 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: 追加テストが Issue #76 の self-unfollow 受け入れ条件を十分に表しているか
