### PR TITLE
[#78]: Profile / Favorites / Follow UIを実装

### DIFF
--- a/frontend/src/app/routes/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/app/routes/__tests__/ProfilePage.test.tsx
@@ -1,0 +1,344 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement } from 'react';
+import { RouterProvider } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AppProviders } from '@/app/providers/AppProviders';
+import type { AuthApi, AuthUser } from '@/features/auth';
+import { ApiError } from '@/lib/apiError';
+import { createAppRouter } from '../router';
+
+const DEMO_USER: AuthUser = {
+  bio: null,
+  email: 'demo@example.com',
+  image: null,
+  username: 'demo-user',
+};
+
+const PROFILE_USER: AuthUser = {
+  bio: 'Profile owner bio',
+  email: 'eric@example.com',
+  image: null,
+  username: 'eric',
+};
+
+function createAuthApi(overrides: Partial<AuthApi> = {}): AuthApi {
+  return {
+    getCurrentUser: vi.fn().mockRejectedValue(
+      new ApiError('Unauthorized', {
+        bodyErrors: ['Unauthorized'],
+        kind: 'unauthorized',
+        status: 401,
+      }),
+    ),
+    login: vi.fn().mockResolvedValue(DEMO_USER),
+    logout: vi.fn().mockResolvedValue(undefined),
+    register: vi.fn().mockResolvedValue(DEMO_USER),
+    updateCurrentUser: vi.fn().mockResolvedValue(DEMO_USER),
+    ...overrides,
+  };
+}
+
+function renderProfileRoute({
+  initialPath,
+  initialUser = null,
+  routes,
+}: {
+  initialPath: string;
+  initialUser?: AuthUser | null;
+  routes: Record<string, Response | unknown | unknown[]>;
+}): { fetchMock: ReturnType<typeof vi.fn>; view: ReactElement } {
+  const fetchMock = createFetchMock(routes);
+  vi.stubGlobal('fetch', fetchMock);
+
+  return {
+    fetchMock,
+    view: (
+      <AppProviders authApi={createAuthApi()} initialUser={initialUser}>
+        <RouterProvider router={createAppRouter([initialPath])} />
+      </AppProviders>
+    ),
+  };
+}
+
+describe('ProfilePage', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('guestはProfile headerとauthored articlesを閲覧でき、follow/settings actionは表示されない', async () => {
+    const { view } = renderProfileRoute({
+      initialPath: '/profile/eric',
+      routes: {
+        '/api/articles?author=eric&limit=10&offset=0': articlesWrapper([
+          articleResponse({
+            slug: 'authored-article',
+            title: 'Authored article',
+            username: 'eric',
+          }),
+        ]),
+        '/api/profiles/eric': profileWrapper({
+          bio: 'Cofounder at Thinkster.',
+          username: 'eric',
+        }),
+      },
+    });
+
+    render(view);
+
+    expect(await screen.findByRole('heading', { name: 'eric' })).toBeInTheDocument();
+    expect(screen.getByText('Cofounder at Thinkster.')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { name: 'Authored article' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Follow eric' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Edit Profile Settings' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('authenticated userは他ユーザーをfollow/unfollowでき、返却されたfollowing stateを表示へ反映する', async () => {
+    const user = userEvent.setup();
+    const { view } = renderProfileRoute({
+      initialPath: '/profile/eric',
+      initialUser: DEMO_USER,
+      routes: {
+        '/api/articles?author=eric&limit=10&offset=0': articlesWrapper([]),
+        '/api/profiles/eric': profileWrapper({
+          following: false,
+          username: 'eric',
+        }),
+        '/api/session/csrf': { csrfToken: 'csrf-token' },
+        'DELETE /api/profiles/eric/follow': profileWrapper({
+          following: false,
+          username: 'eric',
+        }),
+        'POST /api/profiles/eric/follow': profileWrapper({
+          following: true,
+          username: 'eric',
+        }),
+      },
+    });
+
+    render(view);
+
+    await user.click(await screen.findByRole('button', { name: 'Follow eric' }));
+    expect(
+      await screen.findByRole('button', { name: 'Unfollow eric' }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Unfollow eric' }));
+    expect(
+      await screen.findByRole('button', { name: 'Follow eric' }),
+    ).toBeInTheDocument();
+  });
+
+  it('自分のProfileではfollow buttonを表示せずsettings導線を表示する', async () => {
+    const { view } = renderProfileRoute({
+      initialPath: '/profile/eric',
+      initialUser: PROFILE_USER,
+      routes: {
+        '/api/articles?author=eric&limit=10&offset=0': articlesWrapper([]),
+        '/api/profiles/eric': profileWrapper({
+          bio: 'Profile owner bio',
+          username: 'eric',
+        }),
+      },
+    });
+
+    render(view);
+
+    expect(await screen.findByRole('heading', { name: 'eric' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Follow eric' })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Edit Profile Settings' })).toHaveAttribute(
+      'href',
+      '/settings',
+    );
+  });
+
+  it('favorites routeではFavorited Articles tabとfavorited article listを表示する', async () => {
+    const { view } = renderProfileRoute({
+      initialPath: '/profile/eric/favorites',
+      routes: {
+        '/api/articles?favorited=eric&limit=10&offset=0': articlesWrapper([
+          articleResponse({
+            slug: 'favorited-article',
+            title: 'Favorited article',
+            username: 'other-author',
+          }),
+        ]),
+        '/api/profiles/eric': profileWrapper({
+          username: 'eric',
+        }),
+      },
+    });
+
+    render(view);
+
+    expect(await screen.findByRole('heading', { name: 'eric' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Favorited Articles' })).toHaveClass(
+      'is-active',
+    );
+    expect(
+      await screen.findByRole('heading', { name: 'Favorited article' }),
+    ).toBeInTheDocument();
+  });
+
+  it('Profile not foundはProfile画面内でNot Found表示にし、article listを読み込まない', async () => {
+    const { fetchMock, view } = renderProfileRoute({
+      initialPath: '/profile/missing-user',
+      routes: {
+        '/api/profiles/missing-user': jsonResponse(
+          {
+            errors: {
+              body: ['Not Found'],
+            },
+          },
+          404,
+        ),
+      },
+    });
+
+    render(view);
+
+    expect(
+      await screen.findByRole('heading', { name: 'Profile not found' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('The profile could not be found.')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+function profileWrapper({
+  bio = null,
+  following = false,
+  image = null,
+  username,
+}: {
+  bio?: string | null;
+  following?: boolean;
+  image?: string | null;
+  username: string;
+}): unknown {
+  return {
+    profile: {
+      bio,
+      following,
+      image,
+      username,
+    },
+  };
+}
+
+function articlesWrapper(articles: unknown[]): unknown {
+  return {
+    articles,
+    articlesCount: articles.length,
+  };
+}
+
+function articleResponse({
+  slug,
+  title,
+  username,
+}: {
+  slug: string;
+  title: string;
+  username: string;
+}): unknown {
+  return {
+    author: {
+      bio: null,
+      following: false,
+      image: null,
+      username,
+    },
+    createdAt: '2026-05-06T00:00:00.000Z',
+    description: 'Profile article description',
+    favorited: false,
+    favoritesCount: 0,
+    slug,
+    tagList: ['profile'],
+    title,
+    updatedAt: '2026-05-06T00:00:00.000Z',
+  };
+}
+
+function createFetchMock(
+  routes: Record<string, Response | unknown | unknown[]>,
+): ReturnType<typeof vi.fn> {
+  const fetcher: typeof fetch = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const path = requestPath(input);
+    const method = requestMethod(input, init);
+    const response =
+      readMockResponse(routes, `${method} ${path}`) ?? readMockResponse(routes, path);
+
+    if (response instanceof Response) {
+      return response;
+    }
+
+    if (response !== undefined) {
+      return jsonResponse(response);
+    }
+
+    return jsonResponse(
+      {
+        errors: {
+          body: [`Unhandled request: ${method} ${path}`],
+        },
+      },
+      500,
+    );
+  };
+
+  return vi.fn(fetcher);
+}
+
+function readMockResponse(
+  routes: Record<string, Response | unknown | unknown[]>,
+  key: string,
+): Response | unknown {
+  const response = routes[key];
+
+  if (Array.isArray(response)) {
+    return response.shift();
+  }
+
+  return response;
+}
+
+function requestPath(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    const url = new URL(input, window.location.origin);
+
+    return `${url.pathname}${url.search}`;
+  }
+
+  const url = input instanceof URL ? input : new URL(input.url, window.location.origin);
+
+  return `${url.pathname}${url.search}`;
+}
+
+function requestMethod(input: RequestInfo | URL, init: RequestInit | undefined): string {
+  if (init?.method !== undefined) {
+    return init.method.toUpperCase();
+  }
+
+  if (input instanceof Request) {
+    return input.method.toUpperCase();
+  }
+
+  return 'GET';
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+}

--- a/frontend/src/app/routes/pages/ProfilePage.tsx
+++ b/frontend/src/app/routes/pages/ProfilePage.tsx
@@ -1,30 +1,54 @@
-import { type ReactElement } from 'react';
-import { useParams } from 'react-router-dom';
+import { type ReactElement, useCallback } from 'react';
+import { useLocation, useParams, useSearchParams } from 'react-router-dom';
+import { ProfileView, type ProfileTab } from '@/features/profile';
 
 export function ProfilePage(): ReactElement {
   const { username } = useParams();
-  const profileName = username ?? 'profile';
+  const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const profileUsername = username ?? '';
+  const activeTab = getActiveTab(location.pathname);
+  const page = parsePage(searchParams.get('page'));
+
+  const selectPage = useCallback(
+    (nextPage: number): void => {
+      const nextSearchParams = new URLSearchParams();
+
+      if (nextPage > 1) {
+        nextSearchParams.set('page', String(nextPage));
+      }
+
+      setSearchParams(nextSearchParams);
+    },
+    [setSearchParams],
+  );
 
   return (
     <main className="page page--wide">
-      <section className="profile-header" aria-labelledby="profile-title">
-        <span className="avatar avatar--large" aria-hidden="true">
-          {profileName.charAt(0).toUpperCase()}
-        </span>
-        <h1 id="profile-title">{profileName}</h1>
-        <button className="secondary-action" type="button">
-          Follow {profileName}
-        </button>
-      </section>
-      <section className="feed-column" aria-label="Profile articles">
-        <nav className="feed-tabs" aria-label="Profile tabs">
-          <button className="is-active" type="button">
-            My Articles
-          </button>
-          <button type="button">Favorited Articles</button>
-        </nav>
-        <p className="empty-state">Profile article feeds are ready for API integration.</p>
-      </section>
+      <ProfileView
+        activeTab={activeTab}
+        onPageChange={selectPage}
+        page={page}
+        username={profileUsername}
+      />
     </main>
   );
+}
+
+function getActiveTab(pathname: string): ProfileTab {
+  return pathname.endsWith('/favorites') ? 'favorited' : 'authored';
+}
+
+function parsePage(page: string | null): number {
+  if (page === null) {
+    return 1;
+  }
+
+  const parsedPage = Number.parseInt(page, 10);
+
+  if (!Number.isInteger(parsedPage) || parsedPage < 1) {
+    return 1;
+  }
+
+  return parsedPage;
 }

--- a/frontend/src/features/article/__tests__/articleApi.test.ts
+++ b/frontend/src/features/article/__tests__/articleApi.test.ts
@@ -99,6 +99,40 @@ describe('Article API', () => {
     );
   });
 
+  it('Profile画面用のauthor filterとfavorited filterをquery parameterとして送る', async () => {
+    const client = createClient();
+    vi.mocked(client.get).mockResolvedValue({
+      articles: [],
+      articlesCount: 0,
+    });
+
+    await listArticles(
+      {
+        author: 'eric',
+        limit: ARTICLE_PAGE_SIZE,
+        offset: 0,
+      },
+      client,
+    );
+    await listArticles(
+      {
+        favorited: 'space user',
+        limit: ARTICLE_PAGE_SIZE,
+        offset: 10,
+      },
+      client,
+    );
+
+    expect(client.get).toHaveBeenNthCalledWith(
+      1,
+      '/api/articles?author=eric&limit=10&offset=0',
+    );
+    expect(client.get).toHaveBeenNthCalledWith(
+      2,
+      '/api/articles?favorited=space+user&limit=10&offset=10',
+    );
+  });
+
   it('Article detailを取得してbodyを含むfrontend modelへ変換する', async () => {
     const client = createClient();
     vi.mocked(client.get).mockResolvedValue({

--- a/frontend/src/features/article/api/articleApi.ts
+++ b/frontend/src/features/article/api/articleApi.ts
@@ -147,9 +147,19 @@ function mapArticleDetailResponse(response: ArticleDetailResponse): ArticleDetai
 export function buildArticleListPath(basePath: string, params: ArticleListParams): string {
   const query = new URLSearchParams();
   const tag = params.tag?.trim();
+  const author = params.author?.trim();
+  const favorited = params.favorited?.trim();
 
   if (tag !== undefined && tag !== '') {
     query.set('tag', tag);
+  }
+
+  if (author !== undefined && author !== '') {
+    query.set('author', author);
+  }
+
+  if (favorited !== undefined && favorited !== '') {
+    query.set('favorited', favorited);
   }
 
   query.set('limit', String(params.limit));

--- a/frontend/src/features/article/types/article.ts
+++ b/frontend/src/features/article/types/article.ts
@@ -33,6 +33,8 @@ export interface ArticleListQuery {
 }
 
 export interface ArticleListParams extends ArticleListQuery {
+  author?: string;
+  favorited?: string;
   tag?: string;
 }
 

--- a/frontend/src/features/profile/__tests__/profileApi.test.ts
+++ b/frontend/src/features/profile/__tests__/profileApi.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ApiClient } from '@/lib/apiClient';
+import { followProfile, getProfile, unfollowProfile } from '../api/profileApi';
+
+function createClient(): ApiClient {
+  return {
+    delete: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    request: vi.fn(),
+  };
+}
+
+const PROFILE_RESPONSE = {
+  profile: {
+    bio: 'API learner',
+    following: false,
+    image: 'https://example.com/eric.png',
+    username: 'eric',
+  },
+};
+
+describe('Profile API', () => {
+  it('Profileを取得してfrontend modelへ変換する', async () => {
+    const client = createClient();
+    vi.mocked(client.get).mockResolvedValue(PROFILE_RESPONSE);
+
+    const result = await getProfile('eric', client);
+
+    expect(client.get).toHaveBeenCalledWith('/api/profiles/eric');
+    expect(result).toEqual({
+      bio: 'API learner',
+      following: false,
+      image: 'https://example.com/eric.png',
+      username: 'eric',
+    });
+  });
+
+  it('usernameをURL encodeしてProfileを取得する', async () => {
+    const client = createClient();
+    vi.mocked(client.get).mockResolvedValue({
+      profile: {
+        ...PROFILE_RESPONSE.profile,
+        username: 'space user',
+      },
+    });
+
+    await getProfile('space user', client);
+
+    expect(client.get).toHaveBeenCalledWith('/api/profiles/space%20user');
+  });
+
+  it('followとunfollowを実行し、更新後Profileを返す', async () => {
+    const client = createClient();
+    vi.mocked(client.post).mockResolvedValue({
+      profile: {
+        ...PROFILE_RESPONSE.profile,
+        following: true,
+      },
+    });
+    vi.mocked(client.delete).mockResolvedValue({
+      profile: {
+        ...PROFILE_RESPONSE.profile,
+        following: false,
+      },
+    });
+
+    const followed = await followProfile('eric', client);
+    const unfollowed = await unfollowProfile('eric', client);
+
+    expect(client.post).toHaveBeenCalledWith('/api/profiles/eric/follow');
+    expect(client.delete).toHaveBeenCalledWith('/api/profiles/eric/follow');
+    expect(followed.following).toBe(true);
+    expect(unfollowed.following).toBe(false);
+  });
+});

--- a/frontend/src/features/profile/api/profileApi.ts
+++ b/frontend/src/features/profile/api/profileApi.ts
@@ -1,0 +1,65 @@
+import { apiClient, type ApiClient } from '@/lib/apiClient';
+import type { Profile } from '../types/profile';
+
+interface ProfileResponse {
+  profile: {
+    bio: string | null;
+    following: boolean;
+    image: string | null;
+    username: string;
+  };
+}
+
+/**
+ * usernameで指定された公開ProfileをBFF経由で取得する。
+ */
+export async function getProfile(
+  username: string,
+  client: ApiClient = apiClient,
+  signal?: AbortSignal,
+): Promise<Profile> {
+  const path = buildProfilePath(username);
+
+  if (signal === undefined) {
+    return mapProfileResponse(await client.get<ProfileResponse>(path));
+  }
+
+  return mapProfileResponse(await client.get<ProfileResponse>(path, { signal }));
+}
+
+/**
+ * 対象Profileをfollowし、更新後のProfileを返す。
+ */
+export async function followProfile(
+  username: string,
+  client: ApiClient = apiClient,
+): Promise<Profile> {
+  return mapProfileResponse(
+    await client.post<ProfileResponse>(`${buildProfilePath(username)}/follow`),
+  );
+}
+
+/**
+ * 対象Profileのfollowを解除し、更新後のProfileを返す。
+ */
+export async function unfollowProfile(
+  username: string,
+  client: ApiClient = apiClient,
+): Promise<Profile> {
+  return mapProfileResponse(
+    await client.delete<ProfileResponse>(`${buildProfilePath(username)}/follow`),
+  );
+}
+
+export function mapProfileResponse(response: ProfileResponse): Profile {
+  return {
+    bio: response.profile.bio,
+    following: response.profile.following,
+    image: response.profile.image,
+    username: response.profile.username,
+  };
+}
+
+export function buildProfilePath(username: string): string {
+  return `/api/profiles/${encodeURIComponent(username)}`;
+}

--- a/frontend/src/features/profile/components/ProfileView.tsx
+++ b/frontend/src/features/profile/components/ProfileView.tsx
@@ -31,21 +31,25 @@ type ProfileState =
       error: null;
       profile: null;
       status: 'loading';
+      username: string;
     }
   | {
       error: null;
       profile: Profile;
       status: 'success';
+      username: string;
     }
   | {
       error: string;
       profile: null;
       status: 'error';
+      username: string;
     }
   | {
       error: null;
       profile: null;
       status: 'not_found';
+      username: string;
     };
 
 /**
@@ -62,20 +66,15 @@ export function ProfileView({
     error: null,
     profile: null,
     status: 'loading',
+    username,
   });
   const [isFollowMutating, setIsFollowMutating] = useState(false);
   const [followError, setFollowError] = useState<string | null>(null);
+  const currentState = state.username === username ? state : createLoadingState(username);
 
   useEffect(() => {
     const controller = new AbortController();
     let isCurrent = true;
-
-    setState({
-      error: null,
-      profile: null,
-      status: 'loading',
-    });
-    setFollowError(null);
 
     async function load(): Promise<void> {
       try {
@@ -89,7 +88,9 @@ export function ProfileView({
           error: null,
           profile,
           status: 'success',
+          username,
         });
+        setFollowError(null);
       } catch (error: unknown) {
         if (!isCurrent || isAbortError(error)) {
           return;
@@ -100,6 +101,7 @@ export function ProfileView({
             error: null,
             profile: null,
             status: 'not_found',
+            username,
           });
           return;
         }
@@ -108,6 +110,7 @@ export function ProfileView({
           error: 'Profile could not be loaded.',
           profile: null,
           status: 'error',
+          username,
         });
       }
     }
@@ -142,7 +145,7 @@ export function ProfileView({
   );
 
   const handleToggleFollow = useCallback(async (): Promise<void> => {
-    if (state.status !== 'success') {
+    if (currentState.status !== 'success') {
       return;
     }
 
@@ -150,23 +153,24 @@ export function ProfileView({
     setFollowError(null);
 
     try {
-      const nextProfile = state.profile.following
-        ? await unfollowProfile(state.profile.username)
-        : await followProfile(state.profile.username);
+      const nextProfile = currentState.profile.following
+        ? await unfollowProfile(currentState.profile.username)
+        : await followProfile(currentState.profile.username);
 
       setState({
         error: null,
         profile: nextProfile,
         status: 'success',
+        username,
       });
     } catch {
       setFollowError('Follow state could not be updated.');
     } finally {
       setIsFollowMutating(false);
     }
-  }, [state]);
+  }, [currentState, username]);
 
-  if (state.status === 'loading') {
+  if (currentState.status === 'loading') {
     return (
       <section className="profile-header" aria-live="polite">
         <p className="state-message">Loading profile...</p>
@@ -174,7 +178,7 @@ export function ProfileView({
     );
   }
 
-  if (state.status === 'not_found') {
+  if (currentState.status === 'not_found') {
     return (
       <section className="not-found" aria-labelledby="profile-not-found-title">
         <p className="eyebrow">404</p>
@@ -187,10 +191,10 @@ export function ProfileView({
     );
   }
 
-  if (state.status === 'error') {
+  if (currentState.status === 'error') {
     return (
       <section className="profile-header" aria-live="polite">
-        <p className="state-message state-message--error">{state.error}</p>
+        <p className="state-message state-message--error">{currentState.error}</p>
       </section>
     );
   }
@@ -205,10 +209,10 @@ export function ProfileView({
         isAuthenticated={isAuthenticated}
         isFollowMutating={isFollowMutating}
         onToggleFollow={handleToggleFollow}
-        profile={state.profile}
+        profile={currentState.profile}
       />
       <section className="feed-column" aria-label="Profile articles">
-        <ProfileTabs activeTab={activeTab} username={state.profile.username} />
+        <ProfileTabs activeTab={activeTab} username={currentState.profile.username} />
         <ArticleList
           key={articleListKey}
           loadArticles={loadArticles}
@@ -322,4 +326,13 @@ function ProfileTabs({ activeTab, username }: ProfileTabsProps): ReactElement {
 
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === 'AbortError';
+}
+
+function createLoadingState(username: string): ProfileState {
+  return {
+    error: null,
+    profile: null,
+    status: 'loading',
+    username,
+  };
 }

--- a/frontend/src/features/profile/components/ProfileView.tsx
+++ b/frontend/src/features/profile/components/ProfileView.tsx
@@ -1,0 +1,325 @@
+import {
+  type ReactElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '@/app/providers/useAuth';
+import {
+  ArticleList,
+  listArticles,
+  type ArticleListQuery,
+  type ArticleListResult,
+} from '@/features/article';
+import { isApiError } from '@/lib/apiError';
+import { followProfile, getProfile, unfollowProfile } from '../api/profileApi';
+import type { Profile } from '../types/profile';
+
+export type ProfileTab = 'authored' | 'favorited';
+
+interface ProfileViewProps {
+  activeTab: ProfileTab;
+  onPageChange: (page: number) => void;
+  page: number;
+  username: string;
+}
+
+type ProfileState =
+  | {
+      error: null;
+      profile: null;
+      status: 'loading';
+    }
+  | {
+      error: null;
+      profile: Profile;
+      status: 'success';
+    }
+  | {
+      error: string;
+      profile: null;
+      status: 'error';
+    }
+  | {
+      error: null;
+      profile: null;
+      status: 'not_found';
+    };
+
+/**
+ * Profile画面のProfile取得、follow操作、article tab表示をまとめる。
+ */
+export function ProfileView({
+  activeTab,
+  onPageChange,
+  page,
+  username,
+}: ProfileViewProps): ReactElement {
+  const { isAuthenticated, user } = useAuth();
+  const [state, setState] = useState<ProfileState>({
+    error: null,
+    profile: null,
+    status: 'loading',
+  });
+  const [isFollowMutating, setIsFollowMutating] = useState(false);
+  const [followError, setFollowError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let isCurrent = true;
+
+    setState({
+      error: null,
+      profile: null,
+      status: 'loading',
+    });
+    setFollowError(null);
+
+    async function load(): Promise<void> {
+      try {
+        const profile = await getProfile(username, undefined, controller.signal);
+
+        if (!isCurrent) {
+          return;
+        }
+
+        setState({
+          error: null,
+          profile,
+          status: 'success',
+        });
+      } catch (error: unknown) {
+        if (!isCurrent || isAbortError(error)) {
+          return;
+        }
+
+        if (isApiError(error) && error.kind === 'not_found') {
+          setState({
+            error: null,
+            profile: null,
+            status: 'not_found',
+          });
+          return;
+        }
+
+        setState({
+          error: 'Profile could not be loaded.',
+          profile: null,
+          status: 'error',
+        });
+      }
+    }
+
+    void load();
+
+    return () => {
+      isCurrent = false;
+      controller.abort();
+    };
+  }, [username]);
+
+  const loadArticles = useCallback(
+    (query: ArticleListQuery): Promise<ArticleListResult> => {
+      if (activeTab === 'favorited') {
+        return listArticles({
+          ...query,
+          favorited: username,
+        });
+      }
+
+      return listArticles({
+        ...query,
+        author: username,
+      });
+    },
+    [activeTab, username],
+  );
+  const articleListKey = useMemo(
+    () => `${username}:${activeTab}:${page}`,
+    [activeTab, page, username],
+  );
+
+  const handleToggleFollow = useCallback(async (): Promise<void> => {
+    if (state.status !== 'success') {
+      return;
+    }
+
+    setIsFollowMutating(true);
+    setFollowError(null);
+
+    try {
+      const nextProfile = state.profile.following
+        ? await unfollowProfile(state.profile.username)
+        : await followProfile(state.profile.username);
+
+      setState({
+        error: null,
+        profile: nextProfile,
+        status: 'success',
+      });
+    } catch {
+      setFollowError('Follow state could not be updated.');
+    } finally {
+      setIsFollowMutating(false);
+    }
+  }, [state]);
+
+  if (state.status === 'loading') {
+    return (
+      <section className="profile-header" aria-live="polite">
+        <p className="state-message">Loading profile...</p>
+      </section>
+    );
+  }
+
+  if (state.status === 'not_found') {
+    return (
+      <section className="not-found" aria-labelledby="profile-not-found-title">
+        <p className="eyebrow">404</p>
+        <h1 id="profile-not-found-title">Profile not found</h1>
+        <p>The profile could not be found.</p>
+        <Link className="primary-action" to="/">
+          Go home
+        </Link>
+      </section>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <section className="profile-header" aria-live="polite">
+        <p className="state-message state-message--error">{state.error}</p>
+      </section>
+    );
+  }
+
+  const currentUsername = user?.username ?? null;
+
+  return (
+    <>
+      <ProfileHeader
+        currentUsername={currentUsername}
+        followError={followError}
+        isAuthenticated={isAuthenticated}
+        isFollowMutating={isFollowMutating}
+        onToggleFollow={handleToggleFollow}
+        profile={state.profile}
+      />
+      <section className="feed-column" aria-label="Profile articles">
+        <ProfileTabs activeTab={activeTab} username={state.profile.username} />
+        <ArticleList
+          key={articleListKey}
+          loadArticles={loadArticles}
+          onPageChange={onPageChange}
+          page={page}
+        />
+      </section>
+    </>
+  );
+}
+
+interface ProfileHeaderProps {
+  currentUsername: string | null;
+  followError: string | null;
+  isAuthenticated: boolean;
+  isFollowMutating: boolean;
+  onToggleFollow: () => void;
+  profile: Profile;
+}
+
+function ProfileHeader({
+  currentUsername,
+  followError,
+  isAuthenticated,
+  isFollowMutating,
+  onToggleFollow,
+  profile,
+}: ProfileHeaderProps): ReactElement {
+  const isOwnProfile = currentUsername === profile.username;
+
+  return (
+    <section className="profile-header" aria-labelledby="profile-title">
+      <ProfileAvatar image={profile.image} username={profile.username} />
+      <h1 id="profile-title">{profile.username}</h1>
+      {profile.bio !== null && profile.bio.trim() !== '' ? (
+        <p className="profile-header__bio">{profile.bio}</p>
+      ) : null}
+      <div className="profile-header__actions">
+        {isOwnProfile ? (
+          <Link className="secondary-action" to="/settings">
+            Edit Profile Settings
+          </Link>
+        ) : null}
+        {!isOwnProfile && isAuthenticated ? (
+          <button
+            aria-pressed={profile.following}
+            className={profile.following ? 'secondary-action is-active' : 'secondary-action'}
+            disabled={isFollowMutating}
+            onClick={onToggleFollow}
+            type="button"
+          >
+            {profile.following ? 'Unfollow' : 'Follow'} {profile.username}
+          </button>
+        ) : null}
+      </div>
+      {followError !== null ? (
+        <p className="state-message state-message--compact state-message--error" role="alert">
+          {followError}
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+interface ProfileAvatarProps {
+  image: string | null;
+  username: string;
+}
+
+function ProfileAvatar({ image, username }: ProfileAvatarProps): ReactElement {
+  const imageUrl = image?.trim();
+
+  return (
+    <span className="avatar avatar--large" aria-hidden="true">
+      {imageUrl !== undefined && imageUrl !== '' ? (
+        <img alt="" src={imageUrl} />
+      ) : (
+        username.charAt(0).toUpperCase()
+      )}
+    </span>
+  );
+}
+
+interface ProfileTabsProps {
+  activeTab: ProfileTab;
+  username: string;
+}
+
+function ProfileTabs({ activeTab, username }: ProfileTabsProps): ReactElement {
+  const profilePath = `/profile/${encodeURIComponent(username)}`;
+
+  return (
+    <nav className="feed-tabs" aria-label="Profile tabs">
+      <Link
+        aria-current={activeTab === 'authored' ? 'page' : undefined}
+        className={activeTab === 'authored' ? 'is-active' : undefined}
+        to={profilePath}
+      >
+        My Articles
+      </Link>
+      <Link
+        aria-current={activeTab === 'favorited' ? 'page' : undefined}
+        className={activeTab === 'favorited' ? 'is-active' : undefined}
+        to={`${profilePath}/favorites`}
+      >
+        Favorited Articles
+      </Link>
+    </nav>
+  );
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}

--- a/frontend/src/features/profile/index.ts
+++ b/frontend/src/features/profile/index.ts
@@ -1,0 +1,9 @@
+export {
+  buildProfilePath,
+  followProfile,
+  getProfile,
+  mapProfileResponse,
+  unfollowProfile,
+} from './api/profileApi';
+export { ProfileView, type ProfileTab } from './components/ProfileView';
+export type { Profile } from './types/profile';

--- a/frontend/src/features/profile/types/profile.ts
+++ b/frontend/src/features/profile/types/profile.ts
@@ -1,0 +1,6 @@
+export interface Profile {
+  bio: string | null;
+  following: boolean;
+  image: string | null;
+  username: string;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -247,7 +247,10 @@ textarea:focus-visible {
   border-bottom: 1px solid var(--surface-line);
 }
 
-.feed-tabs button {
+.feed-tabs button,
+.feed-tabs a {
+  display: inline-flex;
+  align-items: center;
   border: 0;
   border-bottom: 2px solid transparent;
   background: transparent;
@@ -256,7 +259,8 @@ textarea:focus-visible {
   font-weight: 700;
 }
 
-.feed-tabs button.is-active {
+.feed-tabs button.is-active,
+.feed-tabs a.is-active {
   border-color: var(--primary);
   color: var(--primary);
 }
@@ -333,6 +337,13 @@ textarea:focus-visible {
   font-size: 2.25rem;
 }
 
+.avatar img {
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  object-fit: cover;
+}
+
 .favorite-button,
 .secondary-action {
   display: inline-flex;
@@ -349,6 +360,12 @@ textarea:focus-visible {
 }
 
 .favorite-button.is-active {
+  border-color: var(--primary);
+  background: var(--primary-soft);
+  color: var(--primary);
+}
+
+.secondary-action.is-active {
   border-color: var(--primary);
   background: var(--primary-soft);
   color: var(--primary);
@@ -719,6 +736,21 @@ button.tag {
   padding-block: 40px;
   border-bottom: 1px solid var(--surface-line);
   text-align: center;
+}
+
+.profile-header__bio {
+  max-width: 620px;
+  color: var(--text-muted);
+  font-family: var(--serif);
+  font-size: 1.08rem;
+  line-height: 1.6;
+}
+
+.profile-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
 }
 
 .not-found {


### PR DESCRIPTION
# 概要

- Profile / Favorites route を実 API 連携の画面へ置き換え
- `features/profile` に Profile API、follow/unfollow API、Profile 画面 UI を追加
- Article list API に `author` / `favorited` filter を追加
- guest / authenticated / own profile / 404 / favorites tab のユーザー視点テストを追加

# 関連Issue

Closes #78

Epic: #54

# 修正ファイルの説明

## Frontend Routes

- `frontend/src/app/routes/pages/ProfilePage.tsx`
  - route param、favorites tab、pagination query を解決し、Profile feature へ渡す構成に変更
  - Page に API 取得や follow state を持たせないため

## Profile Feature

- `frontend/src/features/profile/api/profileApi.ts`
  - Profile 取得、follow、unfollow の BFF API 関数を追加
  - Profile response を frontend model へ閉じ込めるため
- `frontend/src/features/profile/components/ProfileView.tsx`
  - Profile header、follow button、settings 導線、Profile tabs、Article list composition を追加
  - Profile workflow の状態と副作用を feature 内に閉じ込めるため
- `frontend/src/features/profile/types/profile.ts`
  - Profile 表示用 type を追加
- `frontend/src/features/profile/index.ts`
  - feature の公開 API を明示

## Article Feature

- `frontend/src/features/article/api/articleApi.ts`
  - `/api/articles` の `author` / `favorited` query parameter に対応
- `frontend/src/features/article/types/article.ts`
  - Profile 画面用 filter を `ArticleListParams` へ追加

## Styling

- `frontend/src/index.css`
  - Profile tabs の link 表示、Profile bio/action、avatar image 表示を追加
  - 既存の minimal editorial UI と同じ部品・色で表示するため

## Tests

- `frontend/src/app/routes/__tests__/ProfilePage.test.tsx`
  - guest / authenticated / own profile / favorites / not found の画面挙動を追加
- `frontend/src/features/profile/__tests__/profileApi.test.ts`
  - Profile API の path、encoding、follow/unfollow 変換を追加
- `frontend/src/features/article/__tests__/articleApi.test.ts`
  - `author` / `favorited` filter の query 生成を追加

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| フロントエンド変更あり | 型チェック | `pnpm tsc -b --noEmit` (`frontend/`) | 成功する | 成功 |
| フロントエンド変更あり | Vitest | `pnpm vitest run` (`frontend/`) | すべて成功する | 成功: 16 files / 78 tests |
| フロントエンド変更あり | ESLint | `pnpm eslint .` (`frontend/`) | 成功する | 成功 |
| ブラウザ確認 | Vite dev server + in-app browser | `http://127.0.0.1:5173/profile/eric` | BFF 404 時に Profile not found が表示され、console error がない | 成功 |
| バックエンド変更なし | Backend test / lint / static analysis | 対象外 | Frontend only のため未実施 | 対象外 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: Profile feature 境界、follow/unfollow の UI state、guest / own profile の表示差分
