### PR TITLE
[#199]: BFF依存関係のHigh脆弱性を解消

### DIFF
--- a/bff/package.json
+++ b/bff/package.json
@@ -13,8 +13,8 @@
     "type-check": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.6",
-    "hono": "^4.11.1",
+    "@hono/node-server": "^1.19.17",
+    "hono": "^4.13.1",
     "redis": "^6.0.0"
   },
   "devDependencies": {

--- a/bff/pnpm-lock.yaml
+++ b/bff/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
   .:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.19.6
-        version: 1.19.14(hono@4.12.23)
+        specifier: ^1.19.17
+        version: 1.19.17(hono@4.13.1)
       hono:
-        specifier: ^4.11.1
-        version: 4.12.23
+        specifier: ^4.13.1
+        version: 4.13.1
       redis:
         specifier: ^6.0.0
         version: 6.0.0
@@ -240,8 +240,8 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+  '@hono/node-server@1.19.17':
+    resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -511,8 +511,8 @@ packages:
     resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.13.1:
+    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
     engines: {node: '>=16.9.0'}
 
   ignore@5.3.2:
@@ -781,9 +781,9 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@hono/node-server@1.19.14(hono@4.12.23)':
+  '@hono/node-server@1.19.17(hono@4.13.1)':
     dependencies:
-      hono: 4.12.23
+      hono: 4.13.1
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -1085,7 +1085,7 @@ snapshots:
 
   globals@17.6.0: {}
 
-  hono@4.12.23: {}
+  hono@4.13.1: {}
 
   ignore@5.3.2: {}
 

--- a/bff/test/dependency-security.test.ts
+++ b/bff/test/dependency-security.test.ts
@@ -76,9 +76,12 @@ function isVersionAtLeast(version: string, minimumVersion: string): boolean {
   const currentParts = parseVersion(version);
   const minimumParts = parseVersion(minimumVersion);
 
-  for (let index = 0; index < currentParts.length; index += 1) {
-    if (currentParts[index] !== minimumParts[index]) {
-      return currentParts[index] > minimumParts[index];
+  for (const index of [0, 1, 2] as const) {
+    const currentPart = currentParts[index];
+    const minimumPart = minimumParts[index];
+
+    if (currentPart !== minimumPart) {
+      return currentPart > minimumPart;
     }
   }
 

--- a/bff/test/dependency-security.test.ts
+++ b/bff/test/dependency-security.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+interface PackageMetadata {
+  name: string;
+  version: string;
+}
+
+const MINIMUM_SAFE_VERSIONS = new Map([
+  ['@hono/node-server', '1.19.15'],
+  ['hono', '4.12.34'],
+]);
+
+test('BFF runtime dependency は既知advisoryの修正版下限以上を解決する', async () => {
+  for (const [packageName, minimumVersion] of MINIMUM_SAFE_VERSIONS) {
+    const metadata = await readPackageMetadata(packageName);
+
+    assert.equal(metadata.name, packageName);
+    assert.equal(
+      isVersionAtLeast(metadata.version, minimumVersion),
+      true,
+      `${packageName} ${metadata.version} must be >= ${minimumVersion}`,
+    );
+  }
+});
+
+async function readPackageMetadata(packageName: string): Promise<PackageMetadata> {
+  let directory = dirname(fileURLToPath(import.meta.resolve(packageName)));
+
+  while (true) {
+    const packageJsonPath = join(directory, 'package.json');
+
+    try {
+      const metadata: unknown = JSON.parse(await readFile(packageJsonPath, 'utf8'));
+
+      if (isPackageMetadata(metadata) && metadata.name === packageName) {
+        return metadata;
+      }
+    } catch (error: unknown) {
+      if (!isMissingFileError(error)) {
+        throw error;
+      }
+    }
+
+    const parentDirectory = dirname(directory);
+
+    if (parentDirectory === directory) {
+      throw new Error(`Unable to locate package metadata for ${packageName}`);
+    }
+
+    directory = parentDirectory;
+  }
+}
+
+function isPackageMetadata(value: unknown): value is PackageMetadata {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  return 'name' in value
+    && typeof value.name === 'string'
+    && 'version' in value
+    && typeof value.version === 'string';
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return error instanceof Error
+    && 'code' in error
+    && error.code === 'ENOENT';
+}
+
+function isVersionAtLeast(version: string, minimumVersion: string): boolean {
+  const currentParts = parseVersion(version);
+  const minimumParts = parseVersion(minimumVersion);
+
+  for (let index = 0; index < currentParts.length; index += 1) {
+    if (currentParts[index] !== minimumParts[index]) {
+      return currentParts[index] > minimumParts[index];
+    }
+  }
+
+  return true;
+}
+
+function parseVersion(version: string): [number, number, number] {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+
+  if (match === null) {
+    throw new Error(`Unsupported semantic version: ${version}`);
+  }
+
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}


### PR DESCRIPTION
# 概要

- BFFのHonoを4.12.23から4.13.1へ更新
- `@hono/node-server`を1.19.14から安全なv1 patchの1.19.17へ更新
- runtime dependencyの安全版下限を検証する回帰テストを追加
- BrowserSession、CSRF、Public API forwardingの既存契約を回帰確認

# 関連Issue

Closes #199

Epic: #52

# 修正ファイルの説明

## BFF dependencies

- `bff/package.json`
  - HonoとNode adapterの安全なversion rangeへ更新
  - major updateを避け、既存APIとの互換性リスクを限定
- `bff/pnpm-lock.yaml`
  - Hono 4.13.1とNode adapter 1.19.17へ解決結果を更新

## Security regression test

- `bff/test/dependency-security.test.ts`
  - 実際に解決されたruntime package metadataを読み取り、安全版下限以上であることを検証

# テスト

| 条件 | 実施する検証 | 結果 |
| ---- | ------------ | ---- |
| BFF型チェック | `pnpm -C bff type-check` | 成功 |
| BFFテスト | `pnpm -C bff test` | 15件成功 |
| BFF lint | `pnpm -C bff lint` | 成功 |
| BFF build | `pnpm -C bff build` | 成功 |
| Production audit | `pnpm -C bff audit --prod` | 既知脆弱性0件 |
| Lockfile整合 | `pnpm -C bff install --frozen-lockfile --force` | 成功 |
| 差分確認 | `git diff --check` | 成功 |

# Dependency audit triage

- 対象High advisory: `GHSA-88fw-hqm2-52qc`
- dependency path: direct runtime dependency `hono`
- usage: BFF runtime。現在`cors()`は未使用だが、runtime High findingのため本PRで解消
- remediation: Hono 4.13.1へ更新
- production audit: High / Criticalを含めfinding 0件
- full audit残存: ESLint → minimatch → brace-expansionのdev-only High 3件
- exploitability: リポジトリ管理の静的lint設定でのみ利用され、browser/BFF runtime入力から到達しない
- action: runtime remediation対象外としてtriage。BFFのproduction dependencyには含まれない

# マージもしくはレビュー時の注意点

- buildが必要: BFF dependency install
- migrateが必要: なし
- 環境変数・設定変更: なし
- レビュー重点: version下限テスト、Hono v4互換性、session/CSRF/JWT forwardingの回帰
