### PR TITLE
[#75]: Comment UIを実装

### DIFF
--- a/frontend/src/features/article/components/ArticleDetail.tsx
+++ b/frontend/src/features/article/components/ArticleDetail.tsx
@@ -215,7 +215,11 @@ export function ArticleDetail({
         <ArticleMeta author={article.author} createdAt={article.createdAt} />
       </footer>
 
-      <CommentList isAuthenticated={isAuthenticated} slug={article.slug} />
+      <CommentList
+        currentUsername={currentUsername}
+        isAuthenticated={isAuthenticated}
+        slug={article.slug}
+      />
     </article>
   );
 }

--- a/frontend/src/features/comment/__tests__/CommentList.test.tsx
+++ b/frontend/src/features/comment/__tests__/CommentList.test.tsx
@@ -1,0 +1,404 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CommentList } from '../components/CommentList';
+
+type MockRouteResponse = Promise<Response> | Response | unknown | unknown[];
+
+describe('CommentList', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('guestはcommentsを閲覧でき、投稿formではなく認証導線を見る', async () => {
+    vi.stubGlobal(
+      'fetch',
+      createFetchMock({
+        '/api/articles/guest-article/comments': commentsWrapper([
+          commentResponse({
+            body: 'Public comment.',
+            id: 1,
+            username: 'reader',
+          }),
+        ]),
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <CommentList
+          currentUsername={null}
+          isAuthenticated={false}
+          slug="guest-article"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Public comment.')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('textbox', { name: 'Comment' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute(
+      'href',
+      '/login?returnTo=%2Farticle%2Fguest-article',
+    );
+    expect(screen.getByRole('link', { name: 'sign up' })).toHaveAttribute(
+      'href',
+      '/register',
+    );
+  });
+
+  it('authenticated userはcommentを投稿でき、送信中はsubmitを無効化する', async () => {
+    const user = userEvent.setup();
+    const createResponse = createDeferred<Response>();
+    vi.stubGlobal(
+      'fetch',
+      createFetchMock({
+        '/api/articles/create-article/comments': commentsWrapper([]),
+        '/api/session/csrf': { csrfToken: 'csrf-token' },
+        'POST /api/articles/create-article/comments': createResponse.promise,
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <CommentList
+          currentUsername="demo-user"
+          isAuthenticated={true}
+          slug="create-article"
+        />
+      </MemoryRouter>,
+    );
+
+    const commentInput = await screen.findByRole('textbox', { name: 'Comment' });
+    await user.type(commentInput, 'New comment.');
+    await user.click(screen.getByRole('button', { name: 'Post Comment' }));
+
+    expect(screen.getByRole('button', { name: 'Posting...' })).toBeDisabled();
+
+    createResponse.resolve(
+      jsonResponse(
+        singleCommentWrapper(
+          commentResponse({
+            body: 'New comment.',
+            id: 2,
+            username: 'demo-user',
+          }),
+        ),
+      ),
+    );
+
+    expect(await screen.findByText('New comment.')).toBeInTheDocument();
+    expect(commentInput).toHaveValue('');
+  });
+
+  it('required validationはAPIを呼ばずfield errorを表示する', async () => {
+    const user = userEvent.setup();
+    const fetchMock = createFetchMock({
+      '/api/articles/validation-article/comments': commentsWrapper([]),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <MemoryRouter>
+        <CommentList
+          currentUsername="demo-user"
+          isAuthenticated={true}
+          slug="validation-article"
+        />
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole('textbox', { name: 'Comment' });
+    await user.click(screen.getByRole('button', { name: 'Post Comment' }));
+
+    expect(screen.getByText('comment.body is required')).toBeInTheDocument();
+    expect(getRequestLog(fetchMock)).not.toContain(
+      'POST /api/articles/validation-article/comments',
+    );
+  });
+
+  it('API validation errorを表示し入力値を保持する', async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      'fetch',
+      createFetchMock({
+        '/api/articles/api-error-article/comments': commentsWrapper([]),
+        '/api/session/csrf': { csrfToken: 'csrf-token' },
+        'POST /api/articles/api-error-article/comments': jsonResponse(
+          {
+            errors: {
+              body: ['comment.body is too long'],
+            },
+          },
+          422,
+        ),
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <CommentList
+          currentUsername="demo-user"
+          isAuthenticated={true}
+          slug="api-error-article"
+        />
+      </MemoryRouter>,
+    );
+
+    const commentInput = await screen.findByRole('textbox', { name: 'Comment' });
+    await user.type(commentInput, 'Server rejected comment.');
+    await user.click(screen.getByRole('button', { name: 'Post Comment' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'comment.body is too long',
+    );
+    expect(commentInput).toHaveValue('Server rejected comment.');
+  });
+
+  it('comment authorだけにdelete actionを表示し、削除成功後にlistから除く', async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      'fetch',
+      createFetchMock({
+        '/api/articles/delete-article/comments': commentsWrapper([
+          commentResponse({
+            body: 'Other user comment.',
+            id: 1,
+            username: 'reader',
+          }),
+          commentResponse({
+            body: 'Own comment.',
+            id: 2,
+            username: 'demo-user',
+          }),
+        ]),
+        '/api/session/csrf': { csrfToken: 'csrf-token' },
+        'DELETE /api/articles/delete-article/comments/2': emptyResponse(),
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <CommentList
+          currentUsername="demo-user"
+          isAuthenticated={true}
+          slug="delete-article"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Other user comment.')).toBeInTheDocument();
+    expect(screen.getByText('Own comment.')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /^Delete comment by/ })).toHaveLength(
+      1,
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: 'Delete comment by demo-user' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Own comment.')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('Other user comment.')).toBeInTheDocument();
+  });
+
+  it('delete errorを表示し、失敗したcommentをlistに残す', async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      'fetch',
+      createFetchMock({
+        '/api/articles/delete-error-article/comments': commentsWrapper([
+          commentResponse({
+            body: 'Protected comment.',
+            id: 3,
+            username: 'demo-user',
+          }),
+        ]),
+        '/api/session/csrf': { csrfToken: 'csrf-token' },
+        'DELETE /api/articles/delete-error-article/comments/3': jsonResponse(
+          {
+            errors: {
+              body: ['Comment could not be deleted.'],
+            },
+          },
+          403,
+        ),
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <CommentList
+          currentUsername="demo-user"
+          isAuthenticated={true}
+          slug="delete-error-article"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Protected comment.')).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Delete comment by demo-user' }),
+    );
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Comment could not be deleted.',
+    );
+    expect(screen.getByText('Protected comment.')).toBeInTheDocument();
+  });
+});
+
+function commentsWrapper(comments: unknown[]): unknown {
+  return { comments };
+}
+
+function singleCommentWrapper(comment: unknown): unknown {
+  return { comment };
+}
+
+function commentResponse({
+  body,
+  id,
+  username,
+}: {
+  body: string;
+  id: number;
+  username: string;
+}): unknown {
+  return {
+    author: {
+      bio: null,
+      following: false,
+      image: null,
+      username,
+    },
+    body,
+    createdAt: '2026-05-08T00:00:00.000Z',
+    id,
+    updatedAt: '2026-05-08T00:00:00.000Z',
+  };
+}
+
+function createFetchMock(routes: Record<string, MockRouteResponse>): typeof fetch {
+  const fetcher: typeof fetch = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const path = requestPath(input);
+    const method = requestMethod(input, init);
+    const response =
+      readMockResponse(routes, `${method} ${path}`) ?? readMockResponse(routes, path);
+
+    if (response instanceof Promise) {
+      return response;
+    }
+
+    if (response instanceof Response) {
+      return response;
+    }
+
+    if (response !== undefined) {
+      return jsonResponse(response);
+    }
+
+    return jsonResponse(
+      {
+        errors: {
+          body: [`Unhandled request: ${method} ${path}`],
+        },
+      },
+      500,
+    );
+  };
+
+  return vi.fn(fetcher);
+}
+
+function readMockResponse(
+  routes: Record<string, MockRouteResponse>,
+  key: string,
+): MockRouteResponse | undefined {
+  const response = routes[key];
+
+  if (Array.isArray(response)) {
+    return response.shift();
+  }
+
+  return response;
+}
+
+function requestPath(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    const url = new URL(input, window.location.origin);
+
+    return `${url.pathname}${url.search}`;
+  }
+
+  const url = input instanceof URL ? input : new URL(input.url, window.location.origin);
+
+  return `${url.pathname}${url.search}`;
+}
+
+function requestMethod(input: RequestInfo | URL, init: RequestInit | undefined): string {
+  if (init?.method !== undefined) {
+    return init.method.toUpperCase();
+  }
+
+  if (input instanceof Request) {
+    return input.method.toUpperCase();
+  }
+
+  return 'GET';
+}
+
+function getRequestLog(fetchMock: typeof fetch): string[] {
+  return vi.mocked(fetchMock).mock.calls.map(([input, init]) => {
+    const method = requestMethod(input, init);
+    const path = requestPath(input);
+
+    return `${method} ${path}`;
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+}
+
+function emptyResponse(status = 204): Response {
+  return new Response(null, { status });
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T | PromiseLike<T>) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve: Deferred<T>['resolve'] | undefined;
+  let reject: Deferred<T>['reject'] | undefined;
+
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+
+  if (resolve === undefined || reject === undefined) {
+    throw new Error('Deferred callbacks were not initialized.');
+  }
+
+  return {
+    promise,
+    reject,
+    resolve,
+  };
+}

--- a/frontend/src/features/comment/__tests__/commentApi.test.ts
+++ b/frontend/src/features/comment/__tests__/commentApi.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { ApiClient } from '@/lib/apiClient';
-import { listComments } from '../api/commentApi';
+import { createComment, deleteComment, listComments } from '../api/commentApi';
 
 function createClient(): ApiClient {
   return {
@@ -51,5 +51,61 @@ describe('Comment API', () => {
         updatedAt: '2026-05-08T00:00:00.000Z',
       },
     ]);
+  });
+
+  it('Article commentを投稿してfrontend modelへ変換する', async () => {
+    const client = createClient();
+    vi.mocked(client.post).mockResolvedValue({
+      comment: {
+        author: {
+          bio: null,
+          following: false,
+          image: null,
+          username: 'demo-user',
+        },
+        body: 'New comment.',
+        createdAt: '2026-05-09T00:00:00.000Z',
+        id: 2,
+        updatedAt: '2026-05-09T00:00:00.000Z',
+      },
+    });
+
+    const result = await createComment(
+      'how-to-train-your-dragon',
+      { body: 'New comment.' },
+      client,
+    );
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/articles/how-to-train-your-dragon/comments',
+      {
+        comment: {
+          body: 'New comment.',
+        },
+      },
+    );
+    expect(result).toEqual({
+      author: {
+        bio: null,
+        following: false,
+        image: null,
+        username: 'demo-user',
+      },
+      body: 'New comment.',
+      createdAt: '2026-05-09T00:00:00.000Z',
+      id: 2,
+      updatedAt: '2026-05-09T00:00:00.000Z',
+    });
+  });
+
+  it('Article commentを削除する', async () => {
+    const client = createClient();
+    vi.mocked(client.delete).mockResolvedValue(null);
+
+    await deleteComment('how-to-train-your-dragon', 3, client);
+
+    expect(client.delete).toHaveBeenCalledWith(
+      '/api/articles/how-to-train-your-dragon/comments/3',
+    );
   });
 });

--- a/frontend/src/features/comment/api/commentApi.ts
+++ b/frontend/src/features/comment/api/commentApi.ts
@@ -1,8 +1,12 @@
 import { apiClient, type ApiClient } from '@/lib/apiClient';
-import type { ArticleComment } from '../types/comment';
+import type { ArticleComment, CreateCommentInput } from '../types/comment';
 
 interface CommentListResponse {
   comments: CommentResponse[];
+}
+
+interface SingleCommentResponse {
+  comment: CommentResponse;
 }
 
 interface CommentResponse {
@@ -37,6 +41,37 @@ export async function listComments(
   );
 }
 
+/**
+ * Articleへcommentを投稿し、作成されたcommentをfrontend modelへ変換する。
+ */
+export async function createComment(
+  slug: string,
+  input: CreateCommentInput,
+  client: ApiClient = apiClient,
+): Promise<ArticleComment> {
+  const response = await client.post<SingleCommentResponse>(
+    buildCommentsPath(slug),
+    {
+      comment: {
+        body: input.body,
+      },
+    },
+  );
+
+  return mapCommentResponse(response.comment);
+}
+
+/**
+ * Articleに紐づくcommentを削除する。
+ */
+export async function deleteComment(
+  slug: string,
+  commentId: number,
+  client: ApiClient = apiClient,
+): Promise<void> {
+  await client.delete<null>(buildCommentPath(slug, commentId));
+}
+
 export function mapCommentListResponse(
   response: CommentListResponse,
 ): ArticleComment[] {
@@ -45,6 +80,10 @@ export function mapCommentListResponse(
 
 export function buildCommentsPath(slug: string): string {
   return `/api/articles/${encodeURIComponent(slug)}/comments`;
+}
+
+export function buildCommentPath(slug: string, commentId: number): string {
+  return `${buildCommentsPath(slug)}/${encodeURIComponent(String(commentId))}`;
 }
 
 function mapCommentResponse(response: CommentResponse): ArticleComment {

--- a/frontend/src/features/comment/components/CommentList.tsx
+++ b/frontend/src/features/comment/components/CommentList.tsx
@@ -1,10 +1,16 @@
-import { type ReactElement, useEffect, useState } from 'react';
+import {
+  type FormEvent,
+  type ReactElement,
+  useEffect,
+  useState,
+} from 'react';
 import { Link } from 'react-router-dom';
 import { isApiError } from '@/lib/apiError';
-import { listComments } from '../api/commentApi';
+import { createComment, deleteComment, listComments } from '../api/commentApi';
 import type { ArticleComment } from '../types/comment';
 
 interface CommentListProps {
+  currentUsername: string | null;
   isAuthenticated: boolean;
   slug: string;
 }
@@ -27,9 +33,10 @@ type CommentListState =
     };
 
 /**
- * Article Detail内のread-only comments listを取得して表示する。
+ * Article Detail内のcomments list、投稿form、author-only削除操作を扱う。
  */
 export function CommentList({
+  currentUsername,
   isAuthenticated,
   slug,
 }: CommentListProps): ReactElement {
@@ -38,12 +45,21 @@ export function CommentList({
     error: null,
     status: 'loading',
   });
+  const [commentBody, setCommentBody] = useState('');
+  const [formErrors, setFormErrors] = useState<string[]>([]);
+  const [fieldErrors, setFieldErrors] = useState<string[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [deletingCommentId, setDeletingCommentId] = useState<number | null>(null);
+  const [deleteErrors, setDeleteErrors] = useState<Record<number, string>>({});
 
   useEffect(() => {
     const controller = new AbortController();
     let isCurrent = true;
 
     async function load(): Promise<void> {
+      setFormErrors([]);
+      setFieldErrors([]);
+      setDeleteErrors({});
       try {
         const comments = await listComments(slug, undefined, controller.signal);
 
@@ -77,10 +93,88 @@ export function CommentList({
     };
   }, [slug]);
 
+  async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    const body = commentBody.trim();
+
+    if (body === '') {
+      setFormErrors([]);
+      setFieldErrors(['comment.body is required']);
+      return;
+    }
+
+    setFormErrors([]);
+    setFieldErrors([]);
+    setIsSubmitting(true);
+
+    try {
+      const comment = await createComment(slug, { body });
+
+      setState((currentState) => ({
+        comments:
+          currentState.status === 'success'
+            ? [...currentState.comments, comment]
+            : [comment],
+        error: null,
+        status: 'success',
+      }));
+      setCommentBody('');
+    } catch (error: unknown) {
+      setFormErrors(getMutationErrorMessages(error, 'Comment could not be posted.'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleDelete(commentId: number): Promise<void> {
+    setDeleteErrors((currentErrors) => omitCommentError(currentErrors, commentId));
+    setDeletingCommentId(commentId);
+
+    try {
+      await deleteComment(slug, commentId);
+
+      setState((currentState) => {
+        if (currentState.status !== 'success') {
+          return currentState;
+        }
+
+        return {
+          comments: currentState.comments.filter((comment) => comment.id !== commentId),
+          error: null,
+          status: 'success',
+        };
+      });
+    } catch (error: unknown) {
+      setDeleteErrors((currentErrors) => ({
+        ...currentErrors,
+        [commentId]: getMutationErrorMessages(
+          error,
+          'Comment could not be deleted.',
+        ).at(0) ?? 'Comment could not be deleted.',
+      }));
+    } finally {
+      setDeletingCommentId(null);
+    }
+  }
+
   return (
     <section className="comments-section" aria-labelledby="comments-title">
       <h2 id="comments-title">Comments</h2>
-      {isAuthenticated ? null : (
+      {isAuthenticated ? (
+        <CommentForm
+          body={commentBody}
+          errors={formErrors}
+          fieldErrors={fieldErrors}
+          isSubmitting={isSubmitting}
+          onBodyChange={setCommentBody}
+          onSubmit={handleSubmit}
+        />
+      ) : (
         <p className="comment-auth-note">
           <Link to={`/login?returnTo=${encodeURIComponent(`/article/${slug}`)}`}>
             Sign in
@@ -88,16 +182,74 @@ export function CommentList({
           or <Link to="/register">sign up</Link> to add comments on this article.
         </p>
       )}
-      <CommentListContent state={state} />
+      <CommentListContent
+        currentUsername={currentUsername}
+        deleteErrors={deleteErrors}
+        deletingCommentId={deletingCommentId}
+        onDelete={handleDelete}
+        state={state}
+      />
     </section>
   );
 }
 
+interface CommentFormProps {
+  body: string;
+  errors: string[];
+  fieldErrors: string[];
+  isSubmitting: boolean;
+  onBodyChange: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}
+
+function CommentForm({
+  body,
+  errors,
+  fieldErrors,
+  isSubmitting,
+  onBodyChange,
+  onSubmit,
+}: CommentFormProps): ReactElement {
+  return (
+    <form className="comment-form form-stack" noValidate onSubmit={onSubmit}>
+      <FormErrorList errors={errors} />
+      <div className="form-field">
+        <label htmlFor="comment-body">Comment</label>
+        <textarea
+          aria-describedby={fieldErrors.length > 0 ? 'comment-body-error' : undefined}
+          aria-invalid={fieldErrors.length > 0 ? true : undefined}
+          id="comment-body"
+          onChange={(event) => onBodyChange(event.currentTarget.value)}
+          placeholder="Write a comment"
+          rows={4}
+          value={body}
+        />
+        <FieldError errors={fieldErrors} id="comment-body-error" />
+      </div>
+      <div className="form-actions">
+        <button className="primary-action" disabled={isSubmitting} type="submit">
+          {isSubmitting ? 'Posting...' : 'Post Comment'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
 interface CommentListContentProps {
+  currentUsername: string | null;
+  deleteErrors: Record<number, string>;
+  deletingCommentId: number | null;
+  onDelete: (commentId: number) => Promise<void>;
   state: CommentListState;
 }
 
-function CommentListContent({ state }: CommentListContentProps): ReactElement {
+function CommentListContent({
+  currentUsername,
+  deleteErrors,
+  deletingCommentId,
+  onDelete,
+  state,
+}: CommentListContentProps): ReactElement {
   if (state.status === 'loading') {
     return (
       <div className="comment-list" aria-live="polite">
@@ -127,18 +279,66 @@ function CommentListContent({ state }: CommentListContentProps): ReactElement {
   return (
     <div className="comment-list" aria-live="polite">
       {state.comments.map((comment) => (
-        <article className="comment-card" key={comment.id}>
-          <p>{comment.body}</p>
-          <footer className="comment-card__meta">
-            <CommentAvatar comment={comment} />
-            <Link to={`/profile/${encodeURIComponent(comment.author.username)}`}>
-              {comment.author.username}
-            </Link>
-            <time dateTime={comment.createdAt}>{formatDisplayDate(comment.createdAt)}</time>
-          </footer>
-        </article>
+        <CommentCard
+          canDelete={currentUsername === comment.author.username}
+          comment={comment}
+          deleteError={deleteErrors[comment.id]}
+          isDeleting={deletingCommentId === comment.id}
+          key={comment.id}
+          onDelete={onDelete}
+        />
       ))}
     </div>
+  );
+}
+
+interface CommentCardProps {
+  canDelete: boolean;
+  comment: ArticleComment;
+  deleteError?: string;
+  isDeleting: boolean;
+  onDelete: (commentId: number) => Promise<void>;
+}
+
+function CommentCard({
+  canDelete,
+  comment,
+  deleteError,
+  isDeleting,
+  onDelete,
+}: CommentCardProps): ReactElement {
+  return (
+    <article className="comment-card">
+      <p>{comment.body}</p>
+      <footer className="comment-card__meta">
+        <CommentAvatar comment={comment} />
+        <Link to={`/profile/${encodeURIComponent(comment.author.username)}`}>
+          {comment.author.username}
+        </Link>
+        <time dateTime={comment.createdAt}>{formatDisplayDate(comment.createdAt)}</time>
+        {canDelete ? (
+          <button
+            aria-label={`Delete comment by ${comment.author.username}`}
+            className="danger-action danger-action--compact comment-card__delete"
+            disabled={isDeleting}
+            onClick={() => {
+              void onDelete(comment.id);
+            }}
+            type="button"
+          >
+            {isDeleting ? 'Deleting...' : 'Delete'}
+          </button>
+        ) : null}
+      </footer>
+      {deleteError === undefined ? null : (
+        <p
+          className="state-message state-message--compact state-message--error comment-card__error"
+          role="alert"
+        >
+          {deleteError}
+        </p>
+      )}
+    </article>
   );
 }
 
@@ -172,6 +372,29 @@ function getCommentsErrorMessage(error: unknown): string {
   return 'Comments could not be loaded.';
 }
 
+function getMutationErrorMessages(error: unknown, fallback: string): string[] {
+  if (isApiError(error)) {
+    return error.bodyErrors.length > 0 ? error.bodyErrors : [error.message];
+  }
+
+  if (error instanceof Error) {
+    return [error.message];
+  }
+
+  return [fallback];
+}
+
+function omitCommentError(
+  errors: Record<number, string>,
+  commentId: number,
+): Record<number, string> {
+  const nextErrors = { ...errors };
+
+  delete nextErrors[commentId];
+
+  return nextErrors;
+}
+
 function formatDisplayDate(value: string): string {
   const date = new Date(value);
 
@@ -188,4 +411,39 @@ function formatDisplayDate(value: string): string {
 
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === 'AbortError';
+}
+
+interface FormErrorListProps {
+  errors: string[];
+}
+
+function FormErrorList({ errors }: FormErrorListProps): ReactElement | null {
+  if (errors.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className="form-errors" role="alert">
+      {errors.map((error) => (
+        <li key={error}>{error}</li>
+      ))}
+    </ul>
+  );
+}
+
+interface FieldErrorProps {
+  errors: string[];
+  id: string;
+}
+
+function FieldError({ errors, id }: FieldErrorProps): ReactElement | null {
+  if (errors.length === 0) {
+    return null;
+  }
+
+  return (
+    <p className="field-error" id={id}>
+      {errors.join(' ')}
+    </p>
+  );
 }

--- a/frontend/src/features/comment/index.ts
+++ b/frontend/src/features/comment/index.ts
@@ -1,7 +1,14 @@
 export {
+  buildCommentPath,
   buildCommentsPath,
+  createComment,
+  deleteComment,
   listComments,
   mapCommentListResponse,
 } from './api/commentApi';
 export { CommentList } from './components/CommentList';
-export type { ArticleComment, CommentAuthor } from './types/comment';
+export type {
+  ArticleComment,
+  CommentAuthor,
+  CreateCommentInput,
+} from './types/comment';

--- a/frontend/src/features/comment/types/comment.ts
+++ b/frontend/src/features/comment/types/comment.ts
@@ -12,3 +12,7 @@ export interface ArticleComment {
   id: number;
   updatedAt: string;
 }
+
+export interface CreateCommentInput {
+  body: string;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -686,6 +686,15 @@ button.tag {
   font-weight: 700;
 }
 
+.comment-form {
+  margin-top: 20px;
+}
+
+.comment-form textarea {
+  min-height: 112px;
+  resize: vertical;
+}
+
 .comment-list {
   display: grid;
   gap: 16px;
@@ -725,6 +734,15 @@ button.tag {
 
 .comment-card__meta time {
   margin-left: auto;
+}
+
+.comment-card__delete {
+  flex: 0 0 auto;
+}
+
+.comment-card__error {
+  margin: 0;
+  padding: 0 18px 16px;
 }
 
 .profile-header {


### PR DESCRIPTION
# 概要

- Article Detail 内の Comment list に authenticated user 向け投稿フォームを追加
- comment author のみ Delete action を表示し、削除成功時に list から除外
- validation / API error と投稿・削除中の loading state を追加

# 関連Issue

Closes #75

Epic: #58

# 修正ファイルの説明

## Frontend comment feature

- `frontend/src/features/comment/api/commentApi.ts`
  - `createComment` / `deleteComment` と comment detail path builder を追加
  - RealWorld の `comment` wrapper を frontend model へ変換するため
- `frontend/src/features/comment/components/CommentList.tsx`
  - comment form、author-only delete、create/delete error と loading state を追加
  - Issue #75 の Comment UI workflow を feature 内へ閉じ込めるため
- `frontend/src/features/comment/types/comment.ts` / `frontend/src/features/comment/index.ts`
  - create input type と public export を追加
  - feature の公開 API を明示するため
- `frontend/src/features/comment/__tests__/commentApi.test.ts` / `frontend/src/features/comment/__tests__/CommentList.test.tsx`
  - list/create/delete API と guest/auth/author の UI 差分を追加
  - validation、API error、loading state、delete failure をユーザー視点で検証するため

## Article Detail

- `frontend/src/features/article/components/ArticleDetail.tsx`
  - current username を `CommentList` へ渡す
  - comment author 判定を comment feature 側で行えるようにするため
- `frontend/src/index.css`
  - comment form と delete error の最小スタイルを追加
  - 既存 Article Detail の UI トーンに合わせるため

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| フロントエンド変更あり | 型チェック | `pnpm exec tsc -b --noEmit` | 成功する | 成功 |
| フロントエンド変更あり | Vitest | `pnpm exec vitest run` | すべて成功する | 17 files / 86 tests 成功 |
| フロントエンド変更あり | ESLint | `pnpm exec eslint .` | 成功する | 成功 |
| バックエンド変更なし | Backend テスト | 対象外 | 変更なし | 未実施 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: comment form / delete action の状態管理、author-only 表示、API error 表示の妥当性