### PR TITLE
[#73]: Article DetailとFavorite UIを実装

### DIFF
--- a/frontend/src/app/routes/__tests__/ArticleDetailPage.test.tsx
+++ b/frontend/src/app/routes/__tests__/ArticleDetailPage.test.tsx
@@ -1,0 +1,359 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement } from 'react';
+import { RouterProvider } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AppProviders } from '@/app/providers/AppProviders';
+import type { AuthApi, AuthUser } from '@/features/auth';
+import { ApiError } from '@/lib/apiError';
+import { createAppRouter } from '../router';
+
+const DEMO_USER: AuthUser = {
+  bio: null,
+  email: 'demo@example.com',
+  image: null,
+  username: 'demo-user',
+};
+
+const AUTHOR_USER: AuthUser = {
+  bio: 'Author bio',
+  email: 'author@example.com',
+  image: null,
+  username: 'article-author',
+};
+
+function createAuthApi(overrides: Partial<AuthApi> = {}): AuthApi {
+  return {
+    getCurrentUser: vi.fn().mockRejectedValue(
+      new ApiError('Unauthorized', {
+        bodyErrors: ['Unauthorized'],
+        kind: 'unauthorized',
+        status: 401,
+      }),
+    ),
+    login: vi.fn().mockResolvedValue(DEMO_USER),
+    logout: vi.fn().mockResolvedValue(undefined),
+    register: vi.fn().mockResolvedValue(DEMO_USER),
+    updateCurrentUser: vi.fn().mockResolvedValue(DEMO_USER),
+    ...overrides,
+  };
+}
+
+function renderArticleRoute({
+  initialPath,
+  initialUser = null,
+  routes,
+}: {
+  initialPath: string;
+  initialUser?: AuthUser | null;
+  routes: Record<string, unknown | unknown[]>;
+}): ReactElement {
+  vi.stubGlobal('fetch', createFetchMock(routes));
+
+  return (
+    <AppProviders authApi={createAuthApi()} initialUser={initialUser}>
+      <RouterProvider router={createAppRouter([initialPath])} />
+    </AppProviders>
+  );
+}
+
+describe('ArticleDetailPage', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('guestはArticle Detailとcomments listを閲覧でき、favorite操作ではloginへ誘導される', async () => {
+    const user = userEvent.setup();
+
+    render(
+      renderArticleRoute({
+        initialPath: '/article/guest-article',
+        routes: {
+          '/api/articles/guest-article': articleWrapper({
+            body: 'Guest readable article body.',
+            favoritesCount: 3,
+            slug: 'guest-article',
+            title: 'Guest readable article',
+          }),
+          '/api/articles/guest-article/comments': commentsWrapper([
+            commentResponse({
+              body: 'A public comment.',
+              id: 1,
+              username: 'reader',
+            }),
+          ]),
+        },
+      }),
+    );
+
+    expect(
+      await screen.findByRole('heading', { name: 'Guest readable article' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Guest readable article body.')).toBeInTheDocument();
+    expect(screen.getByText('A public comment.')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Favorite Article (3)' }));
+
+    expect(
+      await screen.findByRole('heading', { name: 'Sign in' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('/article/guest-article')).toBeInTheDocument();
+  });
+
+  it('authenticated non-authorはfavoriteとunfavoriteでcountを更新でき、author actionsは表示されない', async () => {
+    const user = userEvent.setup();
+
+    render(
+      renderArticleRoute({
+        initialPath: '/article/non-author-article',
+        initialUser: DEMO_USER,
+        routes: {
+          '/api/articles/non-author-article': articleWrapper({
+            favoritesCount: 3,
+            slug: 'non-author-article',
+            title: 'Non author article',
+          }),
+          '/api/articles/non-author-article/comments': commentsWrapper([]),
+          '/api/session/csrf': { csrfToken: 'csrf-token' },
+          'DELETE /api/articles/non-author-article/favorite': articleWrapper({
+            favorited: false,
+            favoritesCount: 3,
+            slug: 'non-author-article',
+            title: 'Non author article',
+          }),
+          'POST /api/articles/non-author-article/favorite': articleWrapper({
+            favorited: true,
+            favoritesCount: 4,
+            slug: 'non-author-article',
+            title: 'Non author article',
+          }),
+        },
+      }),
+    );
+
+    expect(
+      await screen.findByRole('heading', { name: 'Non author article' }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Favorite Article (3)' }));
+    expect(
+      await screen.findByRole('button', { name: 'Unfavorite Article (4)' }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Unfavorite Article (4)' }));
+    expect(
+      await screen.findByRole('button', { name: 'Favorite Article (3)' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Edit Article' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Delete Article' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('authorだけがedit/delete actionを使え、delete成功後はHomeへ遷移する', async () => {
+    const user = userEvent.setup();
+
+    render(
+      renderArticleRoute({
+        initialPath: '/article/author-article',
+        initialUser: AUTHOR_USER,
+        routes: {
+          '/api/articles/author-article': articleWrapper({
+            authorUsername: AUTHOR_USER.username,
+            slug: 'author-article',
+            title: 'Author article',
+          }),
+          '/api/articles/author-article/comments': commentsWrapper([]),
+          '/api/articles?limit=10&offset=0': {
+            articles: [],
+            articlesCount: 0,
+          },
+          '/api/session/csrf': { csrfToken: 'csrf-token' },
+          '/api/tags': { tags: [] },
+          'DELETE /api/articles/author-article': emptyResponse(),
+        },
+      }),
+    );
+
+    expect(
+      await screen.findByRole('heading', { name: 'Author article' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Edit Article' })).toHaveAttribute(
+      'href',
+      '/editor/author-article',
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Delete Article' }));
+
+    expect(
+      await screen.findByRole('heading', { name: 'Global Feed' }),
+    ).toBeInTheDocument();
+  });
+
+  it('404 slugはArticle Detail内でNot Found表示にする', async () => {
+    render(
+      renderArticleRoute({
+        initialPath: '/article/missing-article',
+        routes: {
+          '/api/articles/missing-article': jsonResponse(
+            {
+              errors: {
+                body: ['Not Found'],
+              },
+            },
+            404,
+          ),
+        },
+      }),
+    );
+
+    expect(
+      await screen.findByRole('heading', { name: 'Article not found' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('The article could not be found.')).toBeInTheDocument();
+  });
+});
+
+function articleWrapper({
+  authorUsername = 'article-author',
+  body = 'Article body.',
+  favorited = false,
+  favoritesCount = 0,
+  slug,
+  title,
+}: {
+  authorUsername?: string;
+  body?: string;
+  favorited?: boolean;
+  favoritesCount?: number;
+  slug: string;
+  title: string;
+}): unknown {
+  return {
+    article: {
+      author: {
+        bio: 'Author bio',
+        following: false,
+        image: null,
+        username: authorUsername,
+      },
+      body,
+      createdAt: '2026-05-06T00:00:00.000Z',
+      description: 'Article description',
+      favorited,
+      favoritesCount,
+      slug,
+      tagList: ['react', 'realworld'],
+      title,
+      updatedAt: '2026-05-07T00:00:00.000Z',
+    },
+  };
+}
+
+function commentsWrapper(comments: unknown[]): unknown {
+  return { comments };
+}
+
+function commentResponse({
+  body,
+  id,
+  username,
+}: {
+  body: string;
+  id: number;
+  username: string;
+}): unknown {
+  return {
+    author: {
+      bio: null,
+      following: false,
+      image: null,
+      username,
+    },
+    body,
+    createdAt: '2026-05-08T00:00:00.000Z',
+    id,
+    updatedAt: '2026-05-08T00:00:00.000Z',
+  };
+}
+
+function createFetchMock(routes: Record<string, unknown | unknown[]>): typeof fetch {
+  const fetcher: typeof fetch = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const path = requestPath(input);
+    const method = requestMethod(input, init);
+    const response =
+      readMockResponse(routes, `${method} ${path}`) ?? readMockResponse(routes, path);
+
+    if (response instanceof Response) {
+      return response;
+    }
+
+    if (response !== undefined) {
+      return jsonResponse(response);
+    }
+
+    return jsonResponse(
+      {
+        errors: {
+          body: [`Unhandled request: ${method} ${path}`],
+        },
+      },
+      500,
+    );
+  };
+
+  return vi.fn(fetcher);
+}
+
+function readMockResponse(
+  routes: Record<string, unknown | unknown[]>,
+  key: string,
+): unknown {
+  const response = routes[key];
+
+  if (Array.isArray(response)) {
+    return response.shift();
+  }
+
+  return response;
+}
+
+function requestPath(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    const url = new URL(input, window.location.origin);
+
+    return `${url.pathname}${url.search}`;
+  }
+
+  const url = input instanceof URL ? input : new URL(input.url, window.location.origin);
+
+  return `${url.pathname}${url.search}`;
+}
+
+function requestMethod(input: RequestInfo | URL, init: RequestInit | undefined): string {
+  if (init?.method !== undefined) {
+    return init.method.toUpperCase();
+  }
+
+  if (input instanceof Request) {
+    return input.method.toUpperCase();
+  }
+
+  return 'GET';
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+}
+
+function emptyResponse(status = 204): Response {
+  return new Response(null, { status });
+}

--- a/frontend/src/app/routes/__tests__/ArticleDetailPage.test.tsx
+++ b/frontend/src/app/routes/__tests__/ArticleDetailPage.test.tsx
@@ -90,7 +90,7 @@ describe('ArticleDetailPage', () => {
       await screen.findByRole('heading', { name: 'Guest readable article' }),
     ).toBeInTheDocument();
     expect(screen.getByText('Guest readable article body.')).toBeInTheDocument();
-    expect(screen.getByText('A public comment.')).toBeInTheDocument();
+    expect(await screen.findByText('A public comment.')).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Favorite Article (3)' }));
 

--- a/frontend/src/app/routes/pages/ArticleDetailPage.tsx
+++ b/frontend/src/app/routes/pages/ArticleDetailPage.tsx
@@ -1,32 +1,45 @@
 import { type ReactElement } from 'react';
-import { useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useAuth } from '@/app/providers/useAuth';
+import { ArticleDetail } from '@/features/article';
 
 export function ArticleDetailPage(): ReactElement {
+  const { isAuthenticated, user } = useAuth();
+  const location = useLocation();
+  const navigate = useNavigate();
   const { slug } = useParams();
+
+  if (slug === undefined) {
+    return (
+      <main className="page page--reading">
+        <section className="article-detail" aria-labelledby="article-not-found-title">
+          <p className="eyebrow">404</p>
+          <h1 id="article-not-found-title">Article not found</h1>
+          <p className="article-detail__dek">The article could not be found.</p>
+        </section>
+      </main>
+    );
+  }
+
+  function requireAuth(): void {
+    const returnTo = `${location.pathname}${location.search}${location.hash}`;
+
+    navigate(`/login?returnTo=${encodeURIComponent(returnTo)}`);
+  }
+
+  function handleDeleted(): void {
+    navigate('/', { replace: true });
+  }
 
   return (
     <main className="page page--reading">
-      <article className="article-detail">
-        <p className="eyebrow">Article</p>
-        <h1>{slug === undefined ? 'Article Detail' : readableSlug(slug)}</h1>
-        <p className="article-detail__dek">
-          This route is ready for the Publishing Context implementation. Article
-          data, favorite state, comments, and author commands will be connected
-          by the follow-up issues.
-        </p>
-        <div className="tag-row">
-          <span className="tag">react</span>
-          <span className="tag">realworld</span>
-        </div>
-      </article>
+      <ArticleDetail
+        currentUsername={user?.username ?? null}
+        isAuthenticated={isAuthenticated}
+        onDeleted={handleDeleted}
+        onRequireAuth={requireAuth}
+        slug={slug}
+      />
     </main>
   );
-}
-
-function readableSlug(slug: string): string {
-  return slug
-    .split('-')
-    .filter((word) => word.length > 0)
-    .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
-    .join(' ');
 }

--- a/frontend/src/features/article/__tests__/articleApi.test.ts
+++ b/frontend/src/features/article/__tests__/articleApi.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { ApiClient } from '@/lib/apiClient';
-import { ARTICLE_PAGE_SIZE, listArticles } from '../api/articleApi';
+import {
+  ARTICLE_PAGE_SIZE,
+  deleteArticle,
+  favoriteArticle,
+  getArticle,
+  listArticles,
+  unfavoriteArticle,
+} from '../api/articleApi';
 
 function createClient(): ApiClient {
   return {
@@ -90,5 +97,84 @@ describe('Article API', () => {
     expect(client.get).toHaveBeenCalledWith(
       '/api/articles?tag=react+patterns&limit=10&offset=0',
     );
+  });
+
+  it('Article detailを取得してbodyを含むfrontend modelへ変換する', async () => {
+    const client = createClient();
+    vi.mocked(client.get).mockResolvedValue({
+      article: {
+        ...ARTICLE_RESPONSE.articles[0],
+        body: 'It takes a Jacobian matrix to train your dragon.',
+      },
+    });
+
+    const result = await getArticle('how-to-train-your-dragon', client);
+
+    expect(client.get).toHaveBeenCalledWith(
+      '/api/articles/how-to-train-your-dragon',
+    );
+    expect(result).toEqual({
+      author: {
+        bio: 'API learner',
+        following: false,
+        image: 'https://example.com/jake.png',
+        username: 'jake',
+      },
+      body: 'It takes a Jacobian matrix to train your dragon.',
+      createdAt: '2026-05-06T00:00:00.000Z',
+      description: 'Ever wonder how?',
+      favorited: false,
+      favoritesCount: 3,
+      slug: 'how-to-train-your-dragon',
+      tags: ['dragons', 'training'],
+      title: 'How to train your dragon',
+      updatedAt: '2026-05-07T00:00:00.000Z',
+    });
+  });
+
+  it('favoriteとunfavoriteをArticle detail modelとして返す', async () => {
+    const client = createClient();
+    vi.mocked(client.post).mockResolvedValue({
+      article: {
+        ...ARTICLE_RESPONSE.articles[0],
+        body: 'Favorite response body',
+        favorited: true,
+        favoritesCount: 4,
+      },
+    });
+    vi.mocked(client.delete).mockResolvedValue({
+      article: {
+        ...ARTICLE_RESPONSE.articles[0],
+        body: 'Unfavorite response body',
+        favorited: false,
+        favoritesCount: 3,
+      },
+    });
+
+    const favoriteResult = await favoriteArticle('how-to-train-your-dragon', client);
+    const unfavoriteResult = await unfavoriteArticle(
+      'how-to-train-your-dragon',
+      client,
+    );
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/articles/how-to-train-your-dragon/favorite',
+    );
+    expect(client.delete).toHaveBeenCalledWith(
+      '/api/articles/how-to-train-your-dragon/favorite',
+    );
+    expect(favoriteResult.favorited).toBe(true);
+    expect(favoriteResult.favoritesCount).toBe(4);
+    expect(unfavoriteResult.favorited).toBe(false);
+    expect(unfavoriteResult.favoritesCount).toBe(3);
+  });
+
+  it('Article delete endpointを呼び出す', async () => {
+    const client = createClient();
+    vi.mocked(client.delete).mockResolvedValue(null);
+
+    await deleteArticle('how-to-train-your-dragon', client);
+
+    expect(client.delete).toHaveBeenCalledWith('/api/articles/how-to-train-your-dragon');
   });
 });

--- a/frontend/src/features/article/api/articleApi.ts
+++ b/frontend/src/features/article/api/articleApi.ts
@@ -1,11 +1,20 @@
 import { apiClient, type ApiClient } from '@/lib/apiClient';
-import type { ArticleListParams, ArticleListResult, ArticleSummary } from '../types/article';
+import type {
+  ArticleDetail,
+  ArticleListParams,
+  ArticleListResult,
+  ArticleSummary,
+} from '../types/article';
 
 export const ARTICLE_PAGE_SIZE = 10;
 
 export interface ArticleListResponse {
   articles: ArticleResponse[];
   articlesCount: number;
+}
+
+export interface SingleArticleResponse {
+  article: ArticleDetailResponse;
 }
 
 interface ArticleResponse {
@@ -23,6 +32,10 @@ interface ArticleResponse {
   tagList: string[];
   title: string;
   updatedAt: string;
+}
+
+interface ArticleDetailResponse extends ArticleResponse {
+  body: string;
 }
 
 /**
@@ -48,6 +61,63 @@ export function mapArticleListResponse(response: ArticleListResponse): ArticleLi
   };
 }
 
+/**
+ * slugで指定されたArticle detailをBFF経由で取得する。
+ */
+export async function getArticle(
+  slug: string,
+  client: ApiClient = apiClient,
+  signal?: AbortSignal,
+): Promise<ArticleDetail> {
+  const path = buildArticlePath(slug);
+
+  if (signal === undefined) {
+    return mapSingleArticleResponse(await client.get<SingleArticleResponse>(path));
+  }
+
+  return mapSingleArticleResponse(
+    await client.get<SingleArticleResponse>(path, { signal }),
+  );
+}
+
+/**
+ * Articleをfavoriteし、更新後のArticle detailを返す。
+ */
+export async function favoriteArticle(
+  slug: string,
+  client: ApiClient = apiClient,
+): Promise<ArticleDetail> {
+  return mapSingleArticleResponse(
+    await client.post<SingleArticleResponse>(`${buildArticlePath(slug)}/favorite`),
+  );
+}
+
+/**
+ * Articleのfavoriteを解除し、更新後のArticle detailを返す。
+ */
+export async function unfavoriteArticle(
+  slug: string,
+  client: ApiClient = apiClient,
+): Promise<ArticleDetail> {
+  return mapSingleArticleResponse(
+    await client.delete<SingleArticleResponse>(`${buildArticlePath(slug)}/favorite`),
+  );
+}
+
+/**
+ * Article authorがArticleを削除する。
+ */
+export async function deleteArticle(
+  slug: string,
+  client: ApiClient = apiClient,
+): Promise<void> {
+  await client.delete<null>(buildArticlePath(slug));
+}
+
+export function mapSingleArticleResponse(response: SingleArticleResponse): ArticleDetail {
+  return mapArticleDetailResponse(response.article);
+}
+
 function mapArticleResponse(response: ArticleResponse): ArticleSummary {
   return {
     author: {
@@ -67,6 +137,13 @@ function mapArticleResponse(response: ArticleResponse): ArticleSummary {
   };
 }
 
+function mapArticleDetailResponse(response: ArticleDetailResponse): ArticleDetail {
+  return {
+    ...mapArticleResponse(response),
+    body: response.body,
+  };
+}
+
 export function buildArticleListPath(basePath: string, params: ArticleListParams): string {
   const query = new URLSearchParams();
   const tag = params.tag?.trim();
@@ -79,6 +156,10 @@ export function buildArticleListPath(basePath: string, params: ArticleListParams
   query.set('offset', String(params.offset));
 
   return `${basePath}?${query.toString()}`;
+}
+
+export function buildArticlePath(slug: string): string {
+  return `/api/articles/${encodeURIComponent(slug)}`;
 }
 
 async function getArticleListResponse(

--- a/frontend/src/features/article/components/ArticleDetail.tsx
+++ b/frontend/src/features/article/components/ArticleDetail.tsx
@@ -1,0 +1,352 @@
+import { type ReactElement, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { CommentList } from '@/features/comment';
+import { isApiError } from '@/lib/apiError';
+import {
+  deleteArticle,
+  favoriteArticle,
+  getArticle,
+  unfavoriteArticle,
+} from '../api/articleApi';
+import type { ArticleAuthor, ArticleDetail as ArticleDetailModel } from '../types/article';
+
+interface ArticleDetailProps {
+  currentUsername: string | null;
+  isAuthenticated: boolean;
+  onDeleted: () => void;
+  onRequireAuth: () => void;
+  slug: string;
+}
+
+type ArticleDetailState =
+  | {
+      article: null;
+      error: null;
+      status: 'loading';
+    }
+  | {
+      article: ArticleDetailModel;
+      error: null;
+      status: 'success';
+    }
+  | {
+      article: null;
+      error: string;
+      status: 'error' | 'not_found';
+    };
+
+/**
+ * Article Detail画面の取得状態、favorite、author action、comments listをまとめる。
+ */
+export function ArticleDetail({
+  currentUsername,
+  isAuthenticated,
+  onDeleted,
+  onRequireAuth,
+  slug,
+}: ArticleDetailProps): ReactElement {
+  const [state, setState] = useState<ArticleDetailState>({
+    article: null,
+    error: null,
+    status: 'loading',
+  });
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [isFavoriteSaving, setIsFavoriteSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let isCurrent = true;
+
+    async function load(): Promise<void> {
+      setActionError(null);
+      setState({
+        article: null,
+        error: null,
+        status: 'loading',
+      });
+
+      try {
+        const article = await getArticle(slug, undefined, controller.signal);
+
+        if (!isCurrent) {
+          return;
+        }
+
+        setState({
+          article,
+          error: null,
+          status: 'success',
+        });
+      } catch (error: unknown) {
+        if (!isCurrent || isAbortError(error)) {
+          return;
+        }
+
+        setState({
+          article: null,
+          error: getArticleErrorMessage(error),
+          status: isApiError(error) && error.kind === 'not_found' ? 'not_found' : 'error',
+        });
+      }
+    }
+
+    void load();
+
+    return () => {
+      isCurrent = false;
+      controller.abort();
+    };
+  }, [slug]);
+
+  if (state.status === 'loading') {
+    return (
+      <section className="article-detail" aria-live="polite">
+        <p className="state-message">Loading article...</p>
+      </section>
+    );
+  }
+
+  if (state.status === 'not_found') {
+    return (
+      <section className="article-detail" aria-labelledby="article-not-found-title">
+        <p className="eyebrow">404</p>
+        <h1 id="article-not-found-title">Article not found</h1>
+        <p className="article-detail__dek">{state.error}</p>
+        <Link className="primary-action article-detail__home-link" to="/">
+          Go home
+        </Link>
+      </section>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <section className="article-detail" aria-live="polite">
+        <p className="state-message state-message--error">{state.error}</p>
+      </section>
+    );
+  }
+
+  if (state.article === null) {
+    return (
+      <section className="article-detail" aria-live="polite">
+        <p className="state-message state-message--error">Article could not be loaded.</p>
+      </section>
+    );
+  }
+
+  const article = state.article;
+  const isAuthor = currentUsername === article.author.username;
+
+  async function handleFavorite(): Promise<void> {
+    if (!isAuthenticated) {
+      onRequireAuth();
+      return;
+    }
+
+    setActionError(null);
+    setIsFavoriteSaving(true);
+
+    try {
+      const updatedArticle = article.favorited
+        ? await unfavoriteArticle(article.slug)
+        : await favoriteArticle(article.slug);
+
+      setState({
+        article: updatedArticle,
+        error: null,
+        status: 'success',
+      });
+    } catch (error: unknown) {
+      setActionError(getActionErrorMessage(error, 'Favorite could not be updated.'));
+    } finally {
+      setIsFavoriteSaving(false);
+    }
+  }
+
+  async function handleDelete(): Promise<void> {
+    setActionError(null);
+    setIsDeleting(true);
+
+    try {
+      await deleteArticle(article.slug);
+      onDeleted();
+    } catch (error: unknown) {
+      setActionError(getActionErrorMessage(error, 'Article could not be deleted.'));
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <article className="article-detail" aria-labelledby="article-title">
+      <header className="article-detail__header">
+        <p className="eyebrow">Article</p>
+        <h1 id="article-title">{article.title}</h1>
+        <ArticleMeta author={article.author} createdAt={article.createdAt} />
+        <ArticleActions
+          article={article}
+          isAuthor={isAuthor}
+          isDeleting={isDeleting}
+          isFavoriteSaving={isFavoriteSaving}
+          onDelete={handleDelete}
+          onFavorite={handleFavorite}
+        />
+        {actionError === null ? null : (
+          <p className="state-message state-message--compact state-message--error" role="alert">
+            {actionError}
+          </p>
+        )}
+      </header>
+
+      <div className="article-detail__body">
+        <p>{article.body}</p>
+      </div>
+
+      <div className="tag-row article-detail__tags">
+        {article.tags.map((tag) => (
+          <span className="tag" key={tag}>
+            {tag}
+          </span>
+        ))}
+      </div>
+
+      <footer className="article-detail__footer">
+        <ArticleMeta author={article.author} createdAt={article.createdAt} />
+      </footer>
+
+      <CommentList isAuthenticated={isAuthenticated} slug={article.slug} />
+    </article>
+  );
+}
+
+interface ArticleMetaProps {
+  author: ArticleAuthor;
+  createdAt: string;
+}
+
+function ArticleMeta({ author, createdAt }: ArticleMetaProps): ReactElement {
+  return (
+    <div className="article-meta">
+      <AuthorAvatar author={author} />
+      <div>
+        <Link to={`/profile/${encodeURIComponent(author.username)}`}>
+          {author.username}
+        </Link>
+        <time dateTime={createdAt}>{formatDisplayDate(createdAt)}</time>
+      </div>
+    </div>
+  );
+}
+
+interface AuthorAvatarProps {
+  author: ArticleAuthor;
+}
+
+function AuthorAvatar({ author }: AuthorAvatarProps): ReactElement {
+  if (author.image !== null && author.image.trim() !== '') {
+    return (
+      <img
+        alt={`${author.username} avatar`}
+        className="avatar"
+        src={author.image}
+      />
+    );
+  }
+
+  return (
+    <span className="avatar" aria-hidden="true">
+      {author.username.charAt(0).toUpperCase()}
+    </span>
+  );
+}
+
+interface ArticleActionsProps {
+  article: ArticleDetailModel;
+  isAuthor: boolean;
+  isDeleting: boolean;
+  isFavoriteSaving: boolean;
+  onDelete: () => Promise<void>;
+  onFavorite: () => Promise<void>;
+}
+
+function ArticleActions({
+  article,
+  isAuthor,
+  isDeleting,
+  isFavoriteSaving,
+  onDelete,
+  onFavorite,
+}: ArticleActionsProps): ReactElement {
+  if (isAuthor) {
+    return (
+      <div className="article-actions">
+        <Link className="secondary-action" to={`/editor/${encodeURIComponent(article.slug)}`}>
+          Edit Article
+        </Link>
+        <button
+          className="danger-action danger-action--compact"
+          disabled={isDeleting}
+          onClick={() => {
+            void onDelete();
+          }}
+          type="button"
+        >
+          Delete Article
+        </button>
+      </div>
+    );
+  }
+
+  const label = article.favorited ? 'Unfavorite Article' : 'Favorite Article';
+
+  return (
+    <div className="article-actions">
+      <button
+        aria-pressed={article.favorited}
+        className={article.favorited ? 'favorite-button is-active' : 'favorite-button'}
+        disabled={isFavoriteSaving}
+        onClick={() => {
+          void onFavorite();
+        }}
+        type="button"
+      >
+        {label} ({article.favoritesCount})
+      </button>
+    </div>
+  );
+}
+
+function getArticleErrorMessage(error: unknown): string {
+  if (isApiError(error) && error.kind === 'not_found') {
+    return 'The article could not be found.';
+  }
+
+  return 'Article could not be loaded.';
+}
+
+function getActionErrorMessage(error: unknown, fallback: string): string {
+  if (isApiError(error)) {
+    return error.bodyErrors.at(0) ?? fallback;
+  }
+
+  return fallback;
+}
+
+function formatDisplayDate(value: string): string {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('en', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  }).format(date);
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}

--- a/frontend/src/features/article/index.ts
+++ b/frontend/src/features/article/index.ts
@@ -1,13 +1,22 @@
 export {
   ARTICLE_PAGE_SIZE,
+  buildArticlePath,
   buildArticleListPath,
+  deleteArticle,
+  favoriteArticle,
+  getArticle,
   listArticles,
   mapArticleListResponse,
+  mapSingleArticleResponse,
+  unfavoriteArticle,
   type ArticleListResponse,
+  type SingleArticleResponse,
 } from './api/articleApi';
+export { ArticleDetail } from './components/ArticleDetail';
 export { ArticleList } from './components/ArticleList';
 export type {
   ArticleAuthor,
+  ArticleDetail as ArticleDetailModel,
   ArticleListParams,
   ArticleListQuery,
   ArticleListResult,

--- a/frontend/src/features/article/types/article.ts
+++ b/frontend/src/features/article/types/article.ts
@@ -17,6 +17,10 @@ export interface ArticleSummary {
   updatedAt: string;
 }
 
+export interface ArticleDetail extends ArticleSummary {
+  body: string;
+}
+
 export interface ArticleListResult {
   articles: ArticleSummary[];
   totalCount: number;

--- a/frontend/src/features/comment/__tests__/commentApi.test.ts
+++ b/frontend/src/features/comment/__tests__/commentApi.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ApiClient } from '@/lib/apiClient';
+import { listComments } from '../api/commentApi';
+
+function createClient(): ApiClient {
+  return {
+    delete: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    request: vi.fn(),
+  };
+}
+
+describe('Comment API', () => {
+  it('Article comments listを取得してfrontend modelへ変換する', async () => {
+    const client = createClient();
+    vi.mocked(client.get).mockResolvedValue({
+      comments: [
+        {
+          author: {
+            bio: null,
+            following: false,
+            image: null,
+            username: 'reader',
+          },
+          body: 'Nice article.',
+          createdAt: '2026-05-08T00:00:00.000Z',
+          id: 1,
+          updatedAt: '2026-05-08T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await listComments('how-to-train-your-dragon', client);
+
+    expect(client.get).toHaveBeenCalledWith(
+      '/api/articles/how-to-train-your-dragon/comments',
+    );
+    expect(result).toEqual([
+      {
+        author: {
+          bio: null,
+          following: false,
+          image: null,
+          username: 'reader',
+        },
+        body: 'Nice article.',
+        createdAt: '2026-05-08T00:00:00.000Z',
+        id: 1,
+        updatedAt: '2026-05-08T00:00:00.000Z',
+      },
+    ]);
+  });
+});

--- a/frontend/src/features/comment/api/commentApi.ts
+++ b/frontend/src/features/comment/api/commentApi.ts
@@ -1,0 +1,63 @@
+import { apiClient, type ApiClient } from '@/lib/apiClient';
+import type { ArticleComment } from '../types/comment';
+
+interface CommentListResponse {
+  comments: CommentResponse[];
+}
+
+interface CommentResponse {
+  author: {
+    bio: string | null;
+    following: boolean;
+    image: string | null;
+    username: string;
+  };
+  body: string;
+  createdAt: string;
+  id: number;
+  updatedAt: string;
+}
+
+/**
+ * Articleに紐づくcomments listをBFF経由で取得する。
+ */
+export async function listComments(
+  slug: string,
+  client: ApiClient = apiClient,
+  signal?: AbortSignal,
+): Promise<ArticleComment[]> {
+  const path = buildCommentsPath(slug);
+
+  if (signal === undefined) {
+    return mapCommentListResponse(await client.get<CommentListResponse>(path));
+  }
+
+  return mapCommentListResponse(
+    await client.get<CommentListResponse>(path, { signal }),
+  );
+}
+
+export function mapCommentListResponse(
+  response: CommentListResponse,
+): ArticleComment[] {
+  return response.comments.map(mapCommentResponse);
+}
+
+export function buildCommentsPath(slug: string): string {
+  return `/api/articles/${encodeURIComponent(slug)}/comments`;
+}
+
+function mapCommentResponse(response: CommentResponse): ArticleComment {
+  return {
+    author: {
+      bio: response.author.bio,
+      following: response.author.following,
+      image: response.author.image,
+      username: response.author.username,
+    },
+    body: response.body,
+    createdAt: response.createdAt,
+    id: response.id,
+    updatedAt: response.updatedAt,
+  };
+}

--- a/frontend/src/features/comment/components/CommentList.tsx
+++ b/frontend/src/features/comment/components/CommentList.tsx
@@ -1,0 +1,191 @@
+import { type ReactElement, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { isApiError } from '@/lib/apiError';
+import { listComments } from '../api/commentApi';
+import type { ArticleComment } from '../types/comment';
+
+interface CommentListProps {
+  isAuthenticated: boolean;
+  slug: string;
+}
+
+type CommentListState =
+  | {
+      comments: ArticleComment[];
+      error: null;
+      status: 'loading';
+    }
+  | {
+      comments: ArticleComment[];
+      error: null;
+      status: 'success';
+    }
+  | {
+      comments: [];
+      error: string;
+      status: 'error';
+    };
+
+/**
+ * Article Detail内のread-only comments listを取得して表示する。
+ */
+export function CommentList({
+  isAuthenticated,
+  slug,
+}: CommentListProps): ReactElement {
+  const [state, setState] = useState<CommentListState>({
+    comments: [],
+    error: null,
+    status: 'loading',
+  });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let isCurrent = true;
+
+    async function load(): Promise<void> {
+      try {
+        const comments = await listComments(slug, undefined, controller.signal);
+
+        if (!isCurrent) {
+          return;
+        }
+
+        setState({
+          comments,
+          error: null,
+          status: 'success',
+        });
+      } catch (error: unknown) {
+        if (!isCurrent || isAbortError(error)) {
+          return;
+        }
+
+        setState({
+          comments: [],
+          error: getCommentsErrorMessage(error),
+          status: 'error',
+        });
+      }
+    }
+
+    void load();
+
+    return () => {
+      isCurrent = false;
+      controller.abort();
+    };
+  }, [slug]);
+
+  return (
+    <section className="comments-section" aria-labelledby="comments-title">
+      <h2 id="comments-title">Comments</h2>
+      {isAuthenticated ? null : (
+        <p className="comment-auth-note">
+          <Link to={`/login?returnTo=${encodeURIComponent(`/article/${slug}`)}`}>
+            Sign in
+          </Link>{' '}
+          or <Link to="/register">sign up</Link> to add comments on this article.
+        </p>
+      )}
+      <CommentListContent state={state} />
+    </section>
+  );
+}
+
+interface CommentListContentProps {
+  state: CommentListState;
+}
+
+function CommentListContent({ state }: CommentListContentProps): ReactElement {
+  if (state.status === 'loading') {
+    return (
+      <div className="comment-list" aria-live="polite">
+        <p className="state-message state-message--compact">Loading comments...</p>
+      </div>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <div className="comment-list" aria-live="polite">
+        <p className="state-message state-message--compact state-message--error">
+          {state.error}
+        </p>
+      </div>
+    );
+  }
+
+  if (state.comments.length === 0) {
+    return (
+      <div className="comment-list" aria-live="polite">
+        <p className="state-message state-message--compact">No comments yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="comment-list" aria-live="polite">
+      {state.comments.map((comment) => (
+        <article className="comment-card" key={comment.id}>
+          <p>{comment.body}</p>
+          <footer className="comment-card__meta">
+            <CommentAvatar comment={comment} />
+            <Link to={`/profile/${encodeURIComponent(comment.author.username)}`}>
+              {comment.author.username}
+            </Link>
+            <time dateTime={comment.createdAt}>{formatDisplayDate(comment.createdAt)}</time>
+          </footer>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+interface CommentAvatarProps {
+  comment: ArticleComment;
+}
+
+function CommentAvatar({ comment }: CommentAvatarProps): ReactElement {
+  if (comment.author.image !== null && comment.author.image.trim() !== '') {
+    return (
+      <img
+        alt={`${comment.author.username} avatar`}
+        className="avatar avatar--small"
+        src={comment.author.image}
+      />
+    );
+  }
+
+  return (
+    <span className="avatar avatar--small" aria-hidden="true">
+      {comment.author.username.charAt(0).toUpperCase()}
+    </span>
+  );
+}
+
+function getCommentsErrorMessage(error: unknown): string {
+  if (isApiError(error) && error.kind === 'not_found') {
+    return 'Comments could not be found.';
+  }
+
+  return 'Comments could not be loaded.';
+}
+
+function formatDisplayDate(value: string): string {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('en', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  }).format(date);
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}

--- a/frontend/src/features/comment/index.ts
+++ b/frontend/src/features/comment/index.ts
@@ -1,0 +1,7 @@
+export {
+  buildCommentsPath,
+  listComments,
+  mapCommentListResponse,
+} from './api/commentApi';
+export { CommentList } from './components/CommentList';
+export type { ArticleComment, CommentAuthor } from './types/comment';

--- a/frontend/src/features/comment/types/comment.ts
+++ b/frontend/src/features/comment/types/comment.ts
@@ -1,0 +1,14 @@
+export interface CommentAuthor {
+  bio: string | null;
+  following: boolean;
+  image: string | null;
+  username: string;
+}
+
+export interface ArticleComment {
+  author: CommentAuthor;
+  body: string;
+  createdAt: string;
+  id: number;
+  updatedAt: string;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -335,7 +335,10 @@ textarea:focus-visible {
 
 .favorite-button,
 .secondary-action {
+  display: inline-flex;
   min-height: 34px;
+  align-items: center;
+  justify-content: center;
   border: 1px solid var(--surface-line);
   border-radius: var(--radius);
   background: var(--surface);
@@ -578,6 +581,133 @@ button.tag {
 
 .article-detail .tag-row {
   margin-top: 28px;
+}
+
+.article-detail__header {
+  text-align: center;
+}
+
+.article-detail__header h1 {
+  margin-bottom: 24px;
+}
+
+.article-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--text-muted);
+  font-size: 0.86rem;
+  text-align: left;
+}
+
+.article-meta a {
+  display: block;
+  color: var(--primary);
+  font-weight: 700;
+}
+
+.article-meta time {
+  display: block;
+  margin-top: 2px;
+}
+
+.article-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.article-detail__body {
+  margin-top: 48px;
+  color: var(--text);
+  font-family: var(--serif);
+  font-size: 1.2rem;
+  line-height: 1.8;
+  white-space: pre-wrap;
+}
+
+.article-detail__tags {
+  padding-bottom: 32px;
+  border-bottom: 1px solid var(--surface-line);
+}
+
+.article-detail__footer {
+  display: flex;
+  justify-content: center;
+  margin-top: 32px;
+}
+
+.article-detail__home-link {
+  margin-top: 24px;
+}
+
+.danger-action--compact {
+  min-height: 34px;
+  padding-inline: 12px;
+  font-size: 0.82rem;
+}
+
+.comments-section {
+  margin-top: 48px;
+}
+
+.comments-section h2 {
+  font-family: var(--sans);
+  font-size: 1rem;
+}
+
+.comment-auth-note {
+  margin-top: 12px;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.comment-auth-note a {
+  color: var(--primary);
+  font-weight: 700;
+}
+
+.comment-list {
+  display: grid;
+  gap: 16px;
+  margin-top: 20px;
+}
+
+.comment-card {
+  border: 1px solid var(--surface-line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  overflow: hidden;
+}
+
+.comment-card > p {
+  padding: 18px;
+  color: var(--text);
+  font-family: var(--serif);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.comment-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-top: 1px solid var(--surface-line);
+  background: var(--surface-soft);
+  color: var(--text-muted);
+  padding: 10px 12px;
+  font-size: 0.82rem;
+}
+
+.comment-card__meta a {
+  color: var(--primary);
+  font-weight: 700;
+}
+
+.comment-card__meta time {
+  margin-left: auto;
 }
 
 .profile-header {


### PR DESCRIPTION
# 概要

- Article Detail を BFF 経由の Article API に接続し、本文、タグ、author summary を表示
- favorite / unfavorite と favoritesCount 更新、guest favorite の login 誘導を実装
- author の Edit / Delete action と、delete 成功後の Home 遷移を実装
- read-only comments list と 404 slug の Not Found 表示を追加

# 関連Issue

Closes #73

Epic: #58

# 修正ファイルの説明

## Frontend route

- `frontend/src/app/routes/pages/ArticleDetailPage.tsx`
  - placeholder を Article Detail feature component の composition に置き換え
  - current user、login 誘導、delete 後遷移を route 側から渡すため

## Article feature

- `frontend/src/features/article/api/articleApi.ts`
  - detail / favorite / unfavorite / delete API と response mapping を追加
  - Article Detail が Public API 形式ではなく frontend model を扱えるようにするため
- `frontend/src/features/article/components/ArticleDetail.tsx`
  - Article detail 表示、favorite toggle、author actions、404/error/loading state を追加
  - Page にビジネスロジックを置かず feature 内へ閉じ込めるため
- `frontend/src/features/article/types/article.ts`
  - body を持つ `ArticleDetail` model を追加
- `frontend/src/features/article/index.ts`
  - Article feature の公開 API を更新

## Comment feature

- `frontend/src/features/comment/api/commentApi.ts`
  - Article comments list API と response mapping を追加
- `frontend/src/features/comment/components/CommentList.tsx`
  - read-only comments list の loading / error / empty / success 表示を追加
- `frontend/src/features/comment/types/comment.ts`
  - comment frontend model を追加
- `frontend/src/features/comment/index.ts`
  - comment feature の公開 API を追加

## Tests / styles

- `frontend/src/app/routes/__tests__/ArticleDetailPage.test.tsx`
  - guest / non-author / author / 404 の表示差分と操作を追加
- `frontend/src/features/article/__tests__/articleApi.test.ts`
  - Article detail / favorite / unfavorite / delete API mapping を追加
- `frontend/src/features/comment/__tests__/commentApi.test.ts`
  - comments list API mapping を追加
- `frontend/src/index.css`
  - Article Detail / comments list の表示スタイルを追加

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| フロントエンド変更あり | 型チェック | `pnpm tsc -b --noEmit` (`frontend/`) | 成功する | 成功 |
| フロントエンド変更あり | 全 Vitest | `pnpm vitest run` (`frontend/`) | 成功する | 成功: 12 files / 58 tests |
| フロントエンド変更あり | ESLint | `pnpm eslint .` (`frontend/`) | 成功する | 成功 |
| バックエンド変更なし | Backend QA | 変更なしのため未実施 | 影響なし | 対象外 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: Article Detail の表示差分、guest favorite の login 誘導、favorite count の更新、delete 後遷移
