### PR TITLE
[#80]: API contract examplesを更新

### DIFF
--- a/docs/api-contract-coverage.md
+++ b/docs/api-contract-coverage.md
@@ -25,17 +25,15 @@ API 仕様そのものは `docs/api-requirements.md` を正本とし、この文
 | `DELETE /api/articles/{slug}` | Required | empty | missing token `401`, non-author `403`, missing article `404`, success `204` | `backend/tests/Feature/Publishing/ArticleCrudApiTest.php` | Covered |
 | `POST /api/articles/{slug}/favorite` | Required | `article` | missing token `401`, missing article `404`, duplicate favorite idempotency | `backend/tests/Feature/Publishing/ArticleFavoriteApiTest.php` | Covered |
 | `DELETE /api/articles/{slug}/favorite` | Required | `article` | missing favorite idempotency | `backend/tests/Feature/Publishing/ArticleFavoriteApiTest.php` | Covered |
-| `GET /api/articles/{slug}/comments` | Optional | `comments` | Not implemented yet | none | Gap |
-| `POST /api/articles/{slug}/comments` | Required | `comment` | Not implemented yet | none | Gap |
-| `DELETE /api/articles/{slug}/comments/{id}` | Required | empty | Comment author ownership is not covered yet | none | Gap |
+| `GET /api/articles/{slug}/comments` | Optional | `comments` | `200`, author following state, invalid optional token `401`, missing article `404` | `backend/tests/Feature/Publishing/CommentApiTest.php` | Covered |
+| `POST /api/articles/{slug}/comments` | Required | `comment` | `201`, missing token `401`, validation `422`, missing article `404` | `backend/tests/Feature/Publishing/CommentApiTest.php` | Covered |
+| `DELETE /api/articles/{slug}/comments/{id}` | Required | empty | success `204`, non-author `403`, missing / cross-article comment `404` | `backend/tests/Feature/Publishing/CommentApiTest.php` | Covered |
 | `GET /api/articles/feed` | Required | `articles`, `articlesCount` | Not implemented yet | none | Gap |
-| `GET /api/tags` | None | `tags` | Not implemented yet | none | Gap |
+| `GET /api/tags` | None | `tags` | `200`, distinct sorted tags, empty list, seeded tags fixture | `backend/tests/Feature/Publishing/TagApiTest.php` | Covered |
 
 ## Remaining Gaps
 
-- Comment API の `comments` / `comment` wrapper、comment author ownership、missing article / comment の `404` は未実装 endpoint のため未対応。
 - Feed API の required auth `401`、followee article list、pagination contract は未実装 endpoint のため未対応。
-- Tag API の distinct tag list wrapper は未実装 endpoint のため未対応。
 - Follow の duplicate follow は `insertOrIgnore` による idempotent insert として扱うが、重複 follow 専用の独立テストは未追加。
 
 ## Review Notes

--- a/docs/api-requirements.md
+++ b/docs/api-requirements.md
@@ -145,7 +145,7 @@ Docker development environment では Hono + TypeScript BFF service を追加し
   "user": {
     "username": "jake",
     "email": "jake@example.com",
-    "password": "secret"
+    "password": "<password>"
   }
 }
 ```
@@ -164,7 +164,7 @@ Validation:
 {
   "user": {
     "email": "jake@example.com",
-    "password": "secret"
+    "password": "<password>"
   }
 }
 ```
@@ -183,7 +183,7 @@ Validation:
   "user": {
     "email": "jake@example.com",
     "username": "jake",
-    "password": "new-secret",
+    "password": "<new-password>",
     "bio": "I like APIs",
     "image": "https://example.com/avatar.png"
   }
@@ -281,13 +281,15 @@ Validation:
 {
   "user": {
     "email": "jake@example.com",
-    "token": "jwt.token.value",
+    "token": "<jwt-token>",
     "username": "jake",
-    "bio": "I like APIs",
-    "image": "https://example.com/avatar.png"
+    "bio": null,
+    "image": null
   }
 }
 ```
+
+Register can return `null` profile fields. Login, Current User, and Update User use the same wrapper and return the current persisted `bio` / `image` values.
 
 BFF が browser へ返す `user` response は同じ表示 field を持つが、`token` field を含めない。
 
@@ -297,8 +299,8 @@ BFF が browser へ返す `user` response は同じ表示 field を持つが、`
 {
   "profile": {
     "username": "jake",
-    "bio": "I like APIs",
-    "image": "https://example.com/avatar.png",
+    "bio": null,
+    "image": null,
     "following": false
   }
 }
@@ -314,14 +316,14 @@ BFF が browser へ返す `user` response は同じ表示 field を持つが、`
     "description": "Ever wonder how?",
     "body": "You have to believe",
     "tagList": ["dragons", "training"],
-    "createdAt": "2026-05-06T00:00:00.000Z",
-    "updatedAt": "2026-05-06T00:00:00.000Z",
+    "createdAt": "2026-05-01T00:00:00.000Z",
+    "updatedAt": "2026-05-01T00:00:00.000Z",
     "favorited": false,
     "favoritesCount": 0,
     "author": {
       "username": "jake",
-      "bio": "I like APIs",
-      "image": "https://example.com/avatar.png",
+      "bio": null,
+      "image": null,
       "following": false
     }
   }
@@ -340,14 +342,14 @@ Article list and feed responses return summaries. They do not include `body`.
       "title": "How to train your dragon",
       "description": "Ever wonder how?",
       "tagList": ["dragons", "training"],
-      "createdAt": "2026-05-06T00:00:00.000Z",
-      "updatedAt": "2026-05-06T00:00:00.000Z",
+      "createdAt": "2026-05-01T00:00:00.000Z",
+      "updatedAt": "2026-05-01T00:00:00.000Z",
       "favorited": false,
       "favoritesCount": 0,
       "author": {
         "username": "jake",
-        "bio": "I like APIs",
-        "image": "https://example.com/avatar.png",
+        "bio": null,
+        "image": null,
         "following": false
       }
     }
@@ -362,13 +364,13 @@ Article list and feed responses return summaries. They do not include `body`.
 {
   "comment": {
     "id": 1,
-    "createdAt": "2026-05-06T00:00:00.000Z",
-    "updatedAt": "2026-05-06T00:00:00.000Z",
+    "createdAt": "2026-05-02T00:00:00.000Z",
+    "updatedAt": "2026-05-02T00:00:00.000Z",
     "body": "Nice article",
     "author": {
-      "username": "jake",
-      "bio": "I like APIs",
-      "image": "https://example.com/avatar.png",
+      "username": "bob",
+      "bio": null,
+      "image": null,
       "following": false
     }
   }
@@ -382,13 +384,13 @@ Article list and feed responses return summaries. They do not include `body`.
   "comments": [
     {
       "id": 1,
-      "createdAt": "2026-05-06T00:00:00.000Z",
-      "updatedAt": "2026-05-06T00:00:00.000Z",
+      "createdAt": "2026-05-02T00:00:00.000Z",
+      "updatedAt": "2026-05-02T00:00:00.000Z",
       "body": "Nice article",
       "author": {
-        "username": "jake",
-        "bio": "I like APIs",
-        "image": "https://example.com/avatar.png",
+        "username": "bob",
+        "bio": null,
+        "image": null,
         "following": false
       }
     }
@@ -400,16 +402,33 @@ Article list and feed responses return summaries. They do not include `body`.
 
 ```json
 {
-  "tags": ["dragons", "training"]
+  "tags": ["dragons", "laravel", "training"]
 }
 ```
 
 ### Errors
 
+Authentication errors:
+
 ```json
 {
   "errors": {
-    "body": ["title is required"]
+    "body": [
+      "Unauthenticated."
+    ]
+  }
+}
+```
+
+Validation errors flatten FormRequest field messages into `errors.body`:
+
+```json
+{
+  "errors": {
+    "body": [
+      "title is required",
+      "body is required"
+    ]
   }
 }
 ```
@@ -425,8 +444,8 @@ Article list and feed responses return summaries. They do not include `body`.
 | `DELETE /api/articles/{slug}` | Authenticated User must be Article author | `403` |
 | `POST /api/articles/{slug}/comments` | Authenticated User only | `401` |
 | `DELETE /api/articles/{slug}/comments/{id}` | Authenticated User must be Comment author | `403` |
-| `POST /api/profiles/{username}/follow` | Authenticated User cannot follow self | `401` or `422` |
-| `DELETE /api/profiles/{username}/follow` | Authenticated User cannot target self | `401` or `422` |
+| `POST /api/profiles/{username}/follow` | Authenticated User cannot follow self | `422` |
+| `DELETE /api/profiles/{username}/follow` | Authenticated User cannot target self | `422` |
 | `POST /api/articles/{slug}/favorite` | Authenticated User only; duplicate is idempotent | `401` |
 | `DELETE /api/articles/{slug}/favorite` | Authenticated User only; missing favorite is idempotent | `401` |
 | `GET /api/articles/feed` | Authenticated User only | `401` |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "scripts": {
     "prepare": "husky",
-    "qa:auth": "node scripts/qa/auth-integration-qa.mjs"
+    "qa:auth": "node scripts/qa/auth-integration-qa.mjs",
+    "test:docs": "node --test tests/docs/*.test.mjs"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.0",

--- a/tests/docs/api-contract-examples.test.mjs
+++ b/tests/docs/api-contract-examples.test.mjs
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const apiRequirements = readFileSync(
+  new URL('../../docs/api-requirements.md', import.meta.url),
+  'utf8',
+);
+
+test('User example matches the implemented Public API wrapper', () => {
+  assert.deepEqual(jsonExampleFor('User'), {
+    user: {
+      email: 'jake@example.com',
+      token: '<jwt-token>',
+      username: 'jake',
+      bio: null,
+      image: null,
+    },
+  });
+});
+
+test('Profile example matches the nullable profile response shape', () => {
+  assert.deepEqual(jsonExampleFor('Profile'), {
+    profile: {
+      username: 'jake',
+      bio: null,
+      image: null,
+      following: false,
+    },
+  });
+});
+
+test('Single Article example matches the backend article resource', () => {
+  assert.deepEqual(jsonExampleFor('Single Article'), {
+    article: {
+      slug: 'how-to-train-your-dragon',
+      title: 'How to train your dragon',
+      description: 'Ever wonder how?',
+      body: 'You have to believe',
+      tagList: ['dragons', 'training'],
+      createdAt: '2026-05-01T00:00:00.000Z',
+      updatedAt: '2026-05-01T00:00:00.000Z',
+      favorited: false,
+      favoritesCount: 0,
+      author: {
+        username: 'jake',
+        bio: null,
+        image: null,
+        following: false,
+      },
+    },
+  });
+});
+
+test('Multiple Articles example is the frontend list response shape without body', () => {
+  const articlesExample = jsonExampleFor('Multiple Articles');
+
+  assert.deepEqual(articlesExample, {
+    articles: [
+      {
+        slug: 'how-to-train-your-dragon',
+        title: 'How to train your dragon',
+        description: 'Ever wonder how?',
+        tagList: ['dragons', 'training'],
+        createdAt: '2026-05-01T00:00:00.000Z',
+        updatedAt: '2026-05-01T00:00:00.000Z',
+        favorited: false,
+        favoritesCount: 0,
+        author: {
+          username: 'jake',
+          bio: null,
+          image: null,
+          following: false,
+        },
+      },
+    ],
+    articlesCount: 1,
+  });
+  assert.equal('body' in articlesExample.articles[0], false);
+});
+
+test('Comment examples match the implemented comments wrappers', () => {
+  const singleComment = {
+    comment: {
+      id: 1,
+      createdAt: '2026-05-02T00:00:00.000Z',
+      updatedAt: '2026-05-02T00:00:00.000Z',
+      body: 'Nice article',
+      author: {
+        username: 'bob',
+        bio: null,
+        image: null,
+        following: false,
+      },
+    },
+  };
+
+  assert.deepEqual(jsonExampleFor('Single Comment'), singleComment);
+  assert.deepEqual(jsonExampleFor('Multiple Comments'), {
+    comments: [singleComment.comment],
+  });
+});
+
+test('Tags example matches the distinct sorted tag fixture', () => {
+  assert.deepEqual(jsonExampleFor('Tags'), {
+    tags: ['dragons', 'laravel', 'training'],
+  });
+});
+
+test('Errors examples use public errors.body messages only', () => {
+  const errorsSection = markdownSection('Errors');
+
+  assert.match(errorsSection, /"body": \[\s+"Unauthenticated\."\s+\]/);
+  assert.match(errorsSection, /"body": \[\s+"title is required",\s+"body is required"\s+\]/);
+  assert.doesNotMatch(errorsSection, /secret|token=|\.env|SELECT \*/i);
+});
+
+test('Response contract examples do not contain JWT-looking token values', () => {
+  const responseContracts = markdownSection('Response Contracts', 2);
+
+  for (const value of stringValuesInJsonCodeBlocks(responseContracts)) {
+    assert.doesNotMatch(value, /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+  }
+});
+
+function jsonExampleFor(heading) {
+  const section = markdownSection(heading);
+  const jsonBlock = section.match(/```json\n([\s\S]*?)\n```/);
+
+  assert.ok(jsonBlock, `Missing JSON example for ${heading}`);
+
+  return JSON.parse(jsonBlock[1]);
+}
+
+function markdownSection(heading, level = 3) {
+  const hashes = '#'.repeat(level);
+  const nextHeading = new RegExp(`\\n#{1,${level}} `);
+  const sectionStart = apiRequirements.indexOf(`${hashes} ${heading}\n`);
+
+  assert.notEqual(sectionStart, -1, `Missing ${hashes} ${heading} section`);
+
+  const bodyStart = sectionStart + `${hashes} ${heading}\n`.length;
+  const remaining = apiRequirements.slice(bodyStart);
+  const nextHeadingMatch = remaining.match(nextHeading);
+
+  return nextHeadingMatch === null
+    ? remaining
+    : remaining.slice(0, nextHeadingMatch.index);
+}
+
+function stringValuesInJsonCodeBlocks(markdown) {
+  const values = [];
+  const jsonBlocks = markdown.matchAll(/```json\n([\s\S]*?)\n```/g);
+
+  for (const [, json] of jsonBlocks) {
+    collectStringValues(JSON.parse(json), values);
+  }
+
+  return values;
+}
+
+function collectStringValues(value, values) {
+  if (typeof value === 'string') {
+    values.push(value);
+
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectStringValues(item, values);
+    }
+
+    return;
+  }
+
+  if (value !== null && typeof value === 'object') {
+    for (const item of Object.values(value)) {
+      collectStringValues(item, values);
+    }
+  }
+}


### PR DESCRIPTION
# 概要

- `docs/api-requirements.md` の API contract examples を実装済み Resource / Feature test fixture に合わせて更新
- `docs/api-contract-coverage.md` の Comment / Tag API coverage を現行テストに追従
- docs examples の回帰検出用に `pnpm test:docs` を追加

# 関連Issue

Closes #80

Epic: #57

# 修正ファイルの説明

## Docs

- `docs/api-requirements.md`
  - User / Profile / Article / Comment / Tags / Errors の response examples を実装済みレスポンスへ追従
  - token は `<jwt-token>` placeholder にし、JWT 風の具体値を docs example から除去
  - nullable な `bio` / `image`、Article list の `body` 非含有、Tag の distinct sorted list を明示
- `docs/api-contract-coverage.md`
  - Comment API と Tag API を未実装 Gap から Covered へ更新
  - 対応する Feature test file と negative coverage を追記

## Tests

- `tests/docs/api-contract-examples.test.mjs`
  - `docs/api-requirements.md` の Response Contracts JSON examples を検査
  - `user.token` の placeholder、nullable profile fields、Article / Comment / Tags / Errors examples のズレを検出
- `package.json`
  - `pnpm test:docs` script を追加

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| ドキュメント変更あり | API contract examples の回帰検出 | `pnpm test:docs` | すべて成功する | 成功 |
| ドキュメント変更あり | Markdown と空白確認 | `git diff --check` | 空白エラーがない | 成功 |
| バックエンド実装変更なし | Backend test | 実装コード変更なしのため未実施 | 変更対象外であること | 未実施 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: docs examples が実装済み API response / frontend が参照する response shape と矛盾していないか
