### PR TITLE
[#82]: READMEとローカルセットアップを更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ React 19 + Laravel 13 で API / CRUD / DDD を学ぶためのモノレポです�
 | レイヤー | 技術 |
 | --- | --- |
 | フロントエンド | React 19 + TypeScript 5.9 + Vite 8 |
+| BFF | Hono + TypeScript |
 | バックエンド | Laravel 13 + PHP 8.4 |
-| DB | MySQL 8.0 |
+| DB / Session Store | MySQL 8.0 / Redis 7 |
 | テスト | Vitest + Testing Library / Pest / Playwright |
 | 品質チェック | ESLint / Pint / PHPStan |
 
@@ -18,29 +19,23 @@ React 19 + Laravel 13 で API / CRUD / DDD を学ぶためのモノレポです�
 必要なもの:
 
 - Docker Desktop
+- ホスト側で docs test / E2E を実行する場合は Node 24 + pnpm（`mise.toml` 参照）
 
-起動:
+初回起動:
 
 ```bash
 docker compose up -d
+docker compose exec backend-php composer install
+cp backend/.env.example backend/.env
+perl -0pi -e 's/DB_HOST=.*/DB_HOST=db/; s/DB_PORT=.*/DB_PORT=3306/; s/DB_DATABASE=.*/DB_DATABASE=real_world/; s/DB_USERNAME=.*/DB_USERNAME=real_world/; s/DB_PASSWORD=.*/DB_PASSWORD=secret/' backend/.env
+JWT_SECRET="$(docker compose exec -T backend-php php -r 'echo bin2hex(random_bytes(32));')" perl -0pi -e 's/JWT_SIGNING_SECRET=.*/JWT_SIGNING_SECRET=$ENV{JWT_SECRET}/' backend/.env
+docker compose exec backend-php php artisan key:generate
+docker compose exec backend-php php artisan migrate
+docker compose exec frontend pnpm install
 ```
 
-バックエンド初期設定:
-
-```bash
-docker compose exec backend-php bash
-composer install
-cp .env.example .env
-php artisan key:generate
-php artisan migrate
-```
-
-フロントエンド初期設定:
-
-```bash
-docker compose exec frontend sh
-pnpm install
-```
+BFF は起動時に `bff/pnpm-lock.yaml` の checksum を見て、必要な場合だけ container 内で `pnpm install --frozen-lockfile` を実行します。
+`backend/.env` は gitignored のローカル設定です。既存ファイルがある場合は上書きせず、Docker では `DB_HOST=db`、`DB_DATABASE=real_world`、`DB_USERNAME=real_world`、`DB_PASSWORD=secret`、`JWT_SIGNING_SECRET` が設定されていることを確認してください。
 
 Dev Container 内でフロントエンドテストを実行する場合:
 
@@ -61,12 +56,14 @@ docker compose down
 
 ## アクセス先
 
-| サービス | URL |
-| --- | --- |
-| フロントエンド | http://localhost:3005 |
-| BFF | http://localhost:3006 |
-| バックエンド API | http://localhost:8080 |
-| Mailpit | http://localhost:8025 |
+| サービス | URL / Port | 用途 |
+| --- | --- | --- |
+| `frontend` | http://localhost:3005 | Vite dev server。browser はこの origin の `/api/*` を呼ぶ |
+| BFF (`bff`) | http://localhost:3006 | Hono BFF。通常は frontend の proxy 経由で使う |
+| `backend-nginx` | http://localhost:8080 | Laravel Public API の直接確認用 |
+| `db` | `localhost:3309` -> container `3306` | MySQL |
+| `redis` | `localhost:6379` | BFF BrowserSession store |
+| `mailpit` | SMTP `localhost:1025` / UI http://localhost:8025 | ローカルメール確認 |
 
 Docker 環境では、frontend の Vite dev server が same-origin の `/api/*` request を BFF へ proxy します。
 BFF は private network 上の `backend-nginx` へ server-to-server request を行い、BrowserSession に保持した Public API JWT だけを `Authorization: Token <jwt>` として送信します。
@@ -99,12 +96,21 @@ XDEBUG_MODE=develop,debug docker compose up -d backend-php backend-nginx
 
 ## テスト・リント
 
+Docs / infra:
+
+```bash
+pnpm install
+pnpm test:docs
+pnpm test:infra
+git diff --check
+```
+
 フロントエンド:
 
 ```bash
-cd frontend && pnpm vitest run
-cd frontend && pnpm eslint .
-cd frontend && pnpm tsc -b --noEmit
+pnpm -C frontend tsc -b --noEmit
+pnpm -C frontend vitest run
+pnpm -C frontend eslint .
 ```
 
 BFF:
@@ -112,6 +118,7 @@ BFF:
 ```bash
 pnpm -C bff type-check
 pnpm -C bff test
+pnpm -C bff lint
 ```
 
 認証統合 QA（Docker 起動済み環境）:
@@ -125,23 +132,20 @@ E2E smoke（Docker 起動済み環境）:
 ```bash
 pnpm install
 pnpm e2e:install
-docker compose up -d
-docker compose exec backend-php composer install
-docker compose exec backend-php php artisan key:generate
-docker compose exec backend-php php artisan migrate
 pnpm e2e
 ```
 
-E2E は browser から `http://127.0.0.1:3005` を開き、Vite proxy -> BFF -> Laravel API の経路で register / login / article / comment / favorite の happy path を確認します。
+E2E は初回起動とバックエンド初期設定が済んだ Docker 環境に対して実行します。
+Browser から `http://127.0.0.1:3005` を開き、Vite proxy -> BFF -> Laravel API の経路で register / login / article / comment / favorite の happy path を確認します。
 別の frontend origin で実行する場合は `E2E_BASE_URL=http://localhost:3005 pnpm e2e` のように指定できます。
 失敗時は `test-results/` の screenshot / trace と `playwright-report/` の HTML report を確認します。
 
 バックエンド:
 
 ```bash
-cd backend && php artisan test
-cd backend && ./vendor/bin/pint --test
-cd backend && ./vendor/bin/phpstan analyse
+docker compose exec backend-php php artisan test
+docker compose exec backend-php ./vendor/bin/pint --test
+docker compose exec backend-php ./vendor/bin/phpstan analyse
 ```
 
 ## 主なディレクトリ
@@ -158,6 +162,7 @@ cd backend && ./vendor/bin/phpstan analyse
 
 - [Docs Guide](docs/README.md)
 - [要件定義](docs/requirements.md)
+- [非機能要件](docs/non-functional-requirements.md)
 - [AI Harness Design](docs/ai/harness.md)
 - [コーディングルール](docs/rules/)
 - [ドメイン設計](docs/arch/)

--- a/docs/non-functional-requirements.md
+++ b/docs/non-functional-requirements.md
@@ -288,14 +288,15 @@ The project must be runnable with Docker Compose and lockfiles.
 Required local prerequisites:
 
 - Docker Desktop or compatible Docker environment
-- Node / pnpm for frontend work outside the container
-- Composer / PHP for backend work outside the container
+- Node 24 / pnpm for docs, frontend, BFF, or E2E work outside the containers
+- Backend Composer / PHP commands should run inside the `backend-php` container
 
 Version hints:
 
 - `mise.toml` pins Node `24` and Python `3.14`.
 - Backend dependencies are locked by `backend/composer.lock`.
 - Frontend dependencies are locked by `frontend/pnpm-lock.yaml`.
+- BFF dependencies are locked by `bff/pnpm-lock.yaml`.
 - The actual package versions are resolved from each package manifest and lockfile.
 
 Docker services:
@@ -303,16 +304,21 @@ Docker services:
 | Service | Purpose | Port |
 | --- | --- | --- |
 | `frontend` | Vite dev server | `3005` |
+| `bff` | Hono BFF for BrowserSession, CSRF, and Public API forwarding | `3006` |
 | `backend-nginx` | Laravel API through Nginx | `8080` |
 | `backend-php` | PHP-FPM / Laravel runtime | internal |
 | `db` | MySQL | host `3309`, container `3306` |
-| `mailpit` | Local mail UI | `8025` |
+| `redis` | BFF BrowserSession store | `6379` |
+| `mailpit` | Local SMTP / mail UI | SMTP `1025`, UI `8025` |
 
 Expected setup flow:
 
 ```bash
 docker compose up -d
 docker compose exec backend-php composer install
+cp backend/.env.example backend/.env
+perl -0pi -e 's/DB_HOST=.*/DB_HOST=db/; s/DB_PORT=.*/DB_PORT=3306/; s/DB_DATABASE=.*/DB_DATABASE=real_world/; s/DB_USERNAME=.*/DB_USERNAME=real_world/; s/DB_PASSWORD=.*/DB_PASSWORD=secret/' backend/.env
+JWT_SECRET="$(docker compose exec -T backend-php php -r 'echo bin2hex(random_bytes(32));')" perl -0pi -e 's/JWT_SIGNING_SECRET=.*/JWT_SIGNING_SECRET=$ENV{JWT_SECRET}/' backend/.env
 docker compose exec backend-php php artisan key:generate
 docker compose exec backend-php php artisan migrate
 docker compose exec frontend pnpm install
@@ -329,12 +335,13 @@ Browser -> frontend origin (:3005) /api/* -> bff -> backend-nginx (private Docke
 - Local development では frontend dev proxy または frontend-facing gateway が `/api/*` を `bff` service へ転送する。
 - `backend-nginx:8080` は Public API contract の直接検証用に利用できるが、first-party frontend の認証付き通信先にはしない。
 - BFF は `backend-nginx` へ server-to-server request を行い、server-side に保持した JWT だけを `Authorization: Token <jwt>` として送る。
-- `compose.yml`、Hono + TypeScript BFF runtime/container、proxy 設定、`.env.example` の追加変数は BFF 実装 Issue で変更する。
+- `compose.yml` では BFF が private network 上の `backend-nginx` と `redis` に接続し、frontend service は `/api/*` を `BFF_PROXY_TARGET` へ proxy する。
 
 `.env` handling:
 
 - Use `backend/.env.example` as the template.
 - `backend/.env` is ignored and must not be committed.
+- Docker local setup expects `DB_HOST=db`, `DB_DATABASE=real_world`, `DB_USERNAME=real_world`, `DB_PASSWORD=secret`, and a non-empty random `JWT_SIGNING_SECRET`.
 - Changes needed by every developer go into `.env.example` or docs, not a personal `.env`.
 
 ## README Requirements

--- a/tests/docs/readme-local-setup.test.mjs
+++ b/tests/docs/readme-local-setup.test.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const readme = readFileSync(new URL('../../README.md', import.meta.url), 'utf8');
+const nonFunctionalRequirements = readFileSync(
+  new URL('../../docs/non-functional-requirements.md', import.meta.url),
+  'utf8',
+);
+const rootPackage = JSON.parse(
+  readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
+);
+const frontendPackage = JSON.parse(
+  readFileSync(new URL('../../frontend/package.json', import.meta.url), 'utf8'),
+);
+const bffPackage = JSON.parse(
+  readFileSync(new URL('../../bff/package.json', import.meta.url), 'utf8'),
+);
+
+test('README has copy-pasteable first-run Docker setup commands', () => {
+  for (const command of [
+    'docker compose up -d',
+    'docker compose exec backend-php composer install',
+    'cp backend/.env.example backend/.env',
+    'perl -0pi -e',
+    'docker compose exec backend-php php artisan key:generate',
+    'docker compose exec backend-php php artisan migrate',
+    'docker compose exec frontend pnpm install',
+    'docker compose down',
+  ]) {
+    assert.match(readme, new RegExp(escapeRegExp(command)));
+  }
+
+  assert.match(readme, /JWT_SECRET=.*random_bytes\(32\)/);
+  assert.doesNotMatch(readme, /docker compose exec backend-php bash/);
+  assert.doesNotMatch(readme, /docker compose exec frontend sh/);
+});
+
+test('README documents implemented Docker services and ports', () => {
+  for (const service of [
+    ['frontend', '3005'],
+    ['BFF', '3006'],
+    ['backend-nginx', '8080'],
+    ['db', '3309'],
+    ['redis', '6379'],
+    ['mailpit', '8025'],
+    ['mailpit', '1025'],
+  ]) {
+    const [name, port] = service;
+
+    assert.match(readme, new RegExp(`${escapeRegExp(name)}[\\s\\S]*${port}`, 'i'));
+  }
+});
+
+test('README verification commands match package scripts and backend Docker execution', () => {
+  assert.equal(rootPackage.scripts['test:docs'], 'node --test tests/docs/*.test.mjs');
+  assert.equal(rootPackage.scripts['test:infra'], 'node --test tests/infra/*.test.mjs');
+  assert.equal(frontendPackage.scripts.test, 'vitest run');
+  assert.equal(frontendPackage.scripts.lint, 'eslint .');
+  assert.equal(bffPackage.scripts.test, 'node --import tsx --test "test/**/*.test.ts"');
+  assert.equal(bffPackage.scripts['type-check'], 'tsc -p tsconfig.json --noEmit');
+  assert.equal(bffPackage.scripts.lint, 'eslint .');
+
+  for (const command of [
+    'pnpm test:docs',
+    'pnpm test:infra',
+    'pnpm -C frontend tsc -b --noEmit',
+    'pnpm -C frontend vitest run',
+    'pnpm -C frontend eslint .',
+    'pnpm -C bff type-check',
+    'pnpm -C bff test',
+    'pnpm -C bff lint',
+    'docker compose exec backend-php php artisan test',
+    'docker compose exec backend-php ./vendor/bin/pint --test',
+    'docker compose exec backend-php ./vendor/bin/phpstan analyse',
+    'git diff --check',
+  ]) {
+    assert.match(readme, new RegExp(escapeRegExp(command)));
+  }
+});
+
+test('README keeps BFF setup caveats and docs links visible', () => {
+  for (const requiredText of [
+    'same-origin',
+    'BFF_PROXY_TARGET',
+    'VITE_API_BASE_URL',
+    'Public API/backend-nginx',
+    '[Docs Guide](docs/README.md)',
+    '[非機能要件](docs/non-functional-requirements.md)',
+    '[コーディングルール](docs/rules/)',
+  ]) {
+    assert.match(readme, new RegExp(escapeRegExp(requiredText)));
+  }
+});
+
+test('non-functional requirements list the current Docker support services', () => {
+  const localReproducibility = markdownSection(
+    nonFunctionalRequirements,
+    'Local Reproducibility',
+    2,
+  );
+
+  for (const service of ['bff', 'redis', 'backend-nginx', 'backend-php', 'frontend']) {
+    assert.match(localReproducibility, new RegExp(escapeRegExp(service)));
+  }
+});
+
+function markdownSection(markdown, heading, level) {
+  const hashes = '#'.repeat(level);
+  const sectionStart = markdown.indexOf(`${hashes} ${heading}\n`);
+
+  assert.notEqual(sectionStart, -1, `${hashes} ${heading} section is missing`);
+
+  const bodyStart = sectionStart + `${hashes} ${heading}\n`.length;
+  const remaining = markdown.slice(bodyStart);
+  const nextHeading = new RegExp(`\\n#{1,${level}} `);
+  const nextHeadingMatch = remaining.match(nextHeading);
+
+  return nextHeadingMatch === null
+    ? remaining
+    : remaining.slice(0, nextHeadingMatch.index);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
# 概要

- README の初回セットアップ手順を Docker/BFF/Redis 構成に合わせて copy-pasteable に更新
- Service URL / port と docs・frontend・BFF・backend の検証コマンドを実装状態に同期
- README と非機能要件がローカルセットアップ前提からズレないよう docs test を追加

# 関連Issue

Closes #82

Epic: #52

# 修正ファイルの説明

## Docs

- `README.md`
  - 初回 Docker 起動、backend `.env` 作成、DB 接続値、JWT signing secret、frontend setup、shutdown を一連の手順へ整理
  - `frontend` / `bff` / `backend-nginx` / `db` / `redis` / `mailpit` の port と用途を実装状態に合わせて更新
  - docs / infra / frontend / BFF / backend の検証コマンドを現在の scripts と Docker 実行方針に合わせて更新
- `docs/non-functional-requirements.md`
  - Local Reproducibility の service 一覧と setup flow に BFF / Redis / BFF lockfile / backend Docker 実行方針を反映

## Tests

- `tests/docs/readme-local-setup.test.mjs`
  - README の初回セットアップ、service ports、検証コマンド、BFF caveat、docs links、非機能要件の service 記述を検証
  - README が `compose.yml` / package scripts / Docker backend 実行方針からズレた場合に検出するため追加

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| ドキュメント変更 | README / docs の整合性テスト | `pnpm test:docs` | すべて成功する | 成功 |
| インフラ docs 影響 | Dev Container / README 既存テスト | `pnpm test:infra` | すべて成功する | 成功 |
| ドキュメント変更 | Markdown whitespace check | `git diff --check` | 空白エラーがない | 成功 |
| 対象外の検証あり | Frontend / BFF / Backend の単体・静的解析 | docs-only 変更で runtime code と lockfile を変更していないため未実施 | 未検証範囲を判断できる | 対象外 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: なし。README に `backend/.env` のローカル作成手順を記載したが、`.env` 実ファイルは変更していない
- レビュー時に重点確認してほしい点: 初回セットアップ手順が実際の Docker service 名・port・BFF 経路と一致しているか
