### PR TITLE
[#84]: E2Eスモークを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,3 +189,94 @@ jobs:
 
       - name: Static analysis (PHPStan / Larastan)
         run: ./vendor/bin/phpstan analyse --no-progress --memory-limit=512M
+
+  # ---------------------------------------------------------------
+  # E2E
+  # ---------------------------------------------------------------
+  e2e:
+    name: E2E Smoke
+    runs-on: ubuntu-latest
+    needs:
+      - frontend
+      - bff
+      - backend
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install E2E dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: pnpm e2e:install
+
+      - name: Prepare backend environment
+        run: |
+          cp backend/.env.example backend/.env
+          sed -i 's/^APP_URL=.*/APP_URL=http:\/\/localhost:8080/' backend/.env
+          sed -i 's/^JWT_SIGNING_SECRET=.*/JWT_SIGNING_SECRET=ci-realworld-e2e-jwt-secret/' backend/.env
+          sed -i 's/^DB_HOST=.*/DB_HOST=db/' backend/.env
+          sed -i 's/^DB_PORT=.*/DB_PORT=3306/' backend/.env
+          sed -i 's/^DB_DATABASE=.*/DB_DATABASE=real_world/' backend/.env
+          sed -i 's/^DB_USERNAME=.*/DB_USERNAME=real_world/' backend/.env
+          sed -i 's/^DB_PASSWORD=.*/DB_PASSWORD=secret/' backend/.env
+
+      - name: Start Docker services
+        run: docker compose up -d db redis backend-php backend-nginx bff frontend
+
+      - name: Install backend dependencies
+        run: docker compose exec -T backend-php composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Generate application key
+        run: docker compose exec -T backend-php php artisan key:generate
+
+      - name: Run migrations
+        run: |
+          for i in {1..30}; do
+            docker compose exec -T backend-php php artisan migrate:fresh --force && exit 0
+            sleep 2
+          done
+
+          docker compose logs --tail=200 db backend-php backend-nginx
+          exit 1
+
+      - name: Wait for frontend
+        run: |
+          for i in {1..60}; do
+            curl -fsS http://127.0.0.1:3005 >/dev/null && exit 0
+            sleep 2
+          done
+
+          docker compose logs --tail=200 frontend bff backend-nginx
+          exit 1
+
+      - name: Run E2E smoke
+        run: pnpm e2e
+
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright-artifacts
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore
+
+      - name: Print Docker logs
+        if: failure()
+        run: docker compose logs --tail=200
+
+      - name: Stop Docker services
+        if: always()
+        run: docker compose down -v

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .pnpm-store
 node_modules/
 bff/dist/
+playwright-report/
+test-results/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ React 19 + Laravel 13 で API / CRUD / DDD を学ぶためのモノレポです�
 | フロントエンド | React 19 + TypeScript 5.9 + Vite 8 |
 | バックエンド | Laravel 13 + PHP 8.4 |
 | DB | MySQL 8.0 |
-| テスト | Vitest + Testing Library / Pest |
+| テスト | Vitest + Testing Library / Pest / Playwright |
 | 品質チェック | ESLint / Pint / PHPStan |
 
 ## セットアップ
@@ -111,6 +111,22 @@ pnpm -C bff test
 ```bash
 pnpm qa:auth
 ```
+
+E2E smoke（Docker 起動済み環境）:
+
+```bash
+pnpm install
+pnpm e2e:install
+docker compose up -d
+docker compose exec backend-php composer install
+docker compose exec backend-php php artisan key:generate
+docker compose exec backend-php php artisan migrate
+pnpm e2e
+```
+
+E2E は browser から `http://127.0.0.1:3005` を開き、Vite proxy -> BFF -> Laravel API の経路で register / login / article / comment / favorite の happy path を確認します。
+別の frontend origin で実行する場合は `E2E_BASE_URL=http://localhost:3005 pnpm e2e` のように指定できます。
+失敗時は `test-results/` の screenshot / trace と `playwright-report/` の HTML report を確認します。
 
 バックエンド:
 

--- a/e2e/realworld-mvp-smoke.spec.ts
+++ b/e2e/realworld-mvp-smoke.spec.ts
@@ -90,7 +90,7 @@ async function publishArticle(page: Page, article: ArticleInput): Promise<void> 
 
 async function postComment(page: Page, body: string): Promise<void> {
   await expect(page.getByRole('heading', { name: 'Comments' })).toBeVisible();
-  await page.getByLabel('Comment').fill(body);
+  await page.getByRole('textbox', { name: 'Comment' }).fill(body);
   await page.getByRole('button', { name: 'Post Comment' }).click();
 }
 

--- a/e2e/realworld-mvp-smoke.spec.ts
+++ b/e2e/realworld-mvp-smoke.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test, type Page } from '@playwright/test';
+
+interface Credentials {
+  email: string;
+  password: string;
+  username: string;
+}
+
+interface ArticleInput {
+  body: string;
+  comment: string;
+  description: string;
+  tags: string;
+  title: string;
+}
+
+test.describe('RealWorld MVP smoke', () => {
+  test('registers, logs in, publishes, comments, and favorites an article', async ({
+    page,
+  }, testInfo) => {
+    const runId = createRunId(testInfo.workerIndex);
+    const author = createCredentials('author', runId);
+    const reader = createCredentials('reader', runId);
+    const article = createArticleInput(runId);
+
+    await register(page, author);
+    await signOut(page);
+    await login(page, author);
+    await expect(page.getByRole('link', { name: 'Profile' })).toBeVisible();
+
+    await publishArticle(page, article);
+    await expect(page.getByRole('heading', { name: article.title })).toBeVisible();
+    await expect(page.getByText(article.body)).toBeVisible();
+
+    await postComment(page, article.comment);
+    await expect(page.getByText(article.comment)).toBeVisible();
+
+    const articleUrl = page.url();
+
+    await signOut(page);
+    await register(page, reader);
+    await page.goto(articleUrl);
+
+    const favoriteButton = page.getByRole('button', {
+      name: /Favorite Article \(0\)/,
+    });
+    await expect(favoriteButton).toBeVisible();
+    await favoriteButton.click();
+
+    await expect(
+      page.getByRole('button', { name: /Unfavorite Article \(1\)/ }),
+    ).toHaveAttribute('aria-pressed', 'true');
+  });
+});
+
+async function register(page: Page, credentials: Credentials): Promise<void> {
+  await page.goto('/register');
+  await expect(page.getByRole('heading', { name: 'Sign up' })).toBeVisible();
+  await page.getByLabel('Username').fill(credentials.username);
+  await page.getByLabel('Email').fill(credentials.email);
+  await page.getByLabel('Password').fill(credentials.password);
+  await page.getByRole('button', { name: 'Sign up' }).click();
+  await expect(page.getByRole('button', { name: 'Sign out' })).toBeVisible();
+}
+
+async function login(page: Page, credentials: Credentials): Promise<void> {
+  await page.goto('/login');
+  await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible();
+  await page.getByLabel('Email').fill(credentials.email);
+  await page.getByLabel('Password').fill(credentials.password);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page.getByRole('button', { name: 'Sign out' })).toBeVisible();
+}
+
+async function signOut(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Sign out' }).click();
+  await expect(page.getByRole('link', { name: 'Sign in' })).toBeVisible();
+}
+
+async function publishArticle(page: Page, article: ArticleInput): Promise<void> {
+  await page.getByRole('link', { name: 'New Article' }).click();
+  await expect(page.getByRole('heading', { name: 'New Article' })).toBeVisible();
+  await page.getByLabel('Title').fill(article.title);
+  await page.getByLabel('Description').fill(article.description);
+  await page.getByLabel('Body').fill(article.body);
+  await page.getByLabel('Tags').fill(article.tags);
+  await page.getByRole('button', { name: 'Publish Article' }).click();
+  await expect(page).toHaveURL(/\/article\/[^/]+$/);
+}
+
+async function postComment(page: Page, body: string): Promise<void> {
+  await expect(page.getByRole('heading', { name: 'Comments' })).toBeVisible();
+  await page.getByLabel('Comment').fill(body);
+  await page.getByRole('button', { name: 'Post Comment' }).click();
+}
+
+function createRunId(workerIndex: number): string {
+  return (
+    process.env.E2E_RUN_ID ??
+    `run-${Date.now().toString(36)}-${workerIndex}`
+  )
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .slice(0, 24);
+}
+
+function createCredentials(role: 'author' | 'reader', runId: string): Credentials {
+  const username = `e2e_${role}_${runId}`.slice(0, 50);
+
+  return {
+    email: `${username}@example.test`,
+    password: 'Password123!',
+    username,
+  };
+}
+
+function createArticleInput(runId: string): ArticleInput {
+  return {
+    body: `This article body was created by the E2E smoke test ${runId}.`,
+    comment: `E2E smoke comment ${runId}`,
+    description: `E2E smoke description ${runId}`,
+    tags: `e2e-smoke, ${runId}`,
+    title: `E2E Smoke Article ${runId}`,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "e2e": "playwright test",
+    "e2e:install": "playwright install chromium",
+    "e2e:report": "playwright show-report",
     "prepare": "husky",
     "qa:auth": "node scripts/qa/auth-integration-qa.mjs",
     "test:docs": "node --test tests/docs/*.test.mjs"
@@ -9,6 +12,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.8.0",
     "@commitlint/config-conventional": "^19.8.0",
+    "@playwright/test": "^1.61.1",
     "husky": "^9.1.7"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.E2E_BASE_URL ?? 'http://127.0.0.1:3005';
+const isCi = process.env.CI === 'true';
+
+export default defineConfig({
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  outputDir: 'test-results/e2e',
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+  ],
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: 'playwright-report' }],
+  ],
+  retries: isCi ? 1 : 0,
+  testDir: './e2e',
+  timeout: 60_000,
+  use: {
+    actionTimeout: 15_000,
+    baseURL,
+    navigationTimeout: 30_000,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+  workers: 1,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^19.8.0
         version: 19.8.1
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -96,6 +99,11 @@ packages:
   '@commitlint/types@19.8.1':
     resolution: {integrity: sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==}
     engines: {node: '>=v18'}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@types/conventional-commits-parser@5.0.2':
     resolution: {integrity: sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==}
@@ -207,6 +215,11 @@ packages:
   find-up@7.0.0:
     resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
     engines: {node: '>=18'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -337,6 +350,16 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -534,6 +557,10 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.2
       chalk: 5.6.2
 
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@types/conventional-commits-parser@5.0.2':
     dependencies:
       '@types/node': 25.6.0
@@ -642,6 +669,9 @@ snapshots:
       path-exists: 5.0.0
       unicorn-magic: 0.1.0
 
+  fsevents@2.3.2:
+    optional: true
+
   get-caller-file@2.0.5: {}
 
   git-raw-commits@4.0.0:
@@ -739,6 +769,14 @@ snapshots:
   path-exists@5.0.0: {}
 
   picocolors@1.1.1: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   require-directory@2.1.1: {}
 


### PR DESCRIPTION
# 概要

- Playwright による RealWorld MVP の E2E smoke を追加
- register / login / article 作成 / comment 投稿 / 別ユーザー favorite の happy path を browser 経由で確認
- CI に Docker Compose 起動、backend 初期化、Playwright artifact upload を含む E2E job を追加
- README に local E2E 実行手順と artifact 確認先を追記

# 関連Issue

Closes #84

Epic: #52

# 修正ファイルの説明

## E2E

- `e2e/realworld-mvp-smoke.spec.ts`
  - register -> logout -> login/current user -> article create -> comment -> second user register -> favorite の smoke test を追加
  - fixture は run id 付き username/email/title/tag/comment で衝突を避ける
- `playwright.config.ts`
  - Chromium project、base URL、trace / screenshot / HTML report 出力を定義
- `package.json` / `pnpm-lock.yaml`
  - `@playwright/test` と `pnpm e2e` / `pnpm e2e:install` / `pnpm e2e:report` を追加
- `.gitignore`
  - Playwright report と test result artifact を除外

## CI / Docs

- `.github/workflows/ci.yml`
  - frontend / bff / backend job 後に E2E smoke job を追加
  - CI 内で backend `.env` を `.env.example` から生成し、Docker Compose 経由で migration 後に `pnpm e2e` を実行
  - 失敗時に Playwright artifact と Docker logs を残す
- `README.md`
  - E2E smoke の local 実行手順、`E2E_BASE_URL`、artifact 確認先を追記

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| Playwright 設定 | テスト検出 | `pnpm exec playwright test --list` | 1 smoke test が検出される | 成功 |
| Root dependency | lockfile 整合性 | `pnpm install --frozen-lockfile` | 成功する | 成功 |
| Docs | docs test | `pnpm test:docs` | 全て成功する | 成功 |
| フロントエンド変更影響 | 型チェック | `pnpm -C frontend exec tsc -b --noEmit` | 成功する | 成功 |
| フロントエンド変更影響 | lint | `pnpm -C frontend run lint` | 成功する | 成功 |
| フロントエンド変更影響 | Vitest | `pnpm -C frontend run test` | 全て成功する | 成功 |
| 空白チェック | diff whitespace | `git diff --check` | 空である | 成功 |
| E2E full run | Docker Compose 上で `pnpm e2e` | Docker daemon 起動環境で smoke が成功する | 未実施 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: E2E job では `migrate:fresh --force` を実行
- 環境変数・設定変更: CI runtime のみ `backend/.env` を `.env.example` から生成。git 管理ファイルの `.env` は変更なし
- レビュー時に重点確認してほしい点: CI の Docker Compose 初期化手順、BFF 経由で Public API を直接叩いていないこと、E2E fixture の独立性
- ローカル Codex 環境では Docker daemon が起動していなかったため full E2E は未実施。CI または Docker 起動済み環境で確認する想定
