### PR TITLE
[#207]: API性能要件と負荷試験方針を定義

### DIFF
--- a/docs/non-functional-requirements.md
+++ b/docs/non-functional-requirements.md
@@ -281,6 +281,177 @@ runtime dependency の high / critical finding は、明確な mitigation と短
 expiry がない限り temporary exception にしない。期限切れの exception は新規
 dependency 追加や release の前に再評価する。
 
+## Performance / Load Testing
+
+API の性能判断は、固定データセットと固定シナリオを使った再現可能な計測を基準にする。
+ローカル Docker の絶対値にはホスト差があるため、暫定 Performance Budget への適合と、
+同一環境での Before / After の両方を記録する。Frontend の描画、Core Web Vitals、
+bundle size は API latency と混同せず、Frontend Performance Budget で別に扱う。
+
+### Metrics
+
+計測値は経路、scenario、endpoint ごとに記録する。複数 endpoint の集計値だけで、
+特定 endpoint の劣化を隠してはならない。
+
+| Metric | Definition | 採用理由 |
+| --- | --- | --- |
+| throughput / RPS | 計測区間中に完了した request 数を秒数で割った実効値。設定した arrival rate とは分けて記録する | 目標負荷を実際に処理できたか、処理能力が低下していないかを確認するため |
+| p50 latency | request duration の中央値 | 通常の request で利用者が経験する代表的な応答時間を確認するため |
+| p95 latency | request duration の 95 percentile | 大多数の利用者に影響する遅い request を品質ゲートとして捉えるため |
+| p99 latency | request duration の 99 percentile | tail latency、lock、slow query、BFF / Redis の一時的な停滞を検出するため |
+| error rate | expected status / response check を満たさない response と、timeout、connection error の合計を全 request 数で割った値 | HTTP response が返るだけでは成功とみなさず、契約違反と到達不能を検出するため |
+| request count | 計測区間に開始・完了した request 数。未処理の iteration と dropped iteration も併記する | percentile の標本数と、負荷生成側が目標 RPS を維持できたかを確認するため |
+
+latency は load generator から response body の受信完了までを計測する。
+load generator の実行位置は比較中に変更せず、client-side の待ち時間を含む
+end-to-end 指標として扱う。DB query time や Laravel / BFF 内部の処理時間は
+ボトルネック分析の補助指標であり、この latency の代替にはしない。
+
+### Initial Performance Budget
+
+以下は初回ベースライン取得前の暫定値であり、production capacity の保証値ではない。
+通常負荷とピーク負荷は、主要 read API を混ぜた system-wide arrival rate とする。
+latency と error rate は warm-up を除いた計測区間について、経路別かつ endpoint 別に
+評価する。
+
+| Condition | Budget |
+| --- | --- |
+| 通常負荷 | 100 RPS を 10 分間維持する |
+| ピーク負荷 | 300 RPS を3分間維持する |
+| p95 latency | 200 ms 未満 |
+| p99 latency | 500 ms 未満 |
+| error rate | 1% 未満 |
+| p50 latency | 必ず記録する。初回ベースラインまでは絶対値 gate を設けない |
+
+設定した arrival rate と実効 throughput の差、request count 不足、dropped iteration は
+capacity 不足として扱い、latency が budget 内でも成功とはみなさない。
+
+### Target APIs And Paths
+
+初期ベースラインは read 比率が高く、DB query、pagination、認証、BFF overhead を
+比較できる次の API を対象にする。各 endpoint の単独 scenario と、実利用に近い
+mixed read scenario の両方を用意する。
+
+| API | Purpose | Authentication |
+| --- | --- | --- |
+| `GET /api/articles?limit=20&offset=<n>` | Article list、pagination、filter の基本性能 | optional |
+| `GET /api/articles/feed?limit=20&offset=<n>` | follow relationship を含む Feed query の性能 | required |
+| `GET /api/articles/{slug}` | Article detail、author、favorite metadata の取得性能 | optional |
+| `GET /api/tags` | distinct tag aggregation の性能 | none |
+
+write API はデータ量を変化させて比較条件を壊すため、初期の共通 mixed scenario には
+含めない。作成・更新・削除を計測するときは read scenario と分離し、実行後に専用DBを
+同じ seed から再生成する。
+
+同じ scenario を次の2経路で別々に実行し、結果を混ぜない。
+
+| Path | Reference endpoint | Authentication boundary |
+| --- | --- | --- |
+| Laravel Public API direct | `http://localhost:8080/api/*` | setup で取得した Public API JWT を `Authorization: Token <jwt>` として送る |
+| BFF | `http://localhost:3006/api/*`。browser と同じ経路まで確認する場合は `http://localhost:3005/api/*` も別結果として記録する | setup で BrowserSession と CSRF proof を確立し、cookie 認証を使用する |
+
+Laravel direct と BFF は同じ dataset、request distribution、arrival rate、warm-up、
+計測時間で順番に実行する。同時実行で互いに resource contention を起こしてはならない。
+BFF overhead は同条件の経路差として評価し、Frontend rendering time を含めない。
+
+### Performance Dataset
+
+負荷試験は通常の development / test fixture と分離した専用DBで行い、production data を
+複製または利用しない。大規模 preset の初期値は次とする。
+
+| Data | Initial volume |
+| --- | ---: |
+| Users | 10,000 |
+| Articles | 100,000 |
+| Comments | 300,000 |
+| Favorites | 500,000 |
+| Follows | 100,000 以上 |
+| Tags | 1,000 以上の distinct tag と、偏りを持つ article-tag relationship |
+
+同じ seed 値から同じ件数と概ね同じ分布を再生成できることを必須とする。
+Article、Comment、Favorite、Follow、Tag の分布は均一にせず、人気記事や多投稿者を含む
+偏りを固定する。論理削除を含む場合は active / deleted 件数を分けて記録し、通常 query が
+deleted record を返さないことを確認する。
+
+各結果には seed、各 table の実件数、生成時間、DB size を記録する。data volume または
+分布が異なる結果は同一 baseline と比較しない。小規模な CI fixture の結果は大規模 preset の
+代替にしない。
+
+### Test Profiles
+
+arrival-rate executor を基本とし、実負荷が target RPS を維持できるだけの VU を確保する。
+以下の VU は初期値であり、変更した場合は理由と実値を結果へ残す。
+
+| Profile | Warm-up（集計外） | Measurement / load shape | Initial concurrency | Purpose |
+| --- | --- | --- | --- | --- |
+| Smoke | 10 秒、1 RPS | 30 秒、1 RPS | 1 VU | script、認証 setup、API contract、計測出力の動作確認 |
+| Load | 2 分、25 RPS | 10 分、100 RPS | 50 pre-allocated VU、200 max VU | 通常負荷の baseline と budget 判定 |
+| Stress | 2 分、50 RPS | 100 / 200 / 300 / 400 RPS を各3分。必要時のみ安全な上限まで追加 | 100 pre-allocated VU、500 max VU | latency / error の悪化点と処理限界の確認 |
+| Spike | 2 分、50 RPS | 50 RPS から300 RPSへ30秒で上げ、30秒維持後、50 RPSで2分 recovery | 100 pre-allocated VU、500 max VU | 突発負荷への応答と回復を確認 |
+| Soak | 5 分、50 RPS | 60 分、100 RPS | 50 pre-allocated VU、200 max VU | connection、memory、pool、cache の時間経過による劣化を確認 |
+
+Stress は error rate 5% 以上、連続した timeout、またはホストの安全を損なう兆候が出た時点で
+停止し、停止点を結果として記録する。Spike と Soak は通常負荷で回復したか、計測開始時と
+終了時で p95 / p99、error rate、resource usage が悪化していないかも確認する。
+
+mixed read scenario の初期 request distribution は Article list 40%、Feed 25%、
+Article detail 25%、Tags 10% とする。slug、offset、認証ユーザーを固定された候補集合から
+seeded selection し、単一 row や単一 cache entry だけを繰り返さない。
+
+### CI And Manual Execution Boundary
+
+| Execution | Scope | Gate |
+| --- | --- | --- |
+| CI lightweight | 小規模な専用 fixture に対する Smoke。performance script、対象API、query、BFF proxy / session を変更したPRで Laravel direct と BFF を実行する | setup 成功、expected response check 100%、transport error なし、dropped iteration なし、最低 request count を満たすこと。shared runner の絶対 latency は記録のみ |
+| Manual reference | 大規模 preset に対する Load。性能影響のあるPR、baseline更新、release前に固定Docker環境で実行する | 暫定 Performance Budget と Before / After degradation rule を適用する |
+| Manual high load | Stress / Spike / Soak。capacity、耐障害性、長時間安定性を検証するときに固定Docker環境で実行する | 処理限界、回復、resource usage、budget逸脱を記録し、意図しないerrorや未回復を許容しない |
+
+shared CI runner の揺らぎが大きい間は p95 / p99 の絶対値を merge-blocking gate にしない。
+専用 runner で分散が許容範囲に収まることを確認できた場合のみ、記録済み baseline と別PRの
+根拠をもって latency gate を昇格する。CI を軽くするために認証、CSRF、response check を
+省略してはならない。
+
+### Baseline And Degradation Rule
+
+初回 baseline は大規模 preset と固定Docker環境を用い、Laravel direct と BFF の Load を
+各3回実行した中央値から作る。#208 で baseline を取得した後、暫定 Performance Budget の
+妥当性を再評価する。値を維持、厳格化、緩和するいずれの場合も、結果と理由を docs とPRへ
+残し、計測なしに budget を緩和しない。
+
+Before / After は base revision と candidate revision について、それぞれ同じ条件で3回実行した
+中央値を比較する。次のいずれかを満たす場合は性能劣化と判定する。
+
+- p95 または p99 latency が 10% を超えて悪化する。
+- 同じ arrival rate で実効 throughput が 10% を超えて低下する。
+- error rate が 0.5 percentage point 以上増加する、または1%に達する。
+- expected request count の99%を完了できない、または dropped iteration が発生する。
+- 暫定または再評価後の Performance Budget を超える。
+
+p50 の 15% を超える悪化は warning とし、p95 / p99、query、resource metrics と合わせて
+原因を確認する。degradation 判定が出た場合は同条件の3回を再実行し、再現することを確認する。
+再現した劣化は修正するか、trade-off、影響、承認理由、follow-up Issue をPRへ記録する。
+
+### Reproducibility And Security
+
+比較可能な結果には、少なくとも次を記録する。
+
+- base / candidate の commit SHA、計測日時、scenario、endpoint、経路。
+- Docker image / dependency version、OS / CPU / memory、Docker resource limit、Xdebug の状態。
+- dataset seed、table count、DB size、warm-up、計測時間、arrival rate、VU、request distribution。
+- request count、実効 RPS、p50 / p95 / p99、error rate、dropped iteration、threshold結果。
+
+比較中は Docker 構成、resource limit、dataset、seed、環境変数、負荷生成元を固定し、
+Xdebug は無効にする。他の高負荷処理を同じホストで動かさず、条件差がある結果は baseline と
+して採用しない。
+
+負荷試験専用ユーザーだけを使い、credential、JWT、session cookie、CSRF token を repository、
+script既定値、結果、ログへ保存しない。secret は実行時に安全な入力から渡し、出力時に redact
+する。BFF scenario は通常の BrowserSession / CSRF 境界を、Laravel direct scenario は通常の
+JWT検証を通し、性能のために認証・認可・server-side validation を無効化しない。
+
+負荷試験はローカルまたは明示的に許可された隔離環境だけを対象にする。production や共有環境へ
+高負荷を送らず、Stress / Spike / Soak は対象、上限、停止条件を確認してから実行する。
+
 ## Local Reproducibility
 
 The project must be runnable with Docker Compose and lockfiles.


### PR DESCRIPTION
# 概要

- API性能要件と負荷試験の共通方針を定義する
- 暫定Performance Budget、主要指標、対象API、固定データセットを明文化する
- Laravel Public API直接とBFF経由の計測を分離する
- Smoke / Load / Stress / Spike / Soakと、CI軽量試験 / 手動高負荷試験の境界を定義する
- ベースライン再評価、Before / Afterの劣化判定、再現性・セキュリティ要件を定義する

# 関連Issue

Closes #207

Epic: #206

# 修正ファイルの説明

## Non-functional requirements

- `docs/non-functional-requirements.md`
  - p50 / p95 / p99、throughput / RPS、error rate、request countの意味と採用理由を追加
  - 通常100 RPS、ピーク300 RPS、p95 200ms未満、p99 500ms未満、error rate 1%未満を初期budgetとして追加
  - Article list / Feed / Article detail / Tagsを対象APIとして定義
  - 大規模dataset、warm-up、duration、arrival rate、VU、request distributionを定義
  - Laravel direct / BFFを同一条件で別計測する方針を追加
  - CIでは安定したSmoke gate、固定Docker環境ではLoad / Stress / Spike / Soakを行う境界を追加
  - 初回baseline後のbudget再評価と、同一条件3回の中央値による性能劣化判定を追加
  - credentialを記録しないこと、productionや共有環境へ高負荷を送らないことを追加

# テスト

| 条件 | 実施する検証 | コマンド・確認内容 | 期待結果 | 結果 |
| ---- | ------------ | ------------------ | -------- | ---- |
| ドキュメントのみ変更 | Markdown と参照確認 | `git diff --check`、見出し・受入条件キーワードの検索、参照ファイルの存在確認 | 空白エラーがなく、受入条件と参照先が揃っている | 成功 |
| コード・依存関係変更なし | アプリケーションQA | 対象外 | 実行不要 | 対象外 |

# マージもしくはレビュー時の注意点

- build が必要: なし
- migrate が必要: なし
- 環境変数・設定変更: なし
- レビュー時に重点確認してほしい点: 初期budgetと試験条件が後続#208・#211の実装契約として十分か、CIと手動試験の境界、劣化判定の閾値

Codexで生成
