### PR TITLE
[#100]: Dev Containerのnode_modulesを分離

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - .:/workspace:cached
+      - devcontainer-root-node-modules:/workspace/node_modules
+      - devcontainer-frontend-node-modules:/workspace/frontend/node_modules
       - devcontainer-bashhistory:/commandhistory
       - pnpm-store:/home/node/.local/share/pnpm/store
       - "${HOME}/.config/gh:/home/node/.config/gh"
@@ -33,4 +35,6 @@ services:
 
 volumes:
   devcontainer-bashhistory:
+  devcontainer-root-node-modules:
+  devcontainer-frontend-node-modules:
   pnpm-store:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ docker compose exec frontend sh
 pnpm install
 ```
 
+Dev Container 内でフロントエンドテストを実行する場合:
+
+```bash
+cd /workspace/frontend && pnpm install && pnpm test
+```
+
+Dev Container では `/workspace/node_modules` と `/workspace/frontend/node_modules` を named volume に分離し、ホスト OS 側の `node_modules` を参照しない構成にしています。
+
 Frontend は browser から same-origin の `/api/*` だけを呼び、Vite dev server が BFF (`BFF_PROXY_TARGET`, 既定 `http://localhost:3006`) へ proxy します。
 既存の `frontend/.env.local` に `VITE_API_BASE_URL=http://localhost:8080` が残っている場合は、Public API/backend-nginx 直送になるため削除してください。
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "prepare": "husky",
     "qa:auth": "node scripts/qa/auth-integration-qa.mjs",
-    "test:docs": "node --test tests/docs/*.test.mjs"
+    "test:docs": "node --test tests/docs/*.test.mjs",
+    "test:infra": "node --test tests/infra/*.test.mjs"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.0",

--- a/tests/infra/devcontainer-compose.test.mjs
+++ b/tests/infra/devcontainer-compose.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const devcontainerCompose = readFileSync(
+  new URL('../../.devcontainer/docker-compose.yml', import.meta.url),
+  'utf8',
+);
+const rootCompose = readFileSync(
+  new URL('../../compose.yml', import.meta.url),
+  'utf8',
+);
+const readme = readFileSync(new URL('../../README.md', import.meta.url), 'utf8');
+const rootPackage = JSON.parse(
+  readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
+);
+
+test('Dev Container isolates root and frontend node_modules from the host bind mount', () => {
+  assertVolumeMount(
+    devcontainerCompose,
+    'devcontainer-root-node-modules',
+    '/workspace/node_modules',
+  );
+  assertVolumeMount(
+    devcontainerCompose,
+    'devcontainer-frontend-node-modules',
+    '/workspace/frontend/node_modules',
+  );
+  assertTopLevelVolume(devcontainerCompose, 'devcontainer-root-node-modules');
+  assertTopLevelVolume(devcontainerCompose, 'devcontainer-frontend-node-modules');
+});
+
+test('frontend service keeps its existing /app/node_modules named volume', () => {
+  assertVolumeMount(rootCompose, 'frontend-node-modules', '/app/node_modules');
+  assertTopLevelVolume(rootCompose, 'frontend-node-modules');
+});
+
+test('README documents the Dev Container frontend test command', () => {
+  assert.match(readme, /Dev Container/);
+  assert.match(readme, /cd \/workspace\/frontend && pnpm install && pnpm test/);
+});
+
+test('root package exposes the infra configuration test', () => {
+  assert.equal(rootPackage.scripts['test:infra'], 'node --test tests/infra/*.test.mjs');
+});
+
+function assertVolumeMount(composeFile, volumeName, mountPath) {
+  assert.match(
+    composeFile,
+    new RegExp(`-\\s+${escapeRegExp(volumeName)}:${escapeRegExp(mountPath)}(?:\\s|$)`),
+    `${volumeName} must be mounted at ${mountPath}`,
+  );
+}
+
+function assertTopLevelVolume(composeFile, volumeName) {
+  assert.match(
+    composeFile,
+    new RegExp(`^  ${escapeRegExp(volumeName)}:\\s*$`, 'm'),
+    `${volumeName} must be declared in top-level volumes`,
+  );
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
# 概要

- Dev Container の `/workspace/node_modules` と `/workspace/frontend/node_modules` を named volume に分離
- Dev Container 内での frontend テスト実行手順を README に追記
- Dev Container / frontend service の node_modules volume 構成を検証する infra test を追加

# 関連Issue

Closes #100

Epic: #52

# 修正ファイルの説明

## Infra / Dev Container

- `.devcontainer/docker-compose.yml`
  - `devcontainer-root-node-modules` と `devcontainer-frontend-node-modules` を追加
  - repository bind mount 配下の node_modules がホスト OS 側と共有されないようにするため
- `tests/infra/devcontainer-compose.test.mjs`
  - Dev Container と frontend service の node_modules volume 構成を検証
  - rolldown など native optional dependency の OS 差分が再発しないようにするため
- `package.json`
  - `test:infra` script を追加
  - infra 設定テストを個別実行できるようにするため

## Docs

- `README.md`
  - Dev Container 内での `cd /workspace/frontend && pnpm install && pnpm test` 手順を追記
  - frontend service と Dev Container の依存関係 install 先を区別できるようにするため

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| Infra 設定変更あり | Dev Container / frontend service の volume 構成 | `pnpm test:infra` | すべて成功する | 成功 |
| Docs 既存テスト | docs contract / policy tests | `pnpm test:docs` | すべて成功する | 成功 |
| フロントエンド変更あり | フロントエンドテスト | `pnpm --dir frontend test` | すべて成功する | 成功 |
| フロントエンド変更あり | フロントエンド lint | `pnpm --dir frontend lint` | 成功する | 成功 |
| フロントエンド変更あり | フロントエンド型チェック | `pnpm --dir frontend exec tsc -b --noEmit` | 成功する | 成功 |
| Dev Container compose | compose 設定の正規化確認 | `docker compose -f compose.yml -f .devcontainer/docker-compose.yml config` | node_modules volumes が含まれる | 成功 |
| Docker frontend service | 既存 frontend service のテスト | `docker compose exec -T frontend sh -lc 'pnpm test'` | 成功する | 未実施: Docker daemon socket が存在せず接続不可 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: Dev Container の nested volume mount が `/workspace` bind mount 配下の host `node_modules` を確実に隠しているか
