### PR TITLE
[#81]: Frontend workflow coverageを補強

### DIFF
--- a/frontend/src/app/routes/__tests__/ArticleDetailPage.test.tsx
+++ b/frontend/src/app/routes/__tests__/ArticleDetailPage.test.tsx
@@ -6,6 +6,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AppProviders } from '@/app/providers/AppProviders';
 import type { AuthApi, AuthUser } from '@/features/auth';
 import { ApiError } from '@/lib/apiError';
+import {
+  createDeferred,
+  createFetchMock,
+  emptyResponse,
+  jsonResponse,
+  type MockRoutes,
+} from '@/test/mockFetch';
 import { createAppRouter } from '../router';
 
 const DEMO_USER: AuthUser = {
@@ -46,7 +53,7 @@ function renderArticleRoute({
 }: {
   initialPath: string;
   initialUser?: AuthUser | null;
-  routes: Record<string, unknown | unknown[]>;
+  routes: MockRoutes;
 }): ReactElement {
   vi.stubGlobal('fetch', createFetchMock(routes));
 
@@ -150,6 +157,56 @@ describe('ArticleDetailPage', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('favorite更新中はbuttonを無効化し、失敗時はArticle上にerrorを表示する', async () => {
+    const user = userEvent.setup();
+    const favoriteResponse = createDeferred<Response>();
+
+    render(
+      renderArticleRoute({
+        initialPath: '/article/favorite-error-article',
+        initialUser: DEMO_USER,
+        routes: {
+          '/api/articles/favorite-error-article': articleWrapper({
+            favoritesCount: 3,
+            slug: 'favorite-error-article',
+            title: 'Favorite error article',
+          }),
+          '/api/articles/favorite-error-article/comments': commentsWrapper([]),
+          '/api/session/csrf': { csrfToken: 'csrf-token' },
+          'POST /api/articles/favorite-error-article/favorite':
+            favoriteResponse.promise,
+        },
+      }),
+    );
+
+    expect(
+      await screen.findByRole('heading', { name: 'Favorite error article' }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Favorite Article (3)' }));
+    expect(
+      screen.getByRole('button', { name: 'Favorite Article (3)' }),
+    ).toBeDisabled();
+
+    favoriteResponse.resolve(
+      jsonResponse(
+        {
+          errors: {
+            body: ['Favorite could not be updated.'],
+          },
+        },
+        403,
+      ),
+    );
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Favorite could not be updated.',
+    );
+    expect(
+      screen.getByRole('button', { name: 'Favorite Article (3)' }),
+    ).toBeEnabled();
+  });
+
   it('authorだけがedit/delete actionを使え、delete成功後はHomeへ遷移する', async () => {
     const user = userEvent.setup();
 
@@ -188,6 +245,48 @@ describe('ArticleDetailPage', () => {
     expect(
       await screen.findByRole('heading', { name: 'Global Feed' }),
     ).toBeInTheDocument();
+  });
+
+  it('delete失敗時はArticleに留まりerrorを表示する', async () => {
+    const user = userEvent.setup();
+
+    render(
+      renderArticleRoute({
+        initialPath: '/article/delete-error-article',
+        initialUser: AUTHOR_USER,
+        routes: {
+          '/api/articles/delete-error-article': articleWrapper({
+            authorUsername: AUTHOR_USER.username,
+            slug: 'delete-error-article',
+            title: 'Delete error article',
+          }),
+          '/api/articles/delete-error-article/comments': commentsWrapper([]),
+          '/api/session/csrf': { csrfToken: 'csrf-token' },
+          'DELETE /api/articles/delete-error-article': jsonResponse(
+            {
+              errors: {
+                body: ['Article could not be deleted.'],
+              },
+            },
+            403,
+          ),
+        },
+      }),
+    );
+
+    expect(
+      await screen.findByRole('heading', { name: 'Delete error article' }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Delete Article' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Article could not be deleted.',
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Delete error article' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete Article' })).toBeEnabled();
   });
 
   it('404 slugはArticle Detail内でNot Found表示にする', async () => {
@@ -275,85 +374,4 @@ function commentResponse({
     id,
     updatedAt: '2026-05-08T00:00:00.000Z',
   };
-}
-
-function createFetchMock(routes: Record<string, unknown | unknown[]>): typeof fetch {
-  const fetcher: typeof fetch = async (
-    input: RequestInfo | URL,
-    init?: RequestInit,
-  ): Promise<Response> => {
-    const path = requestPath(input);
-    const method = requestMethod(input, init);
-    const response =
-      readMockResponse(routes, `${method} ${path}`) ?? readMockResponse(routes, path);
-
-    if (response instanceof Response) {
-      return response;
-    }
-
-    if (response !== undefined) {
-      return jsonResponse(response);
-    }
-
-    return jsonResponse(
-      {
-        errors: {
-          body: [`Unhandled request: ${method} ${path}`],
-        },
-      },
-      500,
-    );
-  };
-
-  return vi.fn(fetcher);
-}
-
-function readMockResponse(
-  routes: Record<string, unknown | unknown[]>,
-  key: string,
-): unknown {
-  const response = routes[key];
-
-  if (Array.isArray(response)) {
-    return response.shift();
-  }
-
-  return response;
-}
-
-function requestPath(input: RequestInfo | URL): string {
-  if (typeof input === 'string') {
-    const url = new URL(input, window.location.origin);
-
-    return `${url.pathname}${url.search}`;
-  }
-
-  const url = input instanceof URL ? input : new URL(input.url, window.location.origin);
-
-  return `${url.pathname}${url.search}`;
-}
-
-function requestMethod(input: RequestInfo | URL, init: RequestInit | undefined): string {
-  if (init?.method !== undefined) {
-    return init.method.toUpperCase();
-  }
-
-  if (input instanceof Request) {
-    return input.method.toUpperCase();
-  }
-
-  return 'GET';
-}
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    status,
-  });
-}
-
-function emptyResponse(status = 204): Response {
-  return new Response(null, { status });
 }

--- a/frontend/src/app/routes/__tests__/HomePage.test.tsx
+++ b/frontend/src/app/routes/__tests__/HomePage.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AppProviders } from '@/app/providers/AppProviders';
 import type { AuthApi, AuthUser } from '@/features/auth';
 import { ApiError } from '@/lib/apiError';
+import { createFetchMock, jsonResponse, type MockRoutes } from '@/test/mockFetch';
 import { createAppRouter } from '../router';
 
 const DEMO_USER: AuthUser = {
@@ -78,7 +79,7 @@ function renderHome({
 }: {
   initialPath?: string;
   initialUser?: AuthUser | null;
-  routes: Record<string, Response | unknown>;
+  routes: MockRoutes;
 }): ReactElement {
   vi.stubGlobal('fetch', createFetchMock(routes));
 
@@ -258,51 +259,4 @@ function articleResponse({
     title,
     updatedAt: '2026-05-06T00:00:00.000Z',
   };
-}
-
-function createFetchMock(routes: Record<string, Response | unknown>): typeof fetch {
-  const fetcher: typeof fetch = async (input: RequestInfo | URL): Promise<Response> => {
-    const path = requestPath(input);
-    const response = routes[path];
-
-    if (response instanceof Response) {
-      return response;
-    }
-
-    if (response !== undefined) {
-      return jsonResponse(response);
-    }
-
-    return jsonResponse(
-      {
-        errors: {
-          body: [`Unhandled request: ${path}`],
-        },
-      },
-      500,
-    );
-  };
-
-  return vi.fn(fetcher);
-}
-
-function requestPath(input: RequestInfo | URL): string {
-  if (typeof input === 'string') {
-    const url = new URL(input, window.location.origin);
-
-    return `${url.pathname}${url.search}`;
-  }
-
-  const url = input instanceof URL ? input : new URL(input.url, window.location.origin);
-
-  return `${url.pathname}${url.search}`;
-}
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    status,
-  });
 }

--- a/frontend/src/app/routes/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/app/routes/__tests__/ProfilePage.test.tsx
@@ -6,6 +6,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AppProviders } from '@/app/providers/AppProviders';
 import type { AuthApi, AuthUser } from '@/features/auth';
 import { ApiError } from '@/lib/apiError';
+import {
+  createDeferred,
+  createFetchMock,
+  jsonResponse,
+  type FetchMock,
+  type MockRoutes,
+} from '@/test/mockFetch';
 import { createAppRouter } from '../router';
 
 const DEMO_USER: AuthUser = {
@@ -46,8 +53,8 @@ function renderProfileRoute({
 }: {
   initialPath: string;
   initialUser?: AuthUser | null;
-  routes: Record<string, Response | unknown | unknown[]>;
-}): { fetchMock: ReturnType<typeof vi.fn>; view: ReactElement } {
+  routes: MockRoutes;
+}): { fetchMock: FetchMock; view: ReactElement } {
   const fetchMock = createFetchMock(routes);
   vi.stubGlobal('fetch', fetchMock);
 
@@ -97,6 +104,35 @@ describe('ProfilePage', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('Profile取得中はloading stateを表示し、成功後にProfile headerを表示する', async () => {
+    const profileResponse = createDeferred<Response>();
+    const { view } = renderProfileRoute({
+      initialPath: '/profile/loading-user',
+      routes: {
+        '/api/articles?author=loading-user&limit=10&offset=0': articlesWrapper([]),
+        '/api/profiles/loading-user': profileResponse.promise,
+      },
+    });
+
+    render(view);
+
+    expect(screen.getByText('Loading profile...')).toBeInTheDocument();
+
+    profileResponse.resolve(
+      jsonResponse(
+        profileWrapper({
+          bio: 'Loaded profile bio',
+          username: 'loading-user',
+        }),
+      ),
+    );
+
+    expect(
+      await screen.findByRole('heading', { name: 'loading-user' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Loaded profile bio')).toBeInTheDocument();
+  });
+
   it('authenticated userは他ユーザーをfollow/unfollowでき、返却されたfollowing stateを表示へ反映する', async () => {
     const user = userEvent.setup();
     const { view } = renderProfileRoute({
@@ -131,6 +167,45 @@ describe('ProfilePage', () => {
     expect(
       await screen.findByRole('button', { name: 'Follow eric' }),
     ).toBeInTheDocument();
+  });
+
+  it('follow更新中はbuttonを無効化し、失敗時はerrorを表示して元のstateを維持する', async () => {
+    const user = userEvent.setup();
+    const followResponse = createDeferred<Response>();
+    const { view } = renderProfileRoute({
+      initialPath: '/profile/eric',
+      initialUser: DEMO_USER,
+      routes: {
+        '/api/articles?author=eric&limit=10&offset=0': articlesWrapper([]),
+        '/api/profiles/eric': profileWrapper({
+          following: false,
+          username: 'eric',
+        }),
+        '/api/session/csrf': { csrfToken: 'csrf-token' },
+        'POST /api/profiles/eric/follow': followResponse.promise,
+      },
+    });
+
+    render(view);
+
+    await user.click(await screen.findByRole('button', { name: 'Follow eric' }));
+    expect(screen.getByRole('button', { name: 'Follow eric' })).toBeDisabled();
+
+    followResponse.resolve(
+      jsonResponse(
+        {
+          errors: {
+            body: ['Follow state could not be updated.'],
+          },
+        },
+        403,
+      ),
+    );
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Follow state could not be updated.',
+    );
+    expect(screen.getByRole('button', { name: 'Follow eric' })).toBeEnabled();
   });
 
   it('自分のProfileではfollow buttonを表示せずsettings導線を表示する', async () => {
@@ -262,83 +337,4 @@ function articleResponse({
     title,
     updatedAt: '2026-05-06T00:00:00.000Z',
   };
-}
-
-function createFetchMock(
-  routes: Record<string, Response | unknown | unknown[]>,
-): ReturnType<typeof vi.fn> {
-  const fetcher: typeof fetch = async (
-    input: RequestInfo | URL,
-    init?: RequestInit,
-  ): Promise<Response> => {
-    const path = requestPath(input);
-    const method = requestMethod(input, init);
-    const response =
-      readMockResponse(routes, `${method} ${path}`) ?? readMockResponse(routes, path);
-
-    if (response instanceof Response) {
-      return response;
-    }
-
-    if (response !== undefined) {
-      return jsonResponse(response);
-    }
-
-    return jsonResponse(
-      {
-        errors: {
-          body: [`Unhandled request: ${method} ${path}`],
-        },
-      },
-      500,
-    );
-  };
-
-  return vi.fn(fetcher);
-}
-
-function readMockResponse(
-  routes: Record<string, Response | unknown | unknown[]>,
-  key: string,
-): Response | unknown {
-  const response = routes[key];
-
-  if (Array.isArray(response)) {
-    return response.shift();
-  }
-
-  return response;
-}
-
-function requestPath(input: RequestInfo | URL): string {
-  if (typeof input === 'string') {
-    const url = new URL(input, window.location.origin);
-
-    return `${url.pathname}${url.search}`;
-  }
-
-  const url = input instanceof URL ? input : new URL(input.url, window.location.origin);
-
-  return `${url.pathname}${url.search}`;
-}
-
-function requestMethod(input: RequestInfo | URL, init: RequestInit | undefined): string {
-  if (init?.method !== undefined) {
-    return init.method.toUpperCase();
-  }
-
-  if (input instanceof Request) {
-    return input.method.toUpperCase();
-  }
-
-  return 'GET';
-}
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    status,
-  });
 }

--- a/frontend/src/features/auth/__tests__/AuthForms.test.tsx
+++ b/frontend/src/features/auth/__tests__/AuthForms.test.tsx
@@ -54,6 +54,40 @@ describe('認証フォーム', () => {
     expect(screen.getByLabelText('Password')).toHaveValue('secret');
   });
 
+  it('login formは送信中の二重submitを防止する', async () => {
+    let resolveSubmit: (() => void) | undefined;
+    const submitPromise = new Promise<void>((resolve) => {
+      resolveSubmit = resolve;
+    });
+    const onSubmit = vi.fn().mockReturnValue(submitPromise);
+
+    render(<LoginForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'jake@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'secret' },
+    });
+
+    const form = screen.getByRole('button', { name: 'Sign in' }).closest('form');
+
+    if (form === null) {
+      throw new Error('Login form was not rendered');
+    }
+
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(screen.getByRole('button', { name: 'Signing in...' })).toBeDisabled();
+
+    await act(async () => {
+      resolveSubmit?.();
+      await submitPromise;
+    });
+  });
+
   it('登録認証情報を送信しAPI拒否時も入力値を保持する', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn().mockRejectedValue(
@@ -82,6 +116,43 @@ describe('認証フォーム', () => {
     expect(screen.getByLabelText('Username')).toHaveValue('jake');
     expect(screen.getByLabelText('Email')).toHaveValue('jake@example.com');
     expect(screen.getByLabelText('Password')).toHaveValue('secret');
+  });
+
+  it('register formは送信中の二重submitを防止する', async () => {
+    let resolveSubmit: (() => void) | undefined;
+    const submitPromise = new Promise<void>((resolve) => {
+      resolveSubmit = resolve;
+    });
+    const onSubmit = vi.fn().mockReturnValue(submitPromise);
+
+    render(<RegisterForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText('Username'), {
+      target: { value: 'jake' },
+    });
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'jake@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'secret' },
+    });
+
+    const form = screen.getByRole('button', { name: 'Sign up' }).closest('form');
+
+    if (form === null) {
+      throw new Error('Register form was not rendered');
+    }
+
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(screen.getByRole('button', { name: 'Signing up...' })).toBeDisabled();
+
+    await act(async () => {
+      resolveSubmit?.();
+      await submitPromise;
+    });
   });
 
   it('settings formは現在のユーザー値を初期表示して更新内容を送信する', async () => {

--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, type ReactElement, useState } from 'react';
+import { type FormEvent, type ReactElement, useRef, useState } from 'react';
 import type { LoginCredentials } from '../types/auth';
 import { getFormErrors } from '../utils/formErrors';
 
@@ -18,9 +18,14 @@ export function LoginForm({
   const [errors, setErrors] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [password, setPassword] = useState('');
+  const isSubmittingRef = useRef(false);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
+
+    if (isSubmittingRef.current) {
+      return;
+    }
 
     const validationErrors = validateLogin({ email, password });
 
@@ -30,6 +35,7 @@ export function LoginForm({
     }
 
     setErrors([]);
+    isSubmittingRef.current = true;
     setIsSubmitting(true);
 
     try {
@@ -38,6 +44,7 @@ export function LoginForm({
     } catch (error: unknown) {
       setErrors(getFormErrors(error));
     } finally {
+      isSubmittingRef.current = false;
       setIsSubmitting(false);
     }
   }

--- a/frontend/src/features/auth/components/RegisterForm.tsx
+++ b/frontend/src/features/auth/components/RegisterForm.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, type ReactElement, useState } from 'react';
+import { type FormEvent, type ReactElement, useRef, useState } from 'react';
 import type { RegisterCredentials } from '../types/auth';
 import { getFormErrors } from '../utils/formErrors';
 
@@ -19,9 +19,14 @@ export function RegisterForm({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [password, setPassword] = useState('');
   const [username, setUsername] = useState('');
+  const isSubmittingRef = useRef(false);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();
+
+    if (isSubmittingRef.current) {
+      return;
+    }
 
     const validationErrors = validateRegister({ email, password, username });
 
@@ -31,6 +36,7 @@ export function RegisterForm({
     }
 
     setErrors([]);
+    isSubmittingRef.current = true;
     setIsSubmitting(true);
 
     try {
@@ -39,6 +45,7 @@ export function RegisterForm({
     } catch (error: unknown) {
       setErrors(getFormErrors(error));
     } finally {
+      isSubmittingRef.current = false;
       setIsSubmitting(false);
     }
   }

--- a/frontend/src/features/comment/__tests__/CommentList.test.tsx
+++ b/frontend/src/features/comment/__tests__/CommentList.test.tsx
@@ -2,9 +2,14 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createDeferred,
+  createFetchMock,
+  emptyResponse,
+  getRequestLog,
+  jsonResponse,
+} from '@/test/mockFetch';
 import { CommentList } from '../components/CommentList';
-
-type MockRouteResponse = Promise<Response> | Response | unknown | unknown[];
 
 describe('CommentList', () => {
   afterEach(() => {
@@ -280,125 +285,5 @@ function commentResponse({
     createdAt: '2026-05-08T00:00:00.000Z',
     id,
     updatedAt: '2026-05-08T00:00:00.000Z',
-  };
-}
-
-function createFetchMock(routes: Record<string, MockRouteResponse>): typeof fetch {
-  const fetcher: typeof fetch = async (
-    input: RequestInfo | URL,
-    init?: RequestInit,
-  ): Promise<Response> => {
-    const path = requestPath(input);
-    const method = requestMethod(input, init);
-    const response =
-      readMockResponse(routes, `${method} ${path}`) ?? readMockResponse(routes, path);
-
-    if (response instanceof Promise) {
-      return response;
-    }
-
-    if (response instanceof Response) {
-      return response;
-    }
-
-    if (response !== undefined) {
-      return jsonResponse(response);
-    }
-
-    return jsonResponse(
-      {
-        errors: {
-          body: [`Unhandled request: ${method} ${path}`],
-        },
-      },
-      500,
-    );
-  };
-
-  return vi.fn(fetcher);
-}
-
-function readMockResponse(
-  routes: Record<string, MockRouteResponse>,
-  key: string,
-): MockRouteResponse | undefined {
-  const response = routes[key];
-
-  if (Array.isArray(response)) {
-    return response.shift();
-  }
-
-  return response;
-}
-
-function requestPath(input: RequestInfo | URL): string {
-  if (typeof input === 'string') {
-    const url = new URL(input, window.location.origin);
-
-    return `${url.pathname}${url.search}`;
-  }
-
-  const url = input instanceof URL ? input : new URL(input.url, window.location.origin);
-
-  return `${url.pathname}${url.search}`;
-}
-
-function requestMethod(input: RequestInfo | URL, init: RequestInit | undefined): string {
-  if (init?.method !== undefined) {
-    return init.method.toUpperCase();
-  }
-
-  if (input instanceof Request) {
-    return input.method.toUpperCase();
-  }
-
-  return 'GET';
-}
-
-function getRequestLog(fetchMock: typeof fetch): string[] {
-  return vi.mocked(fetchMock).mock.calls.map(([input, init]) => {
-    const method = requestMethod(input, init);
-    const path = requestPath(input);
-
-    return `${method} ${path}`;
-  });
-}
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    status,
-  });
-}
-
-function emptyResponse(status = 204): Response {
-  return new Response(null, { status });
-}
-
-interface Deferred<T> {
-  promise: Promise<T>;
-  reject: (reason?: unknown) => void;
-  resolve: (value: T | PromiseLike<T>) => void;
-}
-
-function createDeferred<T>(): Deferred<T> {
-  let resolve: Deferred<T>['resolve'] | undefined;
-  let reject: Deferred<T>['reject'] | undefined;
-
-  const promise = new Promise<T>((innerResolve, innerReject) => {
-    resolve = innerResolve;
-    reject = innerReject;
-  });
-
-  if (resolve === undefined || reject === undefined) {
-    throw new Error('Deferred callbacks were not initialized.');
-  }
-
-  return {
-    promise,
-    reject,
-    resolve,
   };
 }

--- a/frontend/src/test/mockFetch.ts
+++ b/frontend/src/test/mockFetch.ts
@@ -1,0 +1,131 @@
+import { vi, type Mock } from 'vitest';
+
+export type MockRouteResponse = Promise<Response> | Response | unknown;
+export type MockRoutes = Record<string, MockRouteResponse | MockRouteResponse[]>;
+
+type Fetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+export type FetchMock = Mock<Fetcher>;
+
+export interface Deferred<T> {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T | PromiseLike<T>) => void;
+}
+
+/**
+ * route integration tests向けにmethod+path優先、path fallbackのfetch mockを作る。
+ */
+export function createFetchMock(routes: MockRoutes): FetchMock {
+  const fetcher: Fetcher = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const path = requestPath(input);
+    const method = requestMethod(input, init);
+    const response =
+      readMockResponse(routes, `${method} ${path}`) ?? readMockResponse(routes, path);
+
+    if (response instanceof Promise) {
+      return response;
+    }
+
+    if (response instanceof Response) {
+      return response;
+    }
+
+    if (response !== undefined) {
+      return jsonResponse(response);
+    }
+
+    return jsonResponse(
+      {
+        errors: {
+          body: [`Unhandled request: ${method} ${path}`],
+        },
+      },
+      500,
+    );
+  };
+
+  return vi.fn(fetcher);
+}
+
+export function getRequestLog(fetchMock: FetchMock): string[] {
+  return fetchMock.mock.calls.map(([input, init]) => {
+    const method = requestMethod(input, init);
+    const path = requestPath(input);
+
+    return `${method} ${path}`;
+  });
+}
+
+export function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  });
+}
+
+export function emptyResponse(status = 204): Response {
+  return new Response(null, { status });
+}
+
+export function createDeferred<T>(): Deferred<T> {
+  let resolve: Deferred<T>['resolve'] | undefined;
+  let reject: Deferred<T>['reject'] | undefined;
+
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+
+  if (resolve === undefined || reject === undefined) {
+    throw new Error('Deferred callbacks were not initialized.');
+  }
+
+  return {
+    promise,
+    reject,
+    resolve,
+  };
+}
+
+function readMockResponse(
+  routes: MockRoutes,
+  key: string,
+): MockRouteResponse | undefined {
+  const response = routes[key];
+
+  if (Array.isArray(response)) {
+    return response.shift();
+  }
+
+  return response;
+}
+
+function requestPath(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    const url = new URL(input, window.location.origin);
+
+    return `${url.pathname}${url.search}`;
+  }
+
+  const url = input instanceof URL ? input : new URL(input.url, window.location.origin);
+
+  return `${url.pathname}${url.search}`;
+}
+
+function requestMethod(input: RequestInfo | URL, init: RequestInit | undefined): string {
+  if (init?.method !== undefined) {
+    return init.method.toUpperCase();
+  }
+
+  if (input instanceof Request) {
+    return input.method.toUpperCase();
+  }
+
+  return 'GET';
+}


### PR DESCRIPTION
# 概要

- Login / Register form の同期二重 submit 防止テストと guard を追加
- Article favorite/delete と Profile follow の pending/error state をユーザー視点で補強
- route/component test の fetch mock helper を共通化

# 関連Issue

Closes #81

Epic: #52

# 修正ファイルの説明

## Frontend forms

- `frontend/src/features/auth/components/LoginForm.tsx`
  - 送信中に連続 submit されても `onSubmit` を一度だけ呼ぶ guard を追加
  - React state 反映前の同期 submit による二重送信を防ぐため
- `frontend/src/features/auth/components/RegisterForm.tsx`
  - Login と同じ submit guard を追加
  - 登録フォームでも二重送信防止の挙動を揃えるため

## Frontend tests

- `frontend/src/features/auth/__tests__/AuthForms.test.tsx`
  - Login / Register の二重 submit 防止テストを追加
- `frontend/src/app/routes/__tests__/ArticleDetailPage.test.tsx`
  - favorite 更新中/失敗、delete 失敗時のユーザー表示を追加
- `frontend/src/app/routes/__tests__/ProfilePage.test.tsx`
  - profile loading、follow 更新中/失敗時のユーザー表示を追加
- `frontend/src/app/routes/__tests__/HomePage.test.tsx`
  - fetch mock helper を共通化
- `frontend/src/features/comment/__tests__/CommentList.test.tsx`
  - fetch mock / deferred / response helper を共通化
- `frontend/src/test/mockFetch.ts`
  - route/component integration test 用の fetch mock helper を追加

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| フロントエンド変更あり | 型チェック | `pnpm --dir frontend exec tsc -b --noEmit` | 成功する | 成功 |
| フロントエンド変更あり | テスト | `pnpm --dir frontend exec vitest run` | 成功する | 成功: 17 files / 92 tests |
| フロントエンド変更あり | リント | `pnpm --dir frontend exec eslint .` | 成功する | 成功 |
| 差分確認 | whitespace check | `git diff --check` | 成功する | 成功 |
| バックエンド変更なし | バックエンド検証 | 対象外 | 対象外 | 未実施: frontend test 補強のみ |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: Testing Library の assertion がユーザー視点になっているか、共通 mock helper が過剰抽象になっていないか
