### PR TITLE
[#74]: Article Editorを実装

### DIFF
--- a/frontend/src/app/routes/__tests__/router.test.tsx
+++ b/frontend/src/app/routes/__tests__/router.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactElement } from 'react';
 import { RouterProvider } from 'react-router-dom';
@@ -61,6 +61,13 @@ function renderRoute({
   );
 }
 
+async function waitForHomeRequestsToSettle(): Promise<void> {
+  await waitFor(() => {
+    expect(screen.queryByText('Loading articles...')).not.toBeInTheDocument();
+    expect(screen.queryByText('Loading tags...')).not.toBeInTheDocument();
+  });
+}
+
 describe('アプリルーター', () => {
   beforeEach(() => {
     window.localStorage.clear();
@@ -76,6 +83,20 @@ describe('アプリルーター', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('/settings')).toBeInTheDocument();
   });
+
+  it.each(['/editor', '/editor/existing-article'])(
+    '未認証ユーザーを%sからreturn path付きログインへ遷移する',
+    async (initialPath) => {
+      const { render } = await import('@testing-library/react');
+
+      render(renderRoute({ initialPath }));
+
+      expect(
+        await screen.findByRole('heading', { name: 'Sign in' }),
+      ).toBeInTheDocument();
+      expect(screen.getByText(initialPath)).toBeInTheDocument();
+    },
+  );
 
   it('ログイン後にreturn pathへ復帰する', async () => {
     const user = userEvent.setup();
@@ -112,6 +133,7 @@ describe('アプリルーター', () => {
     expect(
       await screen.findByRole('heading', { name: 'Global Feed' }),
     ).toBeInTheDocument();
+    await waitForHomeRequestsToSettle();
   });
 
   it('認証済みユーザーをゲスト専用ルートからリダイレクトする', async () => {
@@ -120,8 +142,9 @@ describe('アプリルーター', () => {
     render(renderRoute({ initialPath: '/login', initialUser: DEMO_USER }));
 
     expect(
-      screen.getByRole('heading', { name: 'Global Feed' }),
+      await screen.findByRole('heading', { name: 'Global Feed' }),
     ).toBeInTheDocument();
+    await waitForHomeRequestsToSettle();
   });
 
   it('未知のルートではnot foundを表示する', async () => {
@@ -213,5 +236,6 @@ describe('アプリルーター', () => {
     expect(
       await screen.findByRole('heading', { name: 'Global Feed' }),
     ).toBeInTheDocument();
+    await waitForHomeRequestsToSettle();
   });
 });

--- a/frontend/src/app/routes/pages/EditorPage.tsx
+++ b/frontend/src/app/routes/pages/EditorPage.tsx
@@ -1,36 +1,29 @@
 import { type ReactElement } from 'react';
 import { useParams } from 'react-router-dom';
+import { useAuth } from '@/app/providers/useAuth';
+import { ArticleEditor } from '@/features/article';
 
 export function EditorPage(): ReactElement {
   const { slug } = useParams();
-  const heading = slug ? 'Edit Article' : 'New Article';
+  const { user } = useAuth();
+
+  if (user === null) {
+    return (
+      <main className="page page--narrow">
+        <section className="editorial-panel" aria-labelledby="editor-title">
+          <h1 id="editor-title">{slug === undefined ? 'New Article' : 'Edit Article'}</h1>
+        </section>
+      </main>
+    );
+  }
 
   return (
     <main className="page page--narrow">
-      <section className="editorial-panel" aria-labelledby="editor-title">
-        <h1 id="editor-title">{heading}</h1>
-        <form className="form-stack">
-          <label>
-            <span>Title</span>
-            <input placeholder="Article title" type="text" />
-          </label>
-          <label>
-            <span>Description</span>
-            <input placeholder="What is this article about?" type="text" />
-          </label>
-          <label>
-            <span>Body</span>
-            <textarea placeholder="Write your article" rows={10} />
-          </label>
-          <label>
-            <span>Tags</span>
-            <input placeholder="Enter tags" type="text" />
-          </label>
-          <button className="primary-action" type="button">
-            Publish Article
-          </button>
-        </form>
-      </section>
+      <ArticleEditor
+        currentUsername={user.username}
+        key={slug ?? 'new'}
+        slug={slug}
+      />
     </main>
   );
 }

--- a/frontend/src/features/article/__tests__/ArticleEditor.test.tsx
+++ b/frontend/src/features/article/__tests__/ArticleEditor.test.tsx
@@ -1,0 +1,244 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ReactElement } from 'react';
+import { MemoryRouter, Route, Routes, useParams } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { ApiError } from '@/lib/apiError';
+import { ArticleEditor } from '../components/ArticleEditor';
+import type { ArticleEditorApi, ArticleEditorArticle } from '../types/editor';
+
+const OWN_ARTICLE: ArticleEditorArticle = {
+  author: {
+    username: 'jake',
+  },
+  body: 'Existing body',
+  description: 'Existing summary',
+  slug: 'existing-article',
+  tagList: ['react', 'tdd'],
+  title: 'Existing article',
+};
+
+const CREATED_ARTICLE: ArticleEditorArticle = {
+  ...OWN_ARTICLE,
+  body: 'Created body',
+  description: 'Created summary',
+  slug: 'created-article',
+  tagList: ['react', 'testing'],
+  title: 'Created article',
+};
+
+function createEditorApi(
+  overrides: Partial<ArticleEditorApi> = {},
+): ArticleEditorApi {
+  return {
+    createArticle: vi.fn().mockResolvedValue(CREATED_ARTICLE),
+    getArticle: vi.fn().mockResolvedValue(OWN_ARTICLE),
+    updateArticle: vi.fn().mockResolvedValue({
+      ...OWN_ARTICLE,
+      slug: 'updated-article',
+    }),
+    ...overrides,
+  };
+}
+
+function renderEditor({
+  api = createEditorApi(),
+  currentUsername = 'jake',
+  initialPath = '/editor',
+  slug,
+}: {
+  api?: ArticleEditorApi;
+  currentUsername?: string;
+  initialPath?: string;
+  slug?: string;
+}): void {
+  const editorPath = slug === undefined ? '/editor' : '/editor/:slug';
+
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route
+          element={
+            <ArticleEditor
+              currentUsername={currentUsername}
+              editorApi={api}
+              slug={slug}
+            />
+          }
+          path={editorPath}
+        />
+        <Route element={<ArticleDestination />} path="/article/:slug" />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function ArticleDestination(): ReactElement {
+  const { slug } = useParams();
+
+  return <h1>Article detail: {slug}</h1>;
+}
+
+describe('ArticleEditor', () => {
+  it('create formを送信し成功後にArticle Detailへ遷移する', async () => {
+    const user = userEvent.setup();
+    const api = createEditorApi();
+
+    renderEditor({ api });
+
+    await user.type(screen.getByLabelText('Title'), 'Created article');
+    await user.type(screen.getByLabelText('Description'), 'Created summary');
+    await user.type(screen.getByLabelText('Body'), 'Created body');
+    await user.type(screen.getByLabelText('Tags'), 'react, testing');
+    await user.click(screen.getByRole('button', { name: 'Publish Article' }));
+
+    expect(api.createArticle).toHaveBeenCalledWith({
+      body: 'Created body',
+      description: 'Created summary',
+      tagList: ['react', 'testing'],
+      title: 'Created article',
+    });
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Article detail: created-article',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('edit formへ既存Articleを読み込み更新成功後にArticle Detailへ遷移する', async () => {
+    const user = userEvent.setup();
+    const api = createEditorApi();
+
+    renderEditor({
+      api,
+      initialPath: '/editor/existing-article',
+      slug: 'existing-article',
+    });
+
+    expect(await screen.findByLabelText('Title')).toHaveValue('Existing article');
+    expect(screen.getByLabelText('Tags')).toHaveValue('react, tdd');
+
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'Updated article');
+    await user.click(screen.getByRole('button', { name: 'Update Article' }));
+
+    expect(api.updateArticle).toHaveBeenCalledWith('existing-article', {
+      body: 'Existing body',
+      description: 'Existing summary',
+      tagList: ['react', 'tdd'],
+      title: 'Updated article',
+    });
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Article detail: updated-article',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('submit中はbuttonをdisabledにして二重送信を防止する', async () => {
+    const user = userEvent.setup();
+    let resolveSubmit: (article: ArticleEditorArticle) => void = () => {};
+    const submitPromise = new Promise<ArticleEditorArticle>((resolve) => {
+      resolveSubmit = resolve;
+    });
+    const api = createEditorApi({
+      createArticle: vi.fn().mockReturnValue(submitPromise),
+    });
+
+    renderEditor({ api });
+
+    await user.type(screen.getByLabelText('Title'), 'Created article');
+    await user.type(screen.getByLabelText('Description'), 'Created summary');
+    await user.type(screen.getByLabelText('Body'), 'Created body');
+    await user.click(screen.getByRole('button', { name: 'Publish Article' }));
+
+    expect(
+      screen.getByRole('button', { name: 'Publishing...' }),
+    ).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: 'Publishing...' }));
+    expect(api.createArticle).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      resolveSubmit(CREATED_ARTICLE);
+      await submitPromise;
+    });
+  });
+
+  it('validation errorを表示し入力値を保持する', async () => {
+    const user = userEvent.setup();
+    const api = createEditorApi({
+      createArticle: vi.fn().mockRejectedValue(
+        new ApiError('title is too long', {
+          bodyErrors: ['title is too long'],
+          kind: 'validation',
+          status: 422,
+        }),
+      ),
+    });
+
+    renderEditor({ api });
+
+    await user.type(screen.getByLabelText('Title'), 'Draft title');
+    await user.type(screen.getByLabelText('Description'), 'Draft summary');
+    await user.type(screen.getByLabelText('Body'), 'Draft body');
+    await user.click(screen.getByRole('button', { name: 'Publish Article' }));
+
+    expect(await screen.findByText('title is too long')).toBeInTheDocument();
+    expect(screen.getByLabelText('Title')).toHaveAccessibleDescription(
+      'title is too long',
+    );
+    expect(screen.getByLabelText('Title')).toHaveValue('Draft title');
+    expect(screen.getByLabelText('Description')).toHaveValue('Draft summary');
+    expect(screen.getByLabelText('Body')).toHaveValue('Draft body');
+  });
+
+  it('required validationはAPIを呼ばずfield errorを表示する', async () => {
+    const user = userEvent.setup();
+    const api = createEditorApi();
+
+    renderEditor({ api });
+
+    await user.click(screen.getByRole('button', { name: 'Publish Article' }));
+
+    expect(api.createArticle).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Title')).toHaveAccessibleDescription(
+      'title is required',
+    );
+    expect(screen.getByLabelText('Description')).toHaveAccessibleDescription(
+      'description is required',
+    );
+    expect(screen.getByLabelText('Body')).toHaveAccessibleDescription(
+      'body is required',
+    );
+  });
+
+  it('non-author editはforbidden stateを表示し更新を防ぐ', async () => {
+    const api = createEditorApi({
+      getArticle: vi.fn().mockResolvedValue({
+        ...OWN_ARTICLE,
+        author: {
+          username: 'other-user',
+        },
+      }),
+    });
+
+    renderEditor({
+      api,
+      currentUsername: 'jake',
+      initialPath: '/editor/existing-article',
+      slug: 'existing-article',
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Forbidden' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('You cannot edit this article.')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Update Article' }),
+    ).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(api.updateArticle).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/features/article/__tests__/articleEditorApi.test.ts
+++ b/frontend/src/features/article/__tests__/articleEditorApi.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ApiClient } from '@/lib/apiClient';
+import {
+  createArticleForEditor,
+  getArticleForEditor,
+  updateArticleForEditor,
+} from '../api/editorApi';
+
+function createClient(): ApiClient {
+  return {
+    delete: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    request: vi.fn(),
+  };
+}
+
+const ARTICLE_RESPONSE = {
+  article: {
+    author: {
+      bio: null,
+      following: false,
+      image: null,
+      username: 'jake',
+    },
+    body: 'You have to believe',
+    createdAt: '2026-05-01T00:00:00.000Z',
+    description: 'Ever wonder how?',
+    favorited: false,
+    favoritesCount: 0,
+    slug: 'how-to-train-your-dragon',
+    tagList: ['dragons', 'training'],
+    title: 'How to train your dragon',
+    updatedAt: '2026-05-01T00:00:00.000Z',
+  },
+};
+
+describe('Article Editor API', () => {
+  it('edit用Articleを取得してfrontend modelへ変換する', async () => {
+    const client = createClient();
+    vi.mocked(client.get).mockResolvedValue(ARTICLE_RESPONSE);
+
+    const article = await getArticleForEditor('how-to-train-your-dragon', client);
+
+    expect(client.get).toHaveBeenCalledWith(
+      '/api/articles/how-to-train-your-dragon',
+    );
+    expect(article).toEqual({
+      author: {
+        username: 'jake',
+      },
+      body: 'You have to believe',
+      description: 'Ever wonder how?',
+      slug: 'how-to-train-your-dragon',
+      tagList: ['dragons', 'training'],
+      title: 'How to train your dragon',
+    });
+  });
+
+  it('create用payloadをRealWorld形式で送信する', async () => {
+    const client = createClient();
+    vi.mocked(client.post).mockResolvedValue(ARTICLE_RESPONSE);
+
+    await createArticleForEditor(
+      {
+        body: 'You have to believe',
+        description: 'Ever wonder how?',
+        tagList: ['dragons', 'training'],
+        title: 'How to train your dragon',
+      },
+      client,
+    );
+
+    expect(client.post).toHaveBeenCalledWith('/api/articles', {
+      article: {
+        body: 'You have to believe',
+        description: 'Ever wonder how?',
+        tagList: ['dragons', 'training'],
+        title: 'How to train your dragon',
+      },
+    });
+  });
+
+  it('update用payloadを対象slugへ送信する', async () => {
+    const client = createClient();
+    vi.mocked(client.put).mockResolvedValue(ARTICLE_RESPONSE);
+
+    await updateArticleForEditor(
+      'how-to-train-your-dragon',
+      {
+        body: 'Updated body',
+        description: 'Updated summary',
+        tagList: [],
+        title: 'Did you train your dragon?',
+      },
+      client,
+    );
+
+    expect(client.put).toHaveBeenCalledWith(
+      '/api/articles/how-to-train-your-dragon',
+      {
+        article: {
+          body: 'Updated body',
+          description: 'Updated summary',
+          tagList: [],
+          title: 'Did you train your dragon?',
+        },
+      },
+    );
+  });
+});

--- a/frontend/src/features/article/api/editorApi.ts
+++ b/frontend/src/features/article/api/editorApi.ts
@@ -1,0 +1,102 @@
+import { apiClient, type ApiClient } from '@/lib/apiClient';
+import type {
+  ArticleEditorApi,
+  ArticleEditorArticle,
+  ArticleEditorInput,
+  ArticleEditorLoadOptions,
+} from '../types/editor';
+
+interface ArticleEditorResponse {
+  article: {
+    author: {
+      username: string;
+    };
+    body: string;
+    description: string;
+    slug: string;
+    tagList: string[];
+    title: string;
+  };
+}
+
+/**
+ * Editor edit flowで既存Articleを取得し、フォーム用modelへ変換する。
+ */
+export async function getArticleForEditor(
+  slug: string,
+  client: ApiClient = apiClient,
+  options: ArticleEditorLoadOptions = {},
+): Promise<ArticleEditorArticle> {
+  const path = buildArticleEditorPath(slug);
+  const response =
+    options.signal === undefined
+      ? await client.get<ArticleEditorResponse>(path)
+      : await client.get<ArticleEditorResponse>(path, { signal: options.signal });
+
+  return mapArticleEditorResponse(response);
+}
+
+/**
+ * Editor create flowの入力をRealWorld形式でBFFへ送信する。
+ */
+export async function createArticleForEditor(
+  input: ArticleEditorInput,
+  client: ApiClient = apiClient,
+): Promise<ArticleEditorArticle> {
+  const response = await client.post<ArticleEditorResponse>('/api/articles', {
+    article: input,
+  });
+
+  return mapArticleEditorResponse(response);
+}
+
+/**
+ * Editor edit flowの入力を対象Article slugへ送信する。
+ */
+export async function updateArticleForEditor(
+  slug: string,
+  input: ArticleEditorInput,
+  client: ApiClient = apiClient,
+): Promise<ArticleEditorArticle> {
+  const response = await client.put<ArticleEditorResponse>(
+    buildArticleEditorPath(slug),
+    {
+      article: input,
+    },
+  );
+
+  return mapArticleEditorResponse(response);
+}
+
+export const editorApi: ArticleEditorApi = {
+  createArticle: (input: ArticleEditorInput): Promise<ArticleEditorArticle> =>
+    createArticleForEditor(input),
+  getArticle: (
+    slug: string,
+    options?: ArticleEditorLoadOptions,
+  ): Promise<ArticleEditorArticle> =>
+    getArticleForEditor(slug, apiClient, options),
+  updateArticle: (
+    slug: string,
+    input: ArticleEditorInput,
+  ): Promise<ArticleEditorArticle> => updateArticleForEditor(slug, input),
+};
+
+function mapArticleEditorResponse(
+  response: ArticleEditorResponse,
+): ArticleEditorArticle {
+  return {
+    author: {
+      username: response.article.author.username,
+    },
+    body: response.article.body,
+    description: response.article.description,
+    slug: response.article.slug,
+    tagList: response.article.tagList,
+    title: response.article.title,
+  };
+}
+
+function buildArticleEditorPath(slug: string): string {
+  return `/api/articles/${encodeURIComponent(slug)}`;
+}

--- a/frontend/src/features/article/components/ArticleEditor.tsx
+++ b/frontend/src/features/article/components/ArticleEditor.tsx
@@ -1,0 +1,493 @@
+import {
+  type FormEvent,
+  type ReactElement,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { useNavigate } from 'react-router-dom';
+import { isApiError } from '@/lib/apiError';
+import { editorApi as defaultEditorApi } from '../api/editorApi';
+import type {
+  ArticleEditorApi,
+  ArticleEditorArticle,
+  ArticleEditorInput,
+} from '../types/editor';
+
+interface ArticleEditorProps {
+  currentUsername: string;
+  editorApi?: ArticleEditorApi;
+  slug?: string;
+}
+
+interface ArticleEditorFields {
+  body: string;
+  description: string;
+  tags: string;
+  title: string;
+}
+
+const ARTICLE_EDITOR_FIELDS = [
+  'body',
+  'description',
+  'tagList',
+  'title',
+] as const;
+
+type ArticleEditorField = (typeof ARTICLE_EDITOR_FIELDS)[number];
+type ArticleEditorFieldErrors = Partial<Record<ArticleEditorField, string[]>>;
+
+interface ArticleEditorErrors {
+  fields: ArticleEditorFieldErrors;
+  global: string[];
+}
+
+type EditorStatus = 'error' | 'forbidden' | 'loading' | 'ready';
+
+/**
+ * Article create/edit flowの取得、権限表示、入力、submit状態を所有する。
+ */
+export function ArticleEditor({
+  currentUsername,
+  editorApi = defaultEditorApi,
+  slug,
+}: ArticleEditorProps): ReactElement {
+  const navigate = useNavigate();
+  const [errors, setErrors] = useState<ArticleEditorErrors>(
+    createEmptyEditorErrors,
+  );
+  const [fields, setFields] = useState<ArticleEditorFields>(
+    createEmptyEditorFields,
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [status, setStatus] = useState<EditorStatus>(
+    slug === undefined ? 'ready' : 'loading',
+  );
+  const isMountedRef = useRef(true);
+  const isSubmittingRef = useRef(false);
+  const isEditMode = slug !== undefined;
+  const heading = getEditorHeading(status, isEditMode);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (slug === undefined) {
+      return;
+    }
+
+    const articleSlug = slug;
+    const controller = new AbortController();
+    let isCurrent = true;
+
+    async function loadArticle(): Promise<void> {
+      setErrors(createEmptyEditorErrors());
+      setStatus('loading');
+
+      try {
+        const article = await editorApi.getArticle(articleSlug, {
+          signal: controller.signal,
+        });
+
+        if (!isCurrent) {
+          return;
+        }
+
+        if (article.author.username !== currentUsername) {
+          setStatus('forbidden');
+          return;
+        }
+
+        setFields(createFieldsFromArticle(article));
+        setStatus('ready');
+      } catch (error: unknown) {
+        if (!isCurrent || isAbortError(error)) {
+          return;
+        }
+
+        setStatus(isApiError(error) && error.kind === 'forbidden' ? 'forbidden' : 'error');
+      }
+    }
+
+    void loadArticle();
+
+    return () => {
+      isCurrent = false;
+      controller.abort();
+    };
+  }, [currentUsername, editorApi, slug]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+
+    if (isSubmittingRef.current || status !== 'ready') {
+      return;
+    }
+
+    const input = createArticleEditorInput(fields);
+    const validationErrors = validateArticleEditorInput(input);
+
+    if (hasFieldErrors(validationErrors)) {
+      setErrors({
+        fields: validationErrors,
+        global: [],
+      });
+      return;
+    }
+
+    setErrors(createEmptyEditorErrors());
+    isSubmittingRef.current = true;
+    setIsSubmitting(true);
+
+    try {
+      const article = isEditMode
+        ? await editorApi.updateArticle(slug, input)
+        : await editorApi.createArticle(input);
+
+      navigate(`/article/${article.slug}`);
+    } catch (error: unknown) {
+      if (isApiError(error) && error.kind === 'forbidden') {
+        setStatus('forbidden');
+        return;
+      }
+
+      setErrors(createEditorErrorsFromMessages(getEditorFormErrors(error)));
+    } finally {
+      isSubmittingRef.current = false;
+
+      if (isMountedRef.current) {
+        setIsSubmitting(false);
+      }
+    }
+  }
+
+  if (status === 'loading') {
+    return (
+      <section className="editorial-panel" aria-labelledby="editor-title">
+        <h1 id="editor-title">{heading}</h1>
+        <p className="state-message">Loading article...</p>
+      </section>
+    );
+  }
+
+  if (status === 'forbidden') {
+    return (
+      <section className="editorial-panel" aria-labelledby="editor-title">
+        <h1 id="editor-title">Forbidden</h1>
+        <p className="state-message state-message--error">
+          You cannot edit this article.
+        </p>
+      </section>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <section className="editorial-panel" aria-labelledby="editor-title">
+        <h1 id="editor-title">{heading}</h1>
+        <p className="state-message state-message--error">
+          Article could not be loaded.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="editorial-panel" aria-labelledby="editor-title">
+      <h1 id="editor-title">{heading}</h1>
+      <EditorForm
+        errors={errors}
+        fields={fields}
+        isEditMode={isEditMode}
+        isSubmitting={isSubmitting}
+        onChange={setFields}
+        onSubmit={handleSubmit}
+      />
+    </section>
+  );
+}
+
+interface EditorFormProps {
+  errors: ArticleEditorErrors;
+  fields: ArticleEditorFields;
+  isEditMode: boolean;
+  isSubmitting: boolean;
+  onChange: (fields: ArticleEditorFields) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}
+
+function EditorForm({
+  errors,
+  fields,
+  isEditMode,
+  isSubmitting,
+  onChange,
+  onSubmit,
+}: EditorFormProps): ReactElement {
+  const submitLabel = getSubmitLabel(isEditMode, isSubmitting);
+
+  return (
+    <form className="form-stack" noValidate onSubmit={onSubmit}>
+      <FormErrorList errors={errors.global} />
+      <div className="form-field">
+        <label htmlFor="editor-title-input">Title</label>
+        <input
+          aria-describedby={getFieldDescribedBy('title', errors.fields)}
+          aria-invalid={hasMessages(errors.fields.title) ? true : undefined}
+          id="editor-title-input"
+          onChange={(event) =>
+            onChange({ ...fields, title: event.currentTarget.value })
+          }
+          placeholder="Article title"
+          type="text"
+          value={fields.title}
+        />
+        <FieldError errors={errors.fields.title} id={getFieldErrorId('title')} />
+      </div>
+      <div className="form-field">
+        <label htmlFor="editor-description">Description</label>
+        <input
+          aria-describedby={getFieldDescribedBy('description', errors.fields)}
+          aria-invalid={hasMessages(errors.fields.description) ? true : undefined}
+          id="editor-description"
+          onChange={(event) =>
+            onChange({ ...fields, description: event.currentTarget.value })
+          }
+          placeholder="What is this article about?"
+          type="text"
+          value={fields.description}
+        />
+        <FieldError
+          errors={errors.fields.description}
+          id={getFieldErrorId('description')}
+        />
+      </div>
+      <div className="form-field">
+        <label htmlFor="editor-body">Body</label>
+        <textarea
+          aria-describedby={getFieldDescribedBy('body', errors.fields)}
+          aria-invalid={hasMessages(errors.fields.body) ? true : undefined}
+          id="editor-body"
+          onChange={(event) =>
+            onChange({ ...fields, body: event.currentTarget.value })
+          }
+          placeholder="Write your article"
+          rows={10}
+          value={fields.body}
+        />
+        <FieldError errors={errors.fields.body} id={getFieldErrorId('body')} />
+      </div>
+      <div className="form-field">
+        <label htmlFor="editor-tags">Tags</label>
+        <input
+          aria-describedby={getFieldDescribedBy('tagList', errors.fields)}
+          aria-invalid={hasMessages(errors.fields.tagList) ? true : undefined}
+          id="editor-tags"
+          onChange={(event) =>
+            onChange({ ...fields, tags: event.currentTarget.value })
+          }
+          placeholder="Enter tags separated by commas"
+          type="text"
+          value={fields.tags}
+        />
+        <FieldError
+          errors={errors.fields.tagList}
+          id={getFieldErrorId('tagList')}
+        />
+      </div>
+      <div className="form-actions">
+        <button className="primary-action" disabled={isSubmitting} type="submit">
+          {submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function getEditorHeading(status: EditorStatus, isEditMode: boolean): string {
+  if (status === 'forbidden') {
+    return 'Forbidden';
+  }
+
+  return isEditMode ? 'Edit Article' : 'New Article';
+}
+
+function getSubmitLabel(isEditMode: boolean, isSubmitting: boolean): string {
+  if (isSubmitting) {
+    return isEditMode ? 'Updating...' : 'Publishing...';
+  }
+
+  return isEditMode ? 'Update Article' : 'Publish Article';
+}
+
+function createEmptyEditorFields(): ArticleEditorFields {
+  return {
+    body: '',
+    description: '',
+    tags: '',
+    title: '',
+  };
+}
+
+function createFieldsFromArticle(
+  article: ArticleEditorArticle,
+): ArticleEditorFields {
+  return {
+    body: article.body,
+    description: article.description,
+    tags: article.tagList.join(', '),
+    title: article.title,
+  };
+}
+
+function createArticleEditorInput(
+  fields: ArticleEditorFields,
+): ArticleEditorInput {
+  return {
+    body: fields.body.trim(),
+    description: fields.description.trim(),
+    tagList: parseTagList(fields.tags),
+    title: fields.title.trim(),
+  };
+}
+
+function parseTagList(tags: string): string[] {
+  return tags
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter((tag) => tag !== '');
+}
+
+function validateArticleEditorInput(
+  input: ArticleEditorInput,
+): ArticleEditorFieldErrors {
+  const errors: ArticleEditorFieldErrors = {};
+
+  if (input.title === '') {
+    errors.title = ['title is required'];
+  }
+
+  if (input.description === '') {
+    errors.description = ['description is required'];
+  }
+
+  if (input.body === '') {
+    errors.body = ['body is required'];
+  }
+
+  return errors;
+}
+
+function createEmptyEditorErrors(): ArticleEditorErrors {
+  return {
+    fields: {},
+    global: [],
+  };
+}
+
+function createEditorErrorsFromMessages(
+  messages: string[],
+): ArticleEditorErrors {
+  const errors = createEmptyEditorErrors();
+
+  for (const message of messages) {
+    const field = findArticleEditorField(message);
+
+    if (field === null) {
+      errors.global.push(message);
+      continue;
+    }
+
+    errors.fields[field] = [...(errors.fields[field] ?? []), message];
+  }
+
+  return errors;
+}
+
+function findArticleEditorField(message: string): ArticleEditorField | null {
+  const normalizedMessage = message.toLowerCase();
+
+  return (
+    ARTICLE_EDITOR_FIELDS.find((field) => {
+      const normalizedField = field.toLowerCase();
+
+      return (
+        normalizedMessage.startsWith(`${normalizedField} `) ||
+        normalizedMessage.startsWith(`article.${normalizedField} `)
+      );
+    }) ?? null
+  );
+}
+
+function getEditorFormErrors(error: unknown): string[] {
+  if (isApiError(error)) {
+    return error.bodyErrors.length > 0 ? error.bodyErrors : [error.message];
+  }
+
+  if (error instanceof Error) {
+    return [error.message];
+  }
+
+  return ['Something went wrong. Please try again.'];
+}
+
+function hasFieldErrors(errors: ArticleEditorFieldErrors): boolean {
+  return Object.values(errors).some((messages) => hasMessages(messages));
+}
+
+function hasMessages(messages: string[] | undefined): messages is string[] {
+  return messages !== undefined && messages.length > 0;
+}
+
+function getFieldErrorId(field: ArticleEditorField): string {
+  return `editor-${field.toLowerCase()}-error`;
+}
+
+function getFieldDescribedBy(
+  field: ArticleEditorField,
+  errors: ArticleEditorFieldErrors,
+): string | undefined {
+  return hasMessages(errors[field]) ? getFieldErrorId(field) : undefined;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
+interface FormErrorListProps {
+  errors: string[];
+}
+
+function FormErrorList({ errors }: FormErrorListProps): ReactElement | null {
+  if (errors.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className="form-errors" role="alert">
+      {errors.map((error) => (
+        <li key={error}>{error}</li>
+      ))}
+    </ul>
+  );
+}
+
+interface FieldErrorProps {
+  errors?: string[];
+  id: string;
+}
+
+function FieldError({ errors, id }: FieldErrorProps): ReactElement | null {
+  if (!hasMessages(errors)) {
+    return null;
+  }
+
+  return (
+    <p className="field-error" id={id}>
+      {errors.join(' ')}
+    </p>
+  );
+}

--- a/frontend/src/features/article/index.ts
+++ b/frontend/src/features/article/index.ts
@@ -5,6 +5,13 @@ export {
   mapArticleListResponse,
   type ArticleListResponse,
 } from './api/articleApi';
+export {
+  createArticleForEditor,
+  editorApi,
+  getArticleForEditor,
+  updateArticleForEditor,
+} from './api/editorApi';
+export { ArticleEditor } from './components/ArticleEditor';
 export { ArticleList } from './components/ArticleList';
 export type {
   ArticleAuthor,
@@ -14,3 +21,9 @@ export type {
   ArticleSummary,
   LoadArticles,
 } from './types/article';
+export type {
+  ArticleEditorApi,
+  ArticleEditorArticle,
+  ArticleEditorInput,
+  ArticleEditorLoadOptions,
+} from './types/editor';

--- a/frontend/src/features/article/types/editor.ts
+++ b/frontend/src/features/article/types/editor.ts
@@ -1,0 +1,35 @@
+export interface ArticleEditorAuthor {
+  username: string;
+}
+
+export interface ArticleEditorArticle {
+  author: ArticleEditorAuthor;
+  body: string;
+  description: string;
+  slug: string;
+  tagList: string[];
+  title: string;
+}
+
+export interface ArticleEditorInput {
+  body: string;
+  description: string;
+  tagList: string[];
+  title: string;
+}
+
+export interface ArticleEditorLoadOptions {
+  signal?: AbortSignal;
+}
+
+export interface ArticleEditorApi {
+  createArticle: (input: ArticleEditorInput) => Promise<ArticleEditorArticle>;
+  getArticle: (
+    slug: string,
+    options?: ArticleEditorLoadOptions,
+  ) => Promise<ArticleEditorArticle>;
+  updateArticle: (
+    slug: string,
+    input: ArticleEditorInput,
+  ) => Promise<ArticleEditorArticle>;
+}


### PR DESCRIPTION
# 概要

- `features/article` にEditor専用API/type/componentを追加
- `/editor` のcreate flowと `/editor/:slug` のedit flowを接続
- non-author forbidden、validation error保持、submit中disabled、成功後 `/article/:slug` 遷移をテスト
- #73 と並列になるArticle Detail / Favorite / Delete UIは変更対象外

# 関連Issue

Closes #74

Epic: #58

# 修正ファイルの説明

## Frontend

- `frontend/src/features/article/api/editorApi.ts`
  - Editor用途に閉じたArticle取得・作成・更新API helperを追加
  - RealWorld形式の `{ article: ... }` payloadとresponse mappingをfeature内へ閉じるため
- `frontend/src/features/article/components/ArticleEditor.tsx`
  - create/edit form、load/forbidden/error/submit状態、field/global error表示を追加
  - 入力保持、二重submit防止、non-author更新防止を画面側でも担保するため
- `frontend/src/app/routes/pages/EditorPage.tsx`
  - current userとslugをArticleEditorへ渡すpage構成へ変更
  - Pagesにbusiness logicを持たせないため
- `frontend/src/features/article/__tests__/*`
  - Editor API、create/edit submit、validation、forbidden、未認証redirectのテストを追加
  - Issue #74 の受け入れ条件をユーザー視点で確認するため

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| フロントエンド変更あり | targeted Vitest | `pnpm exec vitest run --reporter=verbose src/features/article/__tests__/articleEditorApi.test.ts src/features/article/__tests__/ArticleEditor.test.tsx src/app/routes/__tests__/router.test.tsx` | 成功 | 成功 |
| フロントエンド変更あり | 型チェック | `pnpm exec tsc -b --noEmit` | 成功 | 成功 |
| フロントエンド変更あり | 全テスト | `pnpm test` | 成功 | 成功 |
| フロントエンド変更あり | ESLint | `pnpm exec eslint .` | 成功 | 成功 |
| バックエンド変更なし | Backend検証 | 対象外 | 未実施理由を明示 | 対象外 |

# マージもしくはレビュー時の注意点

- buildが必要: なし
- migrateが必要: なし
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: #73 と並列のためArticle Detail / Favorite / Delete UIに触れていないこと
