### PR TITLE
[#98]: Dev Container推奨拡張を更新

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
   "customizations": {
     "vscode": {
       "extensions": [
+        "anthropic.claude-code",
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
         "eamodio.gitlens",

--- a/tests/infra/devcontainer-compose.test.mjs
+++ b/tests/infra/devcontainer-compose.test.mjs
@@ -6,6 +6,9 @@ const devcontainerCompose = readFileSync(
   new URL('../../.devcontainer/docker-compose.yml', import.meta.url),
   'utf8',
 );
+const devcontainerConfig = JSON.parse(
+  readFileSync(new URL('../../.devcontainer/devcontainer.json', import.meta.url), 'utf8'),
+);
 const rootCompose = readFileSync(
   new URL('../../compose.yml', import.meta.url),
   'utf8',
@@ -43,6 +46,24 @@ test('README documents the Dev Container frontend test command', () => {
 test('root package exposes the infra configuration test', () => {
   assert.equal(rootPackage.scripts['test:infra'], 'node --test tests/infra/*.test.mjs');
 });
+
+test('Dev Container recommends the expected VS Code extensions', () => {
+  const extensions = devcontainerConfig.customizations.vscode.extensions;
+
+  assert.deepEqual(
+    requiredDevcontainerExtensions.filter((extension) => !extensions.includes(extension)),
+    [],
+  );
+});
+
+const requiredDevcontainerExtensions = [
+  'anthropic.claude-code',
+  'dbaeumer.vscode-eslint',
+  'esbenp.prettier-vscode',
+  'eamodio.gitlens',
+  'xdebug.php-debug',
+  'bmewburn.vscode-intelephense-client',
+];
 
 function assertVolumeMount(composeFile, volumeName, mountPath) {
   assert.match(


### PR DESCRIPTION
# 概要

- Dev Container の VS Code 推奨拡張に `anthropic.claude-code` を復元
- Intelephense / ESLint / Prettier / GitLens / Xdebug / Claude Code の推奨拡張セットを infra test で固定
- `devcontainer.json` を JSON として parse する検証を追加

# 関連Issue

Closes #98

Epic: #52

# 修正ファイルの説明

## Infra

- `.devcontainer/devcontainer.json`
  - Issue の受け入れ条件にある `anthropic.claude-code` を VS Code 推奨拡張へ復元
  - 既存の ESLint / Prettier / GitLens / Xdebug / Intelephense 拡張は維持

## Tests

- `tests/infra/devcontainer-compose.test.mjs`
  - `.devcontainer/devcontainer.json` を JSON として読み込む検証を追加
  - Dev Container の推奨拡張セットが欠落した場合に検出できるように追加

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| Dev Container 設定変更 | infra 設定テスト | `pnpm test:infra` | すべて成功する | 成功 |
| 設定ファイル変更 | whitespace check | `git diff --check` | 空白エラーがない | 成功 |
| 対象外の検証あり | Frontend / BFF / Backend runtime test | Dev Container 推奨拡張のみの変更で runtime code を変更していないため未実施 | 未検証範囲を判断できる | 対象外 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: なし。`.env` は変更していない
- レビュー時に重点確認してほしい点: Dev Container 推奨拡張セットが Issue #98 の受け入れ条件と一致しているか
